### PR TITLE
fix: raise Windows main-thread stack to 8MB (issue #18)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.7] - 2026-08-19
+
+### Fixed
+
+- **Windows: debug builds die with `STATUS_STACK_OVERFLOW` (#18)**: the main thread's stack comes from the PE header — 1MB by default, against Linux's 8MB. DonSeTch runs its whole future tree there via tokio's `block_on`, and `fetch_tool`'s frame does not fit unoptimized: `cargo build` produced a binary that aborted in `__chkstk` before the function body ran. Release fit only because optimization shrank the frame. `build.rs` now requests 8MB (`/STACK` on MSVC, `-Wl,--stack` on MinGW), so the ceiling no longer depends on the build profile.
+
 ## [2.3.6] - 2026-08-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "donsetch"
-version = "2.3.6"
+version = "2.3.7"
 dependencies = [
  "boring",
  "boring-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "donsetch"
-version = "2.3.6"
+version = "2.3.7"
 edition = "2024"
 license = "AGPL-3.0"
 description = "Web fetch, search and crawl for AI agents. Custom stealthy HTTP fetch tier on BoringSSL."

--- a/build.rs
+++ b/build.rs
@@ -194,6 +194,30 @@ fn main() {
         }
     }
 
+    // ── Windows main-thread stack size ────────────────────────
+    //
+    // On Windows the main thread's stack size comes from the PE header,
+    // which defaults to 1MB. Linux gives 8MB. donsetch runs its whole
+    // future tree on the main thread via tokio's block_on, and the
+    // fetch_tool state machine does not fit in 1MB unoptimized — a debug
+    // build dies with 0xc00000fd (STATUS_STACK_OVERFLOW) inside __chkstk
+    // before entering the function body, with no usable backtrace since
+    // a stack overflow is not a panic. Release only fits because
+    // optimization shrinks the frame, which is luck, not headroom.
+    //
+    // Ask the linker for Linux's 8MB so the ceiling stops being
+    // profile-dependent. Transparent to the user, like the LLD flag above.
+    if is_windows {
+        let abi = env::var("CARGO_CFG_TARGET_ENV").unwrap_or_default();
+        if abi == "gnu" {
+            // MinGW: GNU ld spelling.
+            println!("cargo:rustc-link-arg=-Wl,--stack,8388608");
+        } else {
+            // MSVC link.exe.
+            println!("cargo:rustc-link-arg=/STACK:8388608");
+        }
+    }
+
     // ── aarch64 + ONNX warning ────────────────────────────────
     //
     // ONNX Runtime (via `ort`/`oar-ocr`) is statically linked. Its C++

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "donsetch",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "description": "Web fetch, search and crawl for AI agents. Zero API keys. Chrome-true TLS.",
   "license": "AGPL-3.0-only",
   "author": "Bishesh Bhandari",


### PR DESCRIPTION


## Summary

The main thread's stack size comes from the PE header, which defaults to 1MB; Linux gives 8MB. donsetch runs its whole future tree on that thread via tokio's block_on, and fetch_tool's frame does not fit unoptimized — cargo build produced a binary that aborted in __chkstk before the function body ran. Release only fit because optimization shrank the frame, so the ceiling was profile-dependent.

build.rs now asks the linker for 8MB on Windows: /STACK:8388608 for MSVC, -Wl,--stack,8388608 for MinGW. No RUSTFLAGS or .cargo/config.toml needed, same as the existing LLD flag.
(I genuinely didn't test on GNU tool chain, but it should have same issue,
 and this fix should work)

Boxing the nested futures also works but is whack-a-mole: pinning one call site just moves the fault to the next frame.

Fixes #18.

## Type

- [x] `fix` — stack overflow on windows in Debug build

## Checks

- [x] `cargo test --release` passes (494 passed; 0 failed)
- [ ] `cargo clippy --release -- -Dwarnings` passes (6 pre-existing errors)
- [x] `cargo fmt --all -- --check` passes
- [ ] CI is green on all 3 platforms (Linux, macOS, Windows)

## Breaking changes

None

## Test plan

`cargo run donsetch -- fetch https://example.com`  on Windows.
