### PR TITLE
feat: add Linux ARM64 (aarch64) prebuilt binary builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
           - name: linux-x86_64
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+          - name: linux-aarch64
+            os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
           - name: macos-arm64
             os: macos-latest
             target: aarch64-apple-darwin
@@ -59,6 +62,10 @@ jobs:
       - name: Install NASM (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install -y nasm
+
+      - name: Install LLD (Linux ARM64)
+        if: matrix.os == 'ubuntu-24.04-arm'
+        run: sudo apt-get update && sudo apt-get install -y lld
 
       - name: Install NASM (macOS)
         if: matrix.os == 'macos-latest'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@
 #
 # Artifact naming (npm-compatible for the npm wrapper package):
 #   donsetch-linux-x64.tar.gz       (Linux x86_64)
+#   donsetch-linux-arm64.tar.gz     (Linux ARM64 / aarch64)
 #   donsetch-darwin-arm64.tar.gz    (macOS arm64)
 #   donsetch-win32-x64.zip          (Windows x86_64 + pdfium.dll)
 #
@@ -41,6 +42,9 @@ jobs:
           - name: linux-x64
             os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
+          - name: linux-arm64
+            os: ubuntu-24.04-arm
+            target: aarch64-unknown-linux-gnu
           - name: darwin-arm64
             os: macos-latest
             target: aarch64-apple-darwin
@@ -64,6 +68,10 @@ jobs:
       - name: Install NASM (Linux)
         if: matrix.os == 'ubuntu-latest'
         run: sudo apt-get update && sudo apt-get install -y nasm
+
+      - name: Install LLD (Linux ARM64)
+        if: matrix.os == 'ubuntu-24.04-arm'
+        run: sudo apt-get update && sudo apt-get install -y lld
 
       - name: Install NASM (macOS)
         if: matrix.os == 'macos-latest'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Linux ARM64 (aarch64) prebuilt binaries**: GitHub Actions release workflow now builds `donsetch-linux-arm64.tar.gz` on `ubuntu-24.04-arm` (native ARM64), and the npm `install.js` postinstall script recognizes the `linux-arm64` platform (`process.platform=linux` + `process.arch=arm64`). `npm install -g donsetch` now works on aarch64 Linux. CI also runs the full test suite on `ubuntu-24.04-arm`.
+
 ## [2.3.4] - 2026-08-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Downloads the prebuilt binary for your platform from GitHub Releases with SHA256
 | Platform | Binary |
 |---|---|
 | Linux x86_64 | `donsetch-linux-x64.tar.gz` |
+| Linux arm64 | `donsetch-linux-arm64.tar.gz` |
 | macOS arm64 | `donsetch-darwin-arm64.tar.gz` |
 | Windows x86_64 | `donsetch-win32-x64.tar.gz` |
 | Termux (Android) | Build from source (see build notes) |
@@ -105,9 +106,11 @@ Update with `pi update --extensions` — both the binary and extension update to
 | Dependency | Why | Linux | macOS | Windows |
 |---|---|---|---|---|
 | **Rust** | Build toolchain | `rustup` | `rustup` | `rustup` |
-| **Go** | BoringSSL build | `pacman -S go` | `brew install go` | `winget install GoLang.Go` |
-| **NASM** | BoringSSL assembly | `pacman -S nasm` | `brew install nasm` | `choco install nasm` |
-| **CMake** | BoringSSL build | `pacman -S cmake` | `brew install cmake` | `winget install cmake` |
+| **Go** | BoringSSL build | `pacman -S go` / `apt install golang-go` | `brew install go` | `winget install GoLang.Go` |
+| **NASM** | BoringSSL assembly | `pacman -S nasm` / `apt install nasm` | `brew install nasm` | `choco install nasm` |
+| **CMake** | BoringSSL build | `pacman -S cmake` / `apt install cmake` | `brew install cmake` | `winget install cmake` |
+| **Clang** | bindgen (boring-sys) | `apt install clang libclang-dev` | *(bundled on macOS)* | `choco install llvm` |
+| **LLD** | PDFium link (aarch64) | `apt install lld` *(aarch64 only)* | — | — |
 
 ```bash
 git clone https://github.com/dondai44423/donsetch.git
@@ -125,9 +128,10 @@ Binary lands at `target/release/donsetch`. First build takes ~2 min (compiling B
 - **ONNX Runtime** is downloaded at build time by `oar-ocr` (OCR) and `ort` (reranker) when those features are enabled.
 - **Models** (OCR + reranker) download on first use to `~/.cache/donsetch/`, not bundled in the binary.
 - **Feature flags**: `default = []` — the core tool (fetch, search, crawl, PDF) works standalone. Build with `--features ocr,rerank` for OCR + semantic reranking (pulls in ONNX Runtime). The prebuilt npm binary ships with both features enabled.
-- **Chromium** (optional): needed for tier 2 browser escalation on bot-walled sites. Linux: `pacman -S chromium`. macOS: `brew install chromium`. Windows: Edge works. **Ubuntu Snap**: set `DONGHOST_CHROME=/snap/chromium/current/usr/lib/chromium-browser/chrome` — the `/snap/bin/chromium` wrapper doesn't reliably pass CDP flags.
-- **Linux Xvfb**: for headful Chrome on Linux, `xorg-server-xvfb` is needed. DonSeTch starts Xvfb automatically.
-- **Linux ARM64 (aarch64)**: the default build (no features) works out of the box. If you enable `--features ocr,rerank`, ONNX Runtime's C++ global constructors may deadlock at startup on aarch64. Install `lld` for linking LLVM-produced PDFium archives (`apt install lld`).
+- **Chromium** (optional): needed for tier 2 browser escalation on bot-walled sites. Linux: `pacman -S chromium` / `apt install chromium-browser`. macOS: `brew install chromium`. Windows: Edge works. **Playwright**: if you already have `npx playwright install`, DonSeTch auto-discovers `~/.cache/ms-playwright/chromium-*/chrome-linux/chrome` — no manual `DONGHOST_CHROME` needed. **Ubuntu Snap**: set `DONGHOST_CHROME=/snap/chromium/current/usr/lib/chromium-browser/chrome` — the `/snap/bin/chromium` wrapper doesn't reliably pass CDP flags.
+- **Linux Xvfb**: for headful Chrome on Linux, `xorg-server-xvfb` is needed (`apt install xvfb`). DonSeTch starts Xvfb automatically on `:99`. If your distro uses a regional Ubuntu Ports mirror that is down, fix it: `sudo sed -i 's|http://.*\.clouds\.ports\.ubuntu\.com|http://ports.ubuntu.com|' /etc/apt/sources.list.d/ubuntu.sources && sudo apt-get update`.
+- **Linux ARM64 (aarch64)**: the default build (no features) works out of the box. Requires `lld` + `clang libclang-dev` for PDFium + boring-sys: `apt install lld clang libclang-dev` (fix mirror first if needed, see above). If you enable `--features ocr,rerank`, ONNX Runtime's C++ global constructors may deadlock at startup on aarch64.
+- **AppArmor / sandbox** (Ubuntu 23.10+): unprivileged user namespaces are disabled by default, so Chromium fails with `No usable sandbox!`. DonSeTch now passes `--no-sandbox --disable-setuid-sandbox` automatically — no manual fix needed.
 - **Termux (Android)**: the default build works. Install `pkg install rust clang make pkg-config go` and `cargo build --release`. Chromium: `pkg install x11-repo && pkg install chromium`. DonSeTch auto-detects Termux and uses headless mode (no Xvfb needed). Install `lld` for PDFium linking: `pkg install lld`.
 
 </details>

--- a/build.rs
+++ b/build.rs
@@ -284,7 +284,7 @@ fn fetch_pdfium(os: &str, arch: &str, vendored: &Path) {
         .arg(&tgz)
         .arg(&url)
         .status()
-        .expect("pdfium: failed to spawn curl");
+        .unwrap_or_else(|e| panic!("pdfium: failed to spawn curl ({e}) — install curl: apt install curl"));
     if !status.success() {
         panic!("pdfium: curl download failed for {url}");
     }
@@ -313,7 +313,7 @@ fn fetch_pdfium(os: &str, arch: &str, vendored: &Path) {
         .arg("-C")
         .arg(vendored)
         .status()
-        .expect("pdfium: failed to spawn tar");
+        .unwrap_or_else(|e| panic!("pdfium: failed to spawn tar ({e}) — install tar: apt install tar"));
     if !status.success() {
         panic!("pdfium: tar extraction failed for {tgz:?}");
     }

--- a/npm/README.md
+++ b/npm/README.md
@@ -19,6 +19,7 @@ Downloads the prebuilt binary for your platform from [GitHub Releases](https://g
 | Platform | Binary |
 |---|---|
 | Linux x86_64 | `donsetch-linux-x64.tar.gz` |
+| Linux arm64 | `donsetch-linux-arm64.tar.gz` |
 | macOS arm64 | `donsetch-darwin-arm64.tar.gz` |
 | Windows x86_64 | `donsetch-win32-x64.tar.gz` |
 

--- a/npm/install.js
+++ b/npm/install.js
@@ -11,6 +11,7 @@
 //
 // Supported platforms:
 //   linux-x64      Linux x86_64
+//   linux-arm64    Linux ARM64 (aarch64)
 //   darwin-arm64   macOS Apple Silicon
 //   win32-x64      Windows x86_64
 
@@ -27,6 +28,7 @@ const TAG = `v${VERSION}`;
 // ── platform mapping ────────────────────────────────────────────
 const PLATFORMS = {
   'linux-x64':    { asset: 'donsetch-linux-x64.tar.gz',    binary: 'donsetch'     },
+  'linux-arm64':  { asset: 'donsetch-linux-arm64.tar.gz',  binary: 'donsetch'     },
   'darwin-arm64': { asset: 'donsetch-darwin-arm64.tar.gz', binary: 'donsetch'     },
   'win32-x64':    { asset: 'donsetch-win32-x64.tar.gz',    binary: 'donsetch.exe' },
 };
@@ -39,6 +41,7 @@ if (!plat) {
   console.error('');
   console.error('Supported platforms:');
   console.error('  linux-x64      Linux x86_64');
+  console.error('  linux-arm64    Linux ARM64 (aarch64)');
   console.error('  darwin-arm64   macOS Apple Silicon');
   console.error('  win32-x64      Windows x86_64');
   console.error('');

--- a/src/ghost/mod.rs
+++ b/src/ghost/mod.rs
@@ -107,6 +107,24 @@ fn known_chrome_paths() -> Vec<PathBuf> {
         PathBuf::from("/snap/chromium/current/usr/lib/chromium-browser/chrome"),
         PathBuf::from("/snap/bin/chromium"),
     ];
+    // Playwright cache: ~/.cache/ms-playwright/chromium-*/chrome-linux/chrome
+    // Many devs have Chromium via `npx playwright install` but not as a
+    // system package. Auto-discover it so `donsetch doctor` just works.
+    if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {
+        let base = home.join(".cache/ms-playwright");
+        if let Ok(entries) = std::fs::read_dir(&base) {
+            for entry in entries.flatten() {
+                let name = entry.file_name();
+                let name = name.to_string_lossy();
+                if name.starts_with("chromium-") {
+                    let candidate = entry.path().join("chrome-linux/chrome");
+                    if candidate.is_file() {
+                        paths.push(candidate);
+                    }
+                }
+            }
+        }
+    }
     // Termux: $PREFIX/bin/chromium-browser or chromium.
     // $PREFIX is /data/data/com.termux/files/usr.
     if let Some(prefix) = std::env::var_os("PREFIX") {
@@ -248,6 +266,8 @@ impl Ghost {
             "--disable-background-networking".into(),
             "--disable-component-update".into(),
             "--disable-sync".into(),
+            "--no-sandbox".into(),
+            "--disable-setuid-sandbox".into(),
             "--disable-translate".into(),
             "--mute-audio".into(),
             // ── Disk cache suppression ──


### PR DESCRIPTION
Adds linux-arm64 (ubuntu-24.04-arm) to release + CI, npm linux-arm64 support, README tables, ghost QOL (Playwright auto-discovery, --no-sandbox).