### PR TITLE
fix: Windows Job Object never adopted the browser (issue #11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.5] - 2026-08-19
+
+### Fixed
+
+- **Windows: orphaned Chrome processes after every fetch (#11)**: `AssignProcessToJobObject` requires both `PROCESS_SET_QUOTA` **and** `PROCESS_TERMINATE` on the process handle, but only the former was requested. The call failed with `ERROR_ACCESS_DENIED`, leaving the Job Object empty — so `KILL_ON_JOB_CLOSE` had nothing to kill when the handle dropped, and the whole browser tree outlived donsetch. Because the orphans inherit donsetch's stdout, any pipeline calling donsetch would also block until they were killed by hand, which looked like donsetch itself hanging.
+
+- **Silent Job Object assignment failure**: the failure branch was empty, so this degraded silently. It now warns unconditionally and names the consequence, matching the existing convention for failure-with-fallback messages.
+
 ## [2.3.4] - 2026-08-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "donsetch"
-version = "2.3.4"
+version = "2.3.5"
 dependencies = [
  "boring",
  "boring-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "donsetch"
-version = "2.3.4"
+version = "2.3.5"
 edition = "2024"
 license = "AGPL-3.0"
 description = "Web fetch, search and crawl for AI agents. Custom stealthy HTTP fetch tier on BoringSSL."

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "donsetch",
-  "version": "2.3.4",
+  "version": "2.3.5",
   "description": "Web fetch, search and crawl for AI agents. Zero API keys. Chrome-true TLS.",
   "license": "AGPL-3.0-only",
   "author": "Bishesh Bhandari",

--- a/src/ghost/proc.rs
+++ b/src/ghost/proc.rs
@@ -94,10 +94,15 @@ impl Proc {
             // Process handle with the access rights we need:
             //   PROCESS_SUSPEND_RESUME  — NtSuspendProcess / NtResumeProcess
             //   PROCESS_SET_QUOTA       — AssignProcessToJobObject
+            //   PROCESS_TERMINATE       — AssignProcessToJobObject also requires
+            //                             this; without it the call fails with
+            //                             ERROR_ACCESS_DENIED and the job stays
+            //                             empty, so KILL_ON_JOB_CLOSE kills nothing
             //   PROCESS_QUERY_LIMITED_INFORMATION — status checks
             let proc_handle = thr::OpenProcess(
                 thr::PROCESS_SUSPEND_RESUME
                     | thr::PROCESS_SET_QUOTA
+                    | thr::PROCESS_TERMINATE
                     | thr::PROCESS_QUERY_LIMITED_INFORMATION,
                 0,
                 pid,
@@ -140,7 +145,14 @@ impl Proc {
             // still work via the process handle; only the death-reap
             // safety net is lost.
             if job::AssignProcessToJobObject(job_h, proc_handle) == 0 {
-                // Non-fatal: log via the error channel's debug only.
+                // Non-fatal for the fetch itself, but the job is now empty:
+                // KILL_ON_JOB_CLOSE has nothing to kill, so the browser tree
+                // outlives donsetch and orphaned Chrome processes pile up.
+                // Warn unconditionally — silent degradation is what hid this.
+                eprintln!(
+                    "[ghost] AssignProcessToJobObject failed: {} — browser tree will not be reaped on exit, leaving orphaned Chrome processes",
+                    fnd::GetLastError()
+                );
             }
             Ok(Self {
                 proc_handle,


### PR DESCRIPTION




## Summary

AssignProcessToJobObject requires both PROCESS_SET_QUOTA and PROCESS_TERMINATE on the process handle; OpenProcess only requested the former, so the call failed with ERROR_ACCESS_DENIED and the Job Object stayed empty. KILL_ON_JOB_CLOSE then had nothing to kill on drop, and the whole Chrome tree outlived donsetch. The orphans inherit donsetch's stdout, so piped callers blocked until they were killed by hand — which looked like donsetch itself hanging.

The failure branch was empty, which hid this. Now warns unconditionally and names the consequence, matching the Xvfb fallback messages.

## Type
- [x] `fix` — Bug #11 Leftover chrome processes on Windows

## Checks

- [x] `cargo test --release` passes (475 passed, 0 failed)
- [ ] `cargo clippy --release -- -Dwarnings` : 6 errors, all pre-existing
- [x] `cargo fmt --all -- --check` passes
- [ ] CI is green on all 3 platforms (Linux, macOS, Windows)


<details>
  <summary>Pre existing clippy errors:</summary>
  
```
error: unused doc comment
  --> src\ghost\proc.rs:48:1
   |
48 |   /// ntdll process suspend/resume — always loaded, linked directly.
   |   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
...
51 | / unsafe extern "system" {
52 | |     fn NtSuspendProcess(proc_handle: fnd::HANDLE) -> i32;
53 | |     fn NtResumeProcess(proc_handle: fnd::HANDLE) -> i32;
54 | | }
   | |_- rustdoc does not generate documentation for extern blocks
   = note: `-D unused-doc-comments` implied by `-D warnings`

error: unused variable: `display`
   --> src\ghost\mod.rs:227:9
227 |         display: Option<&str>,
    = note: `-D unused-variables` implied by `-D warnings`

error: this `if` can be collapsed into the outer `match`
  --> src\crawl\sitemap.rs:50:21
    = note: `-D clippy::collapsible-match` implied by `-D warnings`

error: this `if` can be collapsed into the outer `match`
  --> src\crawl\sitemap.rs:55:21

error: this `if` can be collapsed into the outer `match`
   --> src\transport\h2\conn.rs:145:21

error: this `if` can be collapsed into the outer `match`
   --> src\transport\h2\conn.rs:151:21
```
  
</details>


## Breaking changes

None

## Test plan

Verified on Windows 11

* `donsetch doctor`
* `donsetch fetch https://example.com --tier 2`

Verified that chrome windows appeared briefly and auto closed.

With `PROCESS_TERMINATE` flag, 0 leftover processes; with it
commented out, "AssignProcessToJobObject failed: 5" and 9 orphans.

<details>
  <summary> `donsetch doctor` results </summary>

**PATCHED**
```
PS > .\donsetch.exe doctor
DonSeTch Doctor
─────────────────────────────────────────────────────────

  ✓ Binary integrity           v2.3.4, 9MB
  ✓ Network                    example.com 200 OK (139ms)
  ✓ TLS fingerprint            TLS stack active (fingerprint service unreachable)
  ✓ Chrome/Chromium            Google Chrome 151.0.7922.138 at C:\tools\chrome-shim.cmd
  ✓ Xvfb                       not needed on this platform
  ✓ Ghost profile              writable, no stale locks
  ✓ Browser launch             launched in 714ms, fingerprint clean (webdriver=false)
  ✓ Cache directory            134.9MB (self-improvement=6.3KB, ghost-profile=111.0MB, rerank-models=23.9MB, search-cache=13.7KB)
  ✓ State permissions          windows ACLs apply
  ✓ PDFium                     dll, chromium/7802
  ⚠ OCR models                 not compiled (build with --features ocr to enable)
  ⚠ Rerank model               not compiled (build with --features rerank to enable)
  ✓ Ghost state                8 domains, 2 renders cached

  11/13 passed, 2 warning(s), 0 failed
─────────────────────────────────────────────────────────
  Status: healthy with warnings
```

**UNPATCHED (from upstream release)**

```
PS > donsetch doctor
DonSeTch Doctor
─────────────────────────────────────────────────────────

  ✓ Binary integrity           v2.3.4, 32MB
  ✓ Network                    example.com 200 OK (132ms)
  ✓ TLS fingerprint            TLS stack active (fingerprint service unreachable)
  ✓ Chrome/Chromium            Google Chrome 151.0.7922.138 at C:\tools\chrome-shim.cmd
  ✓ Xvfb                       not needed on this platform
  ✓ Ghost profile              writable, no stale locks
  ✗ Browser launch             launch timed out after 40s
    A stale Chromium or Xvfb may be wedged: pkill -f chromium; rm -f /tmp/.X99-lock /tmp/.X11-unix/X99
  ✓ Cache directory            126.4MB (self-improvement=6.3KB, ghost-profile=102.6MB, rerank-models=23.9MB, search-cache=13.7KB)
  ✓ State permissions          windows ACLs apply
  ✓ PDFium                     dll, chromium/7802
  ⚠ OCR models                 not cached (downloads on first use)
  ✓ Rerank model               2 model files cached
  ✓ Ghost state                8 domains, 2 renders cached

  11/13 passed, 1 warning(s), 1 failed
─────────────────────────────────────────────────────────
  Status: issues found
```

</details>