### PR TITLE
fix: base64 padding emitted before the data, corrupting auth headers (issue #15)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.3.7] - 2026-08-19
+
+### Fixed
+
+- **Basic auth and proxy auth headers were corrupted by a base64 bug (#15)**: the encoder placed its `=` padding at the start of the final group instead of the end, so `user:passwd` encoded as `dXNlcjpwYXNz==QA` rather than `dXNlcjpwYXNzd2Q=`. Only credentials whose byte length was an exact multiple of 3 came out valid; everything else was rejected by the server. Covered by RFC 4648 test vectors.
+
 ## [2.3.6] - 2026-08-19
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -807,7 +807,7 @@ dependencies = [
 
 [[package]]
 name = "donsetch"
-version = "2.3.6"
+version = "2.3.7"
 dependencies = [
  "boring",
  "boring-sys",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "donsetch"
-version = "2.3.6"
+version = "2.3.7"
 edition = "2024"
 license = "AGPL-3.0"
 description = "Web fetch, search and crawl for AI agents. Custom stealthy HTTP fetch tier on BoringSSL."

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "donsetch",
-  "version": "2.3.6",
+  "version": "2.3.7",
   "description": "Web fetch, search and crawl for AI agents. Zero API keys. Chrome-true TLS.",
   "license": "AGPL-3.0-only",
   "author": "Bishesh Bhandari",

--- a/src/transport/proxy.rs
+++ b/src/transport/proxy.rs
@@ -533,7 +533,11 @@ pub(crate) fn base64(input: &str) -> String {
             .fold(0u32, |acc, (i, &c)| acc | ((c as u32) << (16 - 8 * i)));
         for i in 0..4 {
             let shift = 18 - 6 * i;
-            let pad = chunk.len() * 8 < shift + 6;
+            // Padding goes at the END: output char `i` covers bits
+            // [i*6, i*6+6). It is padding only when the chunk has no
+            // bits that far in. Testing `shift` instead gets this
+            // backwards, since shift counts down as i counts up.
+            let pad = i * 6 >= chunk.len() * 8;
             out.push(if pad {
                 '='
             } else {
@@ -547,6 +551,30 @@ pub(crate) fn base64(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn base64_rfc4648_vectors() {
+        // RFC 4648 §10 — covers every input-length remainder.
+        assert_eq!(base64(""), "");
+        assert_eq!(base64("f"), "Zg==");
+        assert_eq!(base64("fo"), "Zm8=");
+        assert_eq!(base64("foo"), "Zm9v");
+        assert_eq!(base64("foob"), "Zm9vYg==");
+        assert_eq!(base64("fooba"), "Zm9vYmE=");
+        assert_eq!(base64("foobar"), "Zm9vYmFy");
+    }
+
+    #[test]
+    fn base64_credentials_pad_at_the_end() {
+        // Regression: the final partial group was emitted as padding
+        // first, data after — "dXNlcjpwYXNz==QA" instead of
+        // "dXNlcjpwYXNzd2Q=". Only credentials whose length was an exact
+        // multiple of 3 survived, so most basic-auth and proxy-auth
+        // headers went out corrupted.
+        assert_eq!(base64("user:pass"), "dXNlcjpwYXNz");
+        assert_eq!(base64("user:passw"), "dXNlcjpwYXNzdw==");
+        assert_eq!(base64("user:passwd"), "dXNlcjpwYXNzd2Q=");
+    }
 
     #[test]
     fn parse_bare_http() {


### PR DESCRIPTION




## Summary

The encoder decided padding from the bit-shift instead of the output position: `pad = chunk.len() * 8 < shift + 6`, where `shift = 18 - 6*i` counts down as `i` counts up. So for a partial group the test was inverted in order — a 1-byte chunk padded at i=0 and i=1, then emitted its data at i=2 and i=3. `user:passwd` came out as `dXNlcjpwYXNz==QA` instead of `dXNlcjpwYXNzd2Q=`.

Output char `i` encodes bits [i*6, i*6+6), so it is padding exactly when the chunk has no bits that far in: `pad = i * 6 >= chunk.len() * 8`.

Credentials that were an exact multiple of 3 bytes long encoded correctly, which is why this survived the #15 fix — every other length went out mangled and was rejected as unauthenticated.

Adds RFC 4648 §10 vectors and a credentials regression test.

Fixes #15

## Type

- [ ] `feat` — new feature
- [x] `fix` — bug fix #15
- [ ] `docs` — documentation only
- [ ] `chore` — deps, CI, tooling
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only

## Checks

- [x] `cargo test --release` passes (496 passed; 0 failed;)
- [ ] `cargo clippy --release -- -Dwarnings` passes (6 pre existing)
- [x] `cargo fmt --all -- --check` passes
- [ ] CI is green on all 3 platforms (Linux, macOS, Windows)

## Breaking changes

This logic also affect proxy, but it was same way broken

## Test plan

fetch https://user:passwd@httpbin.io/basic-auth/user/passwd 
