### PR TITLE
fix: harden MCP fetch and browser boundaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -823,6 +823,7 @@ dependencies = [
  "ndarray",
  "oar-ocr",
  "ort",
+ "psl",
  "regex",
  "reqwest",
  "rustls-native-certs",
@@ -2406,6 +2407,21 @@ dependencies = [
  "quote",
  "syn 2.0.119",
 ]
+
+[[package]]
+name = "psl"
+version = "2.1.226"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bc88482eea924ca3a2f56a547454169af58deef35567965eb4fc2392a834841"
+dependencies = [
+ "psl-types",
+]
+
+[[package]]
+name = "psl-types"
+version = "2.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
 name = "pulp"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tar = "0.4"
 semver = "1"
 # Agent CLI: spec-driven command generation (builder API, no derive).
 clap = { version = "4", default-features = false, features = ["std", "help", "usage", "error-context", "suggestions"] }
+psl = { version = "=2.1.226" }
 # Semantic reranker — cross-encoder via ONNX Runtime, shares ort with OCR.
 ort = { version = "=2.0.0-rc.12", default-features = false, features = ["std", "ndarray", "download-binaries", "tls-native", "copy-dylibs"], optional = true }
 tokenizers = { version = "0.23", default-features = false, features = ["onig"], optional = true }

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ Works with **Claude Code**, **Cursor**, **OpenCode**, **Pi**, **Windsurf**, and 
 npm install -g donsetch
 ```
 
+> **Note:** npm prebuilt install is currently disabled — `npm/install.js` contains an empty `PINNED_SHA256` map with no independently audited hashes, so the installer fails closed before any download (a checksum file from the same GitHub release is not trusted). **Build from source is required** until hashes are pinned. See [Install](#-install).
+
 <div align="center">
 
 [Install](#-install) · [Two ways to use it](#-two-ways-to-use-it) · [The 3 tools](#-the-3-tools) · [Chrome TLS](#-chrome-tls-not-chrome-like) · [Solve & Bounce](#-solve-and-bounce) · [Search](#-keyless-search) · [PDF](#-pdf--ocr) · [Benchmark](#-wrb-web-research-benchmark) · [Comparison](#-comparison) · [Gotchas](#-gotchas) · [Limits](#-honest-limits)
@@ -106,15 +108,17 @@ Four things no free (or paid) competitor has, plus a stack of agent-first mechan
 
 ## 📦 Install
 
-### Option 1 — npm (recommended)
+### Option 1 — npm (currently disabled — build from source required)
 
 ```bash
 npm install -g donsetch
 ```
 
-Downloads the prebuilt binary for your platform from GitHub Releases with SHA256 verification. No build tools needed.
+> **Prebuilt install is currently disabled.** The npm installer (`npm/install.js`) verifies release tarballs only against a source-controlled `PINNED_SHA256` map. This repository currently contains no independently audited hashes, so the map is empty and the installer fails closed **before any download**, emitting an error that explains a checksum file downloaded from the same GitHub release is not trusted for authorization. Until audited hashes are pinned, `npm install -g donsetch` will not fetch a binary — **build from source is required** (see Option 4). To re-enable prebuilt installs, add independently audited SHA256 entries to `PINNED_SHA256` in `npm/install.js`; no other code change is needed.
+>
+> When re-enabled, the installer will download the prebuilt binary for your platform from GitHub Releases and verify it against the pinned hash. No build tools will be needed then.
 
-| Platform | Binary |
+| Platform | Binary (used when hashes are pinned) |
 |---|---|
 | Linux x86_64 | `donsetch-linux-x64.tar.gz` |
 | Linux arm64 | `donsetch-linux-arm64.tar.gz` |

--- a/build.rs
+++ b/build.rs
@@ -19,7 +19,8 @@
 //
 // If vendor/pdfium/lib does not contain the library for the target,
 // we download and unpack the pinned release with curl/tar. The SHA-256
-// of the downloaded tarball is verified against a pinned map when present.
+// of the downloaded tarball is verified against a pinned map and is
+// required — builds refuse to download when no pinned hash exists.
 
 use std::env;
 use std::fs;
@@ -37,7 +38,8 @@ const PDFIUM_STATIC_TAG: &str = "chromium/7809";
 /// are Chromium 149-era PDFium builds.
 const PDFIUM_SHARED_TAG: &str = "chromium/7802";
 
-/// sha256 of the pinned tarball per platform "os-arch". Verified on download;
+/// sha256 of the pinned tarball per platform "os-arch". Verified on download and required;
+/// builds fail before any network download if no entry exists.
 /// entries are filled as each platform's artifact is prepped for CI.
 const KNOWN_HASHES: &[(&str, &str)] = &[(
     "linux-x64",
@@ -341,12 +343,32 @@ fn fetch_pdfium(os: &str, arch: &str, vendored: &Path) {
         )
     };
 
+    let pinned_hash = KNOWN_HASHES
+        .iter()
+        .find(|(p, _)| *p == pair)
+        .map(|(_, h)| *h)
+        .unwrap_or_else(|| {
+            panic!(
+                "pdfium: no pinned sha256 for {pair} — refusing unverified download. \
+                Build from source with a vendored pdfium, or add an audited hash to KNOWN_HASHES in build.rs"
+            )
+        });
+
     let tgz = vendored.join(&tgz_name);
     let _ = fs::create_dir_all(vendored);
 
     eprintln!("donsetch build: fetching pdfium {pair} from {url}");
     let status = Command::new("curl")
-        .args(["-fSL", "--retry", "3", "-o"])
+        .args([
+            "-fSL",
+            "--proto",
+            "=https",
+            "--proto-redir",
+            "=https",
+            "--retry",
+            "3",
+            "-o",
+        ])
         .arg(&tgz)
         .arg(&url)
         .status()
@@ -357,23 +379,15 @@ fn fetch_pdfium(os: &str, arch: &str, vendored: &Path) {
         panic!("pdfium: curl download failed for {url}");
     }
 
-    if let Some(hash) = KNOWN_HASHES
-        .iter()
-        .find(|(p, _)| *p == pair)
-        .map(|(_, h)| *h)
-    {
-        let mut f = fs::File::open(&tgz).expect("pdfium: cannot open downloaded tarball");
-        let mut buf = Vec::with_capacity(8 * 1024 * 1024);
-        f.read_to_end(&mut buf)
-            .expect("pdfium: cannot read tarball");
-        let got = sha256_hex(&buf);
-        assert_eq!(
-            got, hash,
-            "pdfium: sha256 mismatch for {pair} (expected {hash}, got {got})"
-        );
-    } else {
-        eprintln!("donsetch build: no pinned sha256 for pdfium {pair} yet (unverified download)");
-    }
+    let mut f = fs::File::open(&tgz).expect("pdfium: cannot open downloaded tarball");
+    let mut buf = Vec::with_capacity(8 * 1024 * 1024);
+    f.read_to_end(&mut buf)
+        .expect("pdfium: cannot read tarball");
+    let got = sha256_hex(&buf);
+    assert_eq!(
+        got, pinned_hash,
+        "pdfium: sha256 mismatch for {pair} (expected {pinned_hash}, got {got})"
+    );
 
     let status = Command::new("tar")
         .arg("xzf")

--- a/build.rs
+++ b/build.rs
@@ -38,13 +38,20 @@ const PDFIUM_STATIC_TAG: &str = "chromium/7809";
 /// are Chromium 149-era PDFium builds.
 const PDFIUM_SHARED_TAG: &str = "chromium/7802";
 
-/// sha256 of the pinned tarball per platform "os-arch". Verified on download and required;
-/// builds fail before any network download if no entry exists.
-/// entries are filled as each platform's artifact is prepped for CI.
-const KNOWN_HASHES: &[(&str, &str)] = &[(
-    "linux-x64",
-    "13908bb2d40a6e017c4c5a6a7baecc6efd7b1c30392c8a79e80072d2b48b18eb",
-)];
+/// sha256 of the pinned tarball per platform "os-arch".
+/// Verified on download and required; builds fail before any network download if no entry exists.
+/// linux-x64 and linux-arm64 values are verified against the Sigstore/SLSA attestation for kognitos/pdfium-static chromium/7809; release sidecar checksum files alone are not authorization.
+/// entries are filled as each platform artifact is prepped for CI.
+const KNOWN_HASHES: &[(&str, &str)] = &[
+    (
+        "linux-x64",
+        "13908bb2d40a6e017c4c5a6a7baecc6efd7b1c30392c8a79e80072d2b48b18eb",
+    ),
+    (
+        "linux-arm64",
+        "abe1c3d5b168ec2baaafc7a8fcddfda1a09417f39199c7993fd28d34d3a7f70e",
+    ),
+];
 
 fn main() {
     // Declare the custom cfg so rustc doesn't warn about it.

--- a/build.rs
+++ b/build.rs
@@ -40,8 +40,11 @@ const PDFIUM_SHARED_TAG: &str = "chromium/7802";
 
 /// sha256 of the pinned tarball per platform "os-arch".
 /// Verified on download and required; builds fail before any network download if no entry exists.
-/// linux-x64 and linux-arm64 values are verified against the Sigstore/SLSA attestation for kognitos/pdfium-static chromium/7809; release sidecar checksum files alone are not authorization.
-/// entries are filled as each platform artifact is prepped for CI.
+/// Entries are release-asset digests for the exact pinned artifacts: static
+/// Linux/macOS assets from kognitos/pdfium-static chromium/7809, and shared
+/// Android/Windows assets from bblanchon/pdfium-binaries chromium/7802.
+/// They were cross-checked against each release's attestation metadata; a
+/// sidecar checksum file from the same release is not authorization.
 const KNOWN_HASHES: &[(&str, &str)] = &[
     (
         "linux-x64",
@@ -50,6 +53,30 @@ const KNOWN_HASHES: &[(&str, &str)] = &[
     (
         "linux-arm64",
         "abe1c3d5b168ec2baaafc7a8fcddfda1a09417f39199c7993fd28d34d3a7f70e",
+    ),
+    (
+        "mac-x64",
+        "c097fd17a07826bb36617dda0cd02bd7829c0f2087f33e927124df21dc5cef06",
+    ),
+    (
+        "mac-arm64",
+        "08556377b5d33b2fef7c6bfec66e01b9b23007c10533ab0404fe54538cbb2837",
+    ),
+    (
+        "win-x64",
+        "487156c28d81bd162107ca0ba85849cbfbb0127be4210a7cfec6def66802082d",
+    ),
+    (
+        "win-arm64",
+        "15d679b0baf8bb470c9fae155c0abc4ab752017b38f4cc71940314af565c53e2",
+    ),
+    (
+        "android-x64",
+        "596cbe4fd6cbb118a9f0576fa96f2c0f4476f7a85779e7f32d64888a6e4f1ddd",
+    ),
+    (
+        "android-arm64",
+        "4e510dd0757af1439107c23577fafdc854fac9c403a5a5b20f78ebf87097672c",
     ),
 ];
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -14,7 +14,16 @@ DonSeTch gives AI agents web research from a single local process — fetch any 
 npm install -g donsetch
 ```
 
-Downloads the prebuilt binary for your platform from [GitHub Releases](https://github.com/dondai44423/donsetch/releases) with SHA256 verification.
+> **Prebuilt install is currently disabled — build from source is required.** The installer in `npm/install.js` verifies release tarballs only against a source-controlled `PINNED_SHA256` map. This repository currently contains no independently audited hashes, so the map is empty and the installer fails closed before any download. A checksum file (e.g. `*.sha256`) hosted alongside the tarball on the same GitHub release is **not** trusted for authorization (same origin) and is never used. Until audited hashes are pinned, `npm install -g donsetch` will not fetch a binary — build from source instead:
+>
+> ```bash
+> git clone https://github.com/dondai44423/donsetch.git
+> cd donsetch && cargo build --release
+> ```
+>
+> To enable prebuilt installs in a future version, add independently audited SHA256 entries to `PINNED_SHA256` in `npm/install.js` — no code change beyond the map is needed.
+
+When hashes are pinned, the installer will download the asset for your platform from [GitHub Releases](https://github.com/dondai44423/donsetch/releases) and verify it against the pinned hash:
 
 | Platform | Binary |
 |---|---|

--- a/npm/install.js
+++ b/npm/install.js
@@ -2,12 +2,22 @@
 'use strict';
 
 // donsetch postinstall: download the prebuilt binary for this platform
-// from GitHub Releases, verify SHA256, and extract to ./binaries/.
+// from GitHub Releases, verify SHA256 against a source-controlled pinned
+// hash, and extract to ./binaries/.
 //
 // The binary is NOT bundled in the npm package — it's fetched at
 // install time from the GitHub release matching this package version.
 // This keeps the npm registry clean (no 35 MB binary tarballs) and
 // uses the same release artifacts that manual users download.
+//
+// Hardening: tarball SHA256 is verified ONLY against PINNED_SHA256 below.
+// A checksum file hosted alongside the tarball on the same GitHub release
+// is NOT trusted for authorization (same origin, no independent audit) and
+// is therefore never fetched or used. If no pinned hash exists for the
+// current platform the installer fails closed before any download and
+// instructs the user to build from source. To enable prebuilt installs for
+// a future release, add independently audited SHA256 entries to
+// PINNED_SHA256 (one per release asset).
 //
 // Supported platforms:
 //   linux-x64      Linux x86_64 (glibc)
@@ -25,6 +35,26 @@ const { execFileSync } = require('child_process');
 const REPO = 'dondai44423/donsetch';
 const VERSION = require('./package.json').version;
 const TAG = `v${VERSION}`;
+
+// ── source-controlled pinned hashes ─────────────────────────────
+// Map of platform key -> hex SHA256 of the release tarball asset.
+// This repository currently contains no independently audited npm
+// release hashes, so the map is intentionally empty. The installer
+// fails closed when the current platform has no entry (see top-level
+// check below, before any download or cached-binary reuse). To enable
+// prebuilt installs, add audited entries:
+//
+//   const PINNED_SHA256 = {
+//     'linux-x64':    '<64-hex-sha256-of-donsetch-linux-x64.tar.gz>',
+//     'linux-arm64':  '<64-hex-sha256-of-donsetch-linux-arm64.tar.gz>',
+//     'darwin-arm64': '<64-hex-sha256-of-donsetch-darwin-arm64.tar.gz>',
+//     'darwin-x64':   '<64-hex-sha256-of-donsetch-darwin-x64.tar.gz>',
+//     'win32-x64':    '<64-hex-sha256-of-donsetch-win32-x64.tar.gz>',
+//   };
+//
+// Do not invent or reuse a checksum downloaded from the GitHub release
+// itself — only add hashes that have been independently audited.
+const PINNED_SHA256 = {};
 
 // ── platform mapping ────────────────────────────────────────────
 const PLATFORMS = {
@@ -127,6 +157,24 @@ if (process.platform === 'linux') {
 const binDir = path.join(__dirname, 'binaries');
 const binaryPath = path.join(binDir, plat.binary);
 
+// Fail closed before any network download — and before accepting an
+// existing/cached binary — if no pinned hash exists for this platform. A
+// checksum file hosted alongside the tarball on the same GitHub release
+// is not trusted for authorization (same origin, no independent audit).
+const expectedHash = PINNED_SHA256[platKey];
+if (!expectedHash) {
+  console.error(`donsetch: no pinned SHA256 hash for ${platKey} (${plat.asset}) in this version of the installer.`);
+  console.error('The checksum file hosted alongside the release tarball on GitHub (e.g. *.sha256) is downloaded from the same origin as the tarball itself and is therefore not trusted for authorization.');
+  console.error('Prebuilt binary download is disabled until an independently audited hash is pinned in npm/install.js (PINNED_SHA256).');
+  console.error('');
+  console.error('Build from source instead:');
+  console.error(`  git clone https://github.com/${REPO}.git`);
+  console.error('  cd donsetch && cargo build --release');
+  console.error('');
+  console.error('See npm/README.md and https://github.com/' + REPO + '#-install for details.');
+  process.exit(1);
+}
+
 // Skip if already installed (npm cache reuse, reinstall, etc.).
 // A plausibility check first: a stale 0-byte or truncated leftover
 // (killed install, crashed download) must not shadow a fresh one.
@@ -145,7 +193,6 @@ fs.mkdirSync(binDir, { recursive: true });
 
 const baseUrl = `https://github.com/${REPO}/releases/download/${TAG}`;
 const assetUrl = `${baseUrl}/${plat.asset}`;
-const checksumUrl = `${baseUrl}/${plat.asset}.sha256`;
 
 // ── download with redirect following (max 5 hops) ───────────────
 function download(url, dest) {
@@ -191,7 +238,6 @@ function download(url, dest) {
 // ── main ────────────────────────────────────────────────────────
 async function main() {
   const tarball = path.join(binDir, plat.asset);
-  const checksumFile = path.join(binDir, 'checksum.sha256');
 
   // 0. Windows: tar ships with Windows 10 1803+; older boxes lack it.
   //    Detect BEFORE downloading so the error names the real problem.
@@ -210,35 +256,29 @@ async function main() {
   console.log(`donsetch: downloading ${plat.asset} from ${TAG}...`);
   await download(assetUrl, tarball);
 
-  // 2. Download the SHA256 checksum
+  // 2. Verify SHA256 against the pinned hash (source-controlled)
   console.log('donsetch: verifying checksum...');
-  await download(checksumUrl, checksumFile);
-
-  // 3. Verify SHA256
-  const expectedHash = fs.readFileSync(checksumFile, 'utf8').trim().split(/\s+/)[0];
   const actualHash = crypto.createHash('sha256').update(fs.readFileSync(tarball)).digest('hex');
 
   if (actualHash !== expectedHash) {
     try { fs.unlinkSync(tarball); } catch (_) {}
-    try { fs.unlinkSync(checksumFile); } catch (_) {}
     console.error(`donsetch: SHA256 mismatch!`);
-    console.error(`  expected: ${expectedHash}`);
-    console.error(`  actual:   ${actualHash}`);
+    console.error(`  expected (pinned): ${expectedHash}`);
+    console.error(`  actual:            ${actualHash}`);
     console.error('The download may have been corrupted or tampered with.');
     process.exit(1);
   }
 
-  // 4. Extract (tar is built into Linux, macOS, and Windows 10+)
+  // 3. Extract (tar is built into Linux, macOS, and Windows 10+)
   console.log('donsetch: extracting...');
   // execFileSync: no shell, no string interpolation — the install
   // path (which can contain quotes/spaces) is passed as argv.
   execFileSync('tar', ['xzf', tarball, '-C', binDir], { stdio: 'inherit' });
 
-  // 5. Cleanup
+  // 4. Cleanup
   try { fs.unlinkSync(tarball); } catch (_) {}
-  try { fs.unlinkSync(checksumFile); } catch (_) {}
 
-  // 6. Verify the binary exists after extraction (BEFORE chmod —
+  // 5. Verify the binary exists after extraction (BEFORE chmod —
   //    chmod on a missing file throws an opaque error).
   if (!fs.existsSync(binaryPath)) {
     console.error(`donsetch: expected ${plat.binary} not found after extraction`);
@@ -247,7 +287,7 @@ async function main() {
     process.exit(1);
   }
 
-  // 7. Make executable (Unix only)
+  // 6. Make executable (Unix only)
   if (process.platform !== 'win32') {
     fs.chmodSync(binaryPath, 0o755);
   }

--- a/npm/install.js
+++ b/npm/install.js
@@ -175,18 +175,20 @@ if (!expectedHash) {
   process.exit(1);
 }
 
-// Skip if already installed (npm cache reuse, reinstall, etc.).
-// A plausibility check first: a stale 0-byte or truncated leftover
-// (killed install, crashed download) must not shadow a fresh one.
+// Never trust an existing/cached binary without a binary-level
+// provenance check. The pinned value above authenticates the release
+// tarball, not an arbitrary file already present in this directory.
+// Remove any existing binary so every successful install comes from a
+// freshly downloaded and verified tarball. This also prevents a stale
+// or attacker-replaced binary from being accepted on reinstall.
 if (fs.existsSync(binaryPath)) {
-  let size = 0;
-  try { size = fs.statSync(binaryPath).size; } catch (_) {}
-  if (size > 1024 * 1024) {
-    console.log(`donsetch: binary already present (${plat.binary})`);
-    process.exit(0);
+  console.log(`donsetch: removing existing ${plat.binary} before verified reinstall`);
+  try {
+    fs.unlinkSync(binaryPath);
+  } catch (err) {
+    console.error(`donsetch: cannot remove existing ${binaryPath}: ${err.message}`);
+    process.exit(1);
   }
-  console.log(`donsetch: leftover ${plat.binary} is ${size} bytes — re-downloading`);
-  try { fs.unlinkSync(binaryPath); } catch (_) {}
 }
 
 fs.mkdirSync(binDir, { recursive: true });

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -26,6 +26,48 @@ use crate::profile::BrowserProfile;
 
 const REPO: &str = "dondai44423/donsetch";
 
+/// Independently reviewed SHA256 pins for self-update tarballs.
+///
+/// The release sidecar checksum is deliberately not trusted: it is
+/// published alongside the artifact and therefore does not provide an
+/// independent authorization decision. A new release must add its
+/// platform pins in a reviewed source change before self-update will
+/// accept it. Missing pins fail closed.
+const PINNED_UPDATE_HASHES: &[(&str, &str, &str)] = &[
+    (
+        "3.2.3",
+        "linux-x64",
+        "a98a9e7bdd32d072ce4637eb4104f539d7df7d52aa583126b1faf94dfb1e55a4",
+    ),
+    (
+        "3.2.3",
+        "linux-arm64",
+        "958c2e9cec861304ace475a8bd6e10fc4fef6e3e39625ab3fe3144f2047b3a70",
+    ),
+    (
+        "3.2.3",
+        "darwin-x64",
+        "435d80e6da9c2694d4ccec8e0827a7e85254b6edcdca38b785340307b34a64b2",
+    ),
+    (
+        "3.2.3",
+        "darwin-arm64",
+        "db789e1eeff78caf4f95f9ad3f9b1b022b35c491b49d567dbe79974339e7ee03",
+    ),
+    (
+        "3.2.3",
+        "win32-x64",
+        "699cb9ae6992c9a82f28788aa4574841394292fc74ae77eb71512e6562cfdccc",
+    ),
+];
+
+fn pinned_update_hash(version: &str, asset: &str) -> Option<&'static str> {
+    PINNED_UPDATE_HASHES
+        .iter()
+        .find(|(v, a, _)| *v == version && *a == asset)
+        .map(|(_, _, hash)| *hash)
+}
+
 pub async fn run() {
     cli::init();
     cli::print_title("DonSeTch Update");
@@ -111,7 +153,18 @@ pub async fn run() {
     let tag = format!("v{latest}");
     let base = format!("https://github.com/{REPO}/releases/download/{tag}");
     let tarball_url = format!("{base}/donsetch-{asset}.tar.gz");
-    let sha256_url = format!("{base}/donsetch-{asset}.tar.gz.sha256");
+
+    let expected = match pinned_update_hash(&latest, asset) {
+        Some(hash) => hash,
+        None => {
+            println!(
+                "  {} Self-update is unavailable for {latest}/{asset}: no reviewed SHA256 pin",
+                cli::icon_fail()
+            );
+            println!("    Build from source: cargo install --path .");
+            std::process::exit(1);
+        }
+    };
 
     let asset_label = format!("donsetch-{asset}.tar.gz");
     cli::print_kv("asset", &asset_label);
@@ -154,33 +207,14 @@ pub async fn run() {
         println!("  {} downloaded ({kb}KB)", cli::icon_pass());
     }
 
-    // ── Download + verify SHA256 ─────────────────────────────
+    // ── Verify against the reviewed source pin ────────────────
 
-    let sha256_text = match fetcher.fetch(&sha256_url).await {
-        Ok(out) if out.status == 200 => String::from_utf8_lossy(&out.body).to_string(),
-        Ok(out) => {
-            println!(
-                "  {} Could not download SHA256: HTTP {}",
-                cli::icon_fail(),
-                out.status,
-            );
-            std::process::exit(1);
-        }
-        Err(e) => {
-            println!("  {} Could not download SHA256: {e}", cli::icon_fail());
-            std::process::exit(1);
-        }
-    };
-
-    let expected = sha256_text.split_whitespace().next().unwrap_or("");
     let actual = sha256_hex(&tarball);
 
-    if expected.is_empty() || expected != actual {
+    if expected != actual {
         println!("  {} SHA256 mismatch", cli::icon_fail());
-        if !expected.is_empty() {
-            println!("    expected: {expected}");
-            println!("    actual:   {actual}");
-        }
+        println!("    expected: {expected}");
+        println!("    actual:   {actual}");
         std::process::exit(1);
     }
     println!("  {} SHA256 verified", cli::icon_pass());
@@ -433,4 +467,23 @@ fn cleanup_previous(exe: &Path) {
     // Unix temp file (half-written binary from interrupted update).
     let tmp = exe_dir.join(".donsetch.update.tmp");
     let _ = std::fs::remove_file(&tmp);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::pinned_update_hash;
+
+    #[test]
+    fn reviewed_release_platform_has_a_pin() {
+        assert_eq!(
+            pinned_update_hash("3.2.3", "linux-arm64"),
+            Some("958c2e9cec861304ace475a8bd6e10fc4fef6e3e39625ab3fe3144f2047b3a70")
+        );
+    }
+
+    #[test]
+    fn unknown_release_or_platform_fails_closed() {
+        assert_eq!(pinned_update_hash("3.2.4", "linux-arm64"), None);
+        assert_eq!(pinned_update_hash("3.2.3", "win32-arm64"), None);
+    }
 }

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -217,7 +217,7 @@ async fn ghost_cmd(args: &[String]) {
         "shot" => {
             let url = args.get(1).expect("usage: ghost shot <url> [path]");
             let path = args.get(2).cloned().unwrap_or_else(|| {
-                std::env::temp_dir()
+                crate::paths::screenshots_dir()
                     .join("ghost.png")
                     .to_string_lossy()
                     .into_owned()

--- a/src/fetch/client.rs
+++ b/src/fetch/client.rs
@@ -131,6 +131,12 @@ impl Fetcher {
         use_jar: bool,
         referer: Option<&str>,
     ) -> Result<FetchOutcome, FetchError> {
+        // Centralized URL safety gate (fetch tier). Every fetch target,
+        // including explicit proxy lanes, env proxies, and every
+        // redirect hop, is validated via the async DNS-aware gate.
+        // Rejects non-http(s), credentials, localhost/private literals
+        // and DNS-resolved private addresses before any network.
+        crate::fetch::guards::ensure_url_safe(url_str).await?;
         let started = Instant::now();
 
         // Fresh-window cache hit: no request at all (browser-true).
@@ -231,27 +237,26 @@ impl Fetcher {
                     };
                     let base = url::Url::parse(&current)
                         .map_err(|_| FetchError::InvalidUrl(current.clone()))?;
-                    let next = base
-                        .join(&loc)
-                        .map_err(|_| FetchError::Http(format!("bad redirect target: {loc}")))?;
-                    if !matches!(next.scheme(), "http" | "https") {
-                        // Non-web scheme (file://, ftp://, …):
-                        // returned honestly, not followed.
-                        out.elapsed = started.elapsed();
-                        out.redirects = redirects;
-                        return Ok(out);
-                    }
-                    // SSRF guard on EVERY hop: a public URL that
-                    // redirects into a private network must not
-                    // be followed (the initial-URL-only check is
-                    // trivially bypassable otherwise).
-                    if let Some(h) = next.host_str()
-                        && crate::fetch::guards::is_ssrf_host(h)
-                    {
-                        return Err(FetchError::Http(format!(
-                            "redirect to private/loopback address blocked: {h} — SSRF guard"
-                        )));
-                    }
+                    // Centralized redirect SSRF guard — validates scheme,
+                    // credentials and host, and rejects private literals.
+                    // Non-http(s) redirects are returned honestly, not followed.
+                    // Every redirect hop also passes through the async DNS-aware
+                    // gate so private DNS results fail closed even on redirects.
+                    let next = match crate::fetch::guards::validate_redirect_url(&base, &loc) {
+                        Ok(u) => u,
+                        Err(e) => {
+                            // Non-web scheme: return honestly per original
+                            // behavior (file://, ftp:// etc. not followed).
+                            if e.to_string().contains("non-http") {
+                                out.elapsed = started.elapsed();
+                                out.redirects = redirects;
+                                return Ok(out);
+                            }
+                            return Err(e);
+                        }
+                    };
+                    // DNS-aware validation for the redirect target (fail-closed).
+                    crate::fetch::guards::ensure_url_safe(next.as_str()).await?;
                     current = next.to_string();
                 }
                 _ => {
@@ -309,6 +314,11 @@ impl Fetcher {
         use_jar: bool,
         referer: Option<&str>,
     ) -> Result<FetchOutcome, FetchError> {
+        // Centralized gate ensures credentials/host checks even for
+        // direct fetch_once calls (e.g. tests, internal callers).
+        // Includes DNS resolution — every target, including proxy
+        // lanes, is checked before any TCP connect.
+        crate::fetch::guards::ensure_url_safe(url_str).await?;
         let url = url::Url::parse(url_str).map_err(|_| FetchError::InvalidUrl(url_str.into()))?;
         let scheme = url.scheme();
         if scheme != "http" && scheme != "https" {

--- a/src/fetch/cookies.rs
+++ b/src/fetch/cookies.rs
@@ -20,6 +20,100 @@ pub struct CookieJar {
     cookies: Vec<Cookie>,
 }
 
+fn normalize_domain(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    // Reject control characters (CR, LF, NUL and other ASCII controls)
+    if trimmed
+        .bytes()
+        .any(|b| b == b'\r' || b == b'\n' || b == b'\0' || b < 0x20 || b == 0x7F)
+    {
+        return None;
+    }
+    let mut s = trimmed.to_ascii_lowercase();
+    // Strip one leading dot (RFC 6265 allows a leading dot, but only one is significant)
+    if s.starts_with('.') {
+        s = s[1..].to_string();
+    }
+    // Strip one trailing root dot (e.g. "example.com.")
+    if s.ends_with('.') {
+        s.pop();
+    }
+    if s.is_empty() {
+        return None;
+    }
+    if s.bytes()
+        .any(|b| b == b'\r' || b == b'\n' || b == b'\0' || b < 0x20 || b == 0x7F)
+    {
+        return None;
+    }
+    if s.len() > 253 {
+        return None;
+    }
+    for label in s.split('.') {
+        if label.is_empty() {
+            return None;
+        }
+        if label.len() > 63 {
+            return None;
+        }
+        if label.starts_with('-') || label.ends_with('-') {
+            return None;
+        }
+        if !label
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+        {
+            return None;
+        }
+    }
+    Some(s)
+}
+
+fn normalize_host(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    if trimmed
+        .bytes()
+        .any(|b| b == b'\r' || b == b'\n' || b == b'\0' || b < 0x20 || b == 0x7F)
+    {
+        return None;
+    }
+    let mut s = trimmed.to_ascii_lowercase();
+    // Strip one trailing root dot for comparison (hosts are sent without it)
+    if s.ends_with('.') {
+        s.pop();
+    }
+    if s.is_empty() {
+        return None;
+    }
+    if s.len() > 253 {
+        return None;
+    }
+    for label in s.split('.') {
+        if label.is_empty() {
+            return None;
+        }
+        if label.len() > 63 {
+            return None;
+        }
+        if label.starts_with('-') || label.ends_with('-') {
+            return None;
+        }
+        if !label
+            .bytes()
+            .all(|b| b.is_ascii_lowercase() || b.is_ascii_digit() || b == b'-')
+        {
+            return None;
+        }
+    }
+    Some(s)
+}
+
 impl CookieJar {
     pub fn new() -> Self {
         Self::default()
@@ -27,6 +121,9 @@ impl CookieJar {
 
     /// Store all Set-Cookie headers from a response for `host`.
     pub fn store_from_headers(&mut self, host: &str, headers: &[(String, String)]) {
+        let Some(normalized_host) = normalize_host(host) else {
+            return;
+        };
         for (n, v) in headers {
             if !n.eq_ignore_ascii_case("set-cookie") {
                 continue;
@@ -47,7 +144,7 @@ impl CookieJar {
             if name.contains(['\r', '\n', '\0']) || value.contains(['\r', '\n', '\0']) {
                 continue;
             }
-            let mut domain = host.to_string();
+            let mut domain = normalized_host.clone();
             let mut host_only = true;
             let mut path = "/".to_string();
             let mut expired = false;
@@ -57,14 +154,23 @@ impl CookieJar {
                 if let Some((k, val)) = attr.split_once('=') {
                     match k.trim().to_ascii_lowercase().as_str() {
                         "domain" => {
-                            let d = val.trim().trim_start_matches('.').to_lowercase();
+                            let Some(normalized) = normalize_domain(val.trim()) else {
+                                continue;
+                            };
+                            // Reject public suffixes (e.g. "com", "co.uk")
+                            // psl::domain is None for public suffixes, Some for registrable domains
+                            if psl::domain(normalized.as_bytes()).is_none() {
+                                continue;
+                            }
                             // RFC 6265 §5.3 step 6: reject Domain
                             // attributes that are not the request
                             // host or a parent of it — otherwise any
                             // origin can pin cookies on any victim
                             // domain (cookie tossing).
-                            if d == host || host.ends_with(&format!(".{d}")) {
-                                domain = d;
+                            if normalized == normalized_host
+                                || normalized_host.ends_with(&format!(".{normalized}"))
+                            {
+                                domain = normalized;
                                 host_only = false;
                             }
                         }
@@ -114,17 +220,22 @@ impl CookieJar {
         if name.contains(['\r', '\n', '\0']) || value.contains(['\r', '\n', '\0']) {
             return;
         }
-        let (dom, host_only) = if let Some(d) = domain.strip_prefix('.') {
-            (d.to_string(), false)
-        } else {
-            (domain.to_string(), true)
+        // Preserve leading-dot subdomain semantics
+        let is_subdomain = domain.trim().starts_with('.');
+        let Some(normalized) = normalize_domain(domain) else {
+            return;
         };
+        // Reject invalid/public-suffix domains
+        if psl::domain(normalized.as_bytes()).is_none() {
+            return;
+        }
+        let host_only = !is_subdomain;
         self.cookies
-            .retain(|c| !(c.name == name && c.domain == dom && c.path == "/"));
+            .retain(|c| !(c.name == name && c.domain == normalized && c.path == "/"));
         self.cookies.push(Cookie {
             name: name.to_string(),
             value: value.to_string(),
-            domain: dom,
+            domain: normalized,
             path: "/".into(),
             host_only,
             expires_at,
@@ -134,15 +245,19 @@ impl CookieJar {
     /// Export all cookies matching `host` as CookieRecords
     /// for write-back to the persistent domain profile.
     pub fn snapshot_for(&self, host: &str) -> Vec<CookieRecord> {
+        let Some(normalized_host) = normalize_host(host) else {
+            return Vec::new();
+        };
         let now = now_secs();
         self.cookies
             .iter()
             .filter(|c| c.expires_at.is_none_or(|e| e > now))
             .filter(|c| {
                 if c.host_only {
-                    host == c.domain
+                    normalized_host == c.domain
                 } else {
-                    host == c.domain || host.ends_with(&format!(".{}", c.domain))
+                    normalized_host == c.domain
+                        || normalized_host.ends_with(&format!(".{}", c.domain))
                 }
             })
             .map(|c| CookieRecord {
@@ -156,6 +271,9 @@ impl CookieJar {
 
     /// Cookie header value for a request to `host` + `path`, if any match.
     pub fn header_for(&self, host: &str, path: &str) -> Option<String> {
+        let Some(normalized_host) = normalize_host(host) else {
+            return None;
+        };
         let now = now_secs();
         let mut pairs: Vec<&Cookie> = Vec::new();
         for c in &self.cookies {
@@ -165,9 +283,9 @@ impl CookieJar {
                 continue;
             }
             let domain_ok = if c.host_only {
-                host == c.domain
+                normalized_host == c.domain
             } else {
-                host == c.domain || host.ends_with(&format!(".{}", c.domain))
+                normalized_host == c.domain || normalized_host.ends_with(&format!(".{}", c.domain))
             };
             // RFC 6265 §5.1.4 path-match: exact, or prefix followed
             // by '/' (a /foo cookie must not match /foobar).
@@ -205,4 +323,197 @@ fn now_secs() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_secs())
         .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn domain_com_not_shared() {
+        let mut jar = CookieJar::new();
+        jar.store_from_headers(
+            "example.com",
+            &[("Set-Cookie".to_string(), "a=1; Domain=com".to_string())],
+        );
+        // Public suffix should be rejected -> fallback to host-only
+        assert_eq!(jar.snapshot_for("example.com").len(), 1);
+        assert_eq!(jar.snapshot_for("sub.example.com").len(), 0);
+        assert_eq!(jar.snapshot_for("evil.com").len(), 0);
+        assert!(jar.header_for("example.com", "/").is_some());
+        assert!(jar.header_for("sub.example.com", "/").is_none());
+        assert!(jar.header_for("other.com", "/").is_none());
+    }
+
+    #[test]
+    fn domain_co_uk_not_shared() {
+        let mut jar = CookieJar::new();
+        jar.store_from_headers(
+            "example.co.uk",
+            &[("Set-Cookie".to_string(), "a=1; Domain=co.uk".to_string())],
+        );
+        assert_eq!(jar.snapshot_for("example.co.uk").len(), 1);
+        assert_eq!(jar.snapshot_for("sub.example.co.uk").len(), 0);
+        assert_eq!(jar.snapshot_for("evil.co.uk").len(), 0);
+        assert!(jar.header_for("example.co.uk", "/").is_some());
+        assert!(jar.header_for("sub.example.co.uk", "/").is_none());
+    }
+
+    #[test]
+    fn host_only_exact_match() {
+        let mut jar = CookieJar::new();
+        jar.store_raw("a", "1", "example.com", None);
+        assert!(jar.header_for("example.com", "/").is_some());
+        assert!(jar.header_for("sub.example.com", "/").is_none());
+        assert!(jar.header_for("evil-example.com", "/").is_none());
+        assert_eq!(jar.snapshot_for("example.com").len(), 1);
+        assert_eq!(jar.snapshot_for("sub.example.com").len(), 0);
+        // host-only should not be visible on parent or unrelated
+        assert!(jar.header_for("other.com", "/").is_none());
+    }
+
+    #[test]
+    fn valid_example_com_matches_subdomain_not_evil() {
+        let mut jar = CookieJar::new();
+        jar.store_raw("a", "1", ".example.com", None);
+        // exact host matches
+        assert_eq!(jar.header_for("example.com", "/"), Some("a=1".to_string()));
+        // subdomains match
+        assert_eq!(
+            jar.header_for("sub.example.com", "/"),
+            Some("a=1".to_string())
+        );
+        assert_eq!(
+            jar.header_for("deep.sub.example.com", "/"),
+            Some("a=1".to_string())
+        );
+        // dot-boundary prevents evil-example.com
+        assert!(jar.header_for("evil-example.com", "/").is_none());
+        assert!(jar.header_for("evil.com", "/").is_none());
+        // snapshot similarly
+        assert_eq!(jar.snapshot_for("sub.example.com").len(), 1);
+        assert_eq!(jar.snapshot_for("evil-example.com").len(), 0);
+    }
+
+    #[test]
+    fn valid_domain_attribute_matching() {
+        let mut jar = CookieJar::new();
+        jar.store_from_headers(
+            "sub.example.com",
+            &[(
+                "Set-Cookie".to_string(),
+                "a=1; Domain=example.com".to_string(),
+            )],
+        );
+        assert!(jar.header_for("sub.example.com", "/").is_some());
+        assert!(jar.header_for("example.com", "/").is_some());
+        assert!(jar.header_for("other.sub.example.com", "/").is_some());
+        assert!(jar.header_for("evil-example.com", "/").is_none());
+    }
+
+    #[test]
+    fn unrelated_hosts_no_leak() {
+        let mut jar = CookieJar::new();
+        jar.store_raw("a", "1", ".example.com", None);
+        assert!(jar.header_for("other.com", "/").is_none());
+        assert!(jar.header_for("example.org", "/").is_none());
+        assert!(jar.header_for("example.com.evil.com", "/").is_none());
+        assert_eq!(jar.snapshot_for("other.com").len(), 0);
+        assert_eq!(jar.snapshot_for("example.org").len(), 0);
+    }
+
+    #[test]
+    fn malformed_domains_rejected() {
+        let mut jar = CookieJar::new();
+        // empty label
+        jar.store_raw("a", "1", "example..com", None);
+        assert_eq!(jar.snapshot_for("example.com").len(), 0);
+        // leading hyphen
+        jar.store_raw("b", "1", "-example.com", None);
+        assert_eq!(jar.snapshot_for("example.com").len(), 0);
+        // trailing hyphen
+        jar.store_raw("c", "1", "example-.com", None);
+        assert_eq!(jar.snapshot_for("example.com").len(), 0);
+        // empty
+        jar.store_raw("d", "1", "", None);
+        assert_eq!(jar.snapshot_for("example.com").len(), 0);
+        // control char
+        jar.store_raw("e", "1", "example.com\u{00}", None);
+        assert_eq!(jar.snapshot_for("example.com").len(), 0);
+        // underscore invalid label
+        jar.store_raw("f", "1", "exa_mple.com", None);
+        assert_eq!(jar.snapshot_for("example.com").len(), 0);
+        // double leading dot -> empty label after stripping one
+        jar.store_raw("g", "1", "..example.com", None);
+        assert_eq!(jar.snapshot_for("example.com").len(), 0);
+
+        // via store_from_headers malformed should fallback to host-only
+        let mut jar2 = CookieJar::new();
+        jar2.store_from_headers(
+            "example.com",
+            &[(
+                "Set-Cookie".to_string(),
+                "a=1; Domain=example..com".to_string(),
+            )],
+        );
+        // fallback host-only: only example.com visible
+        assert_eq!(jar2.snapshot_for("example.com").len(), 1);
+        assert_eq!(jar2.snapshot_for("sub.example.com").len(), 0);
+    }
+
+    #[test]
+    fn raw_public_suffix_rejected() {
+        let mut jar = CookieJar::new();
+        jar.store_raw("a", "1", "com", None);
+        assert_eq!(jar.snapshot_for("com").len(), 0);
+        assert_eq!(jar.snapshot_for("example.com").len(), 0);
+        jar.store_raw("a", "1", ".com", None);
+        assert_eq!(jar.snapshot_for("com").len(), 0);
+        jar.store_raw("a", "1", "co.uk", None);
+        assert_eq!(jar.snapshot_for("co.uk").len(), 0);
+        jar.store_raw("a", "1", ".co.uk", None);
+        assert_eq!(jar.snapshot_for("co.uk").len(), 0);
+        jar.store_raw("a", "1", ".example.com.", None); // trailing dot should still be valid
+        assert_eq!(jar.snapshot_for("example.com").len(), 1);
+        // but pure public suffix with trailing dot rejected
+        jar = CookieJar::new();
+        jar.store_raw("a", "1", "com.", None);
+        assert_eq!(jar.snapshot_for("com").len(), 0);
+    }
+
+    #[test]
+    fn case_insensitivity_and_trailing_dot() {
+        let mut jar = CookieJar::new();
+        jar.store_from_headers(
+            "Example.COM",
+            &[(
+                "Set-Cookie".to_string(),
+                "a=1; Domain=EXAMPLE.COM".to_string(),
+            )],
+        );
+        // normalized to lower case
+        assert!(jar.header_for("example.com", "/").is_some());
+        assert!(jar.header_for("EXAMPLE.COM", "/").is_some());
+        assert!(jar.header_for("sub.example.com", "/").is_some());
+        // trailing root dot stripped
+        let mut jar2 = CookieJar::new();
+        jar2.store_raw("a", "1", ".Example.COM.", None);
+        assert!(jar2.header_for("example.com", "/").is_some());
+        assert!(jar2.header_for("sub.example.com.", "/").is_some());
+    }
+
+    #[test]
+    fn control_chars_in_domain_rejected() {
+        let mut jar = CookieJar::new();
+        jar.store_from_headers(
+            "example.com",
+            &[(
+                "Set-Cookie".to_string(),
+                "a=1; Domain=exa\r\nmple.com".to_string(),
+            )],
+        );
+        // should fallback to host-only
+        assert_eq!(jar.snapshot_for("example.com").len(), 1);
+        assert_eq!(jar.snapshot_for("sub.example.com").len(), 0);
+    }
 }

--- a/src/fetch/cookies.rs
+++ b/src/fetch/cookies.rs
@@ -271,9 +271,7 @@ impl CookieJar {
 
     /// Cookie header value for a request to `host` + `path`, if any match.
     pub fn header_for(&self, host: &str, path: &str) -> Option<String> {
-        let Some(normalized_host) = normalize_host(host) else {
-            return None;
-        };
+        let normalized_host = normalize_host(host)?;
         let now = now_secs();
         let mut pairs: Vec<&Cookie> = Vec::new();
         for c in &self.cookies {

--- a/src/fetch/guards.rs
+++ b/src/fetch/guards.rs
@@ -9,11 +9,11 @@ use std::net::IpAddr;
 /// True if the URL's host is a private/loopback/link-local
 /// address that must never be fetched (SSRF guard).
 ///
-/// Handles literal IPs and well-known localhost names. For
-/// DNS hostnames we can't know the IP without resolution, so
-/// we only block obvious names — the transport layer's
-/// Happy Eyeballs will resolve and connect; private IPs
-/// from DNS are an accepted risk for a client-side tool.
+/// Handles literal IPs and well-known localhost names. This
+/// is a synchronous helper that only handles literal/obvious
+/// names — hostname DNS safety is enforced by the async
+/// `ensure_url_safe` which resolves hostnames and rejects
+/// private addresses.
 pub fn is_ssrf_host(host: &str) -> bool {
     // url::Url::host_str() keeps brackets on IPv6 literals —
     // strip them so the IP parser actually sees an IP.
@@ -51,8 +51,15 @@ fn is_private_ip(ip: &IpAddr) -> bool {
                 || v4.is_link_local()
                 || v4.is_unspecified()
                 || v4.is_broadcast()
+                || v4.is_multicast()
+                || v4.is_documentation()
+                || (v4.octets()[0] == 198 && (v4.octets()[1] == 18 || v4.octets()[1] == 19)) // 198.18.0.0/15 benchmarking
+                || (v4.octets()[0] >= 240) // 240.0.0.0/4 reserved
+                || (v4.octets()[0] == 0) // 0.0.0.0/8 (software)
                 // Carrier-grade NAT: 100.64.0.0/10
                 || (v4.octets()[0] == 100 && (v4.octets()[1] & 0xc0) == 0x40)
+                // 192.88.99.0/24 (6to4 relay anycast) — deprecated/reserved
+                || (v4.octets()[0] == 192 && v4.octets()[1] == 88 && v4.octets()[2] == 99)
         }
         IpAddr::V6(v6) => {
             // IPv4-mapped (::ffff:a.b.c.d) is the v4 address —
@@ -60,14 +67,153 @@ fn is_private_ip(ip: &IpAddr) -> bool {
             if let Some(v4) = v6.to_ipv4_mapped() {
                 return is_private_ip(&IpAddr::V4(v4));
             }
+            // IPv4-compat ::a.b.c.d (deprecated) also maps.
+            if let Some(v4) = v6.to_ipv4() {
+                // to_ipv4 returns Some for ::ffff: and :: forms;
+                // if we already handled mapped, this catches compat.
+                // Only treat as v4 if the v6 is in ::/96 compat range.
+                let segs = v6.segments();
+                if segs[0] == 0 && segs[1] == 0 && segs[2] == 0 && segs[3] == 0 && segs[4] == 0 {
+                    return is_private_ip(&IpAddr::V4(v4));
+                }
+            }
             v6.is_loopback()
                 || v6.is_unspecified()
+                || v6.is_multicast()
                 // Link-local: fe80::/10
                 || (v6.segments()[0] & 0xffc0) == 0xfe80
                 // Unique local: fc00::/7
                 || (v6.segments()[0] & 0xfe00) == 0xfc00
+                // Documentation: 2001:db8::/32
+                || (v6.segments()[0] == 0x2001 && v6.segments()[1] == 0x0db8)
+                // Benchmarking / reserved etc.: treat 0100::/64? Use generic reserved check via multicast+unspecified already.
+                // Discard prefix 100::/64 is also reserved.
+                || (v6.segments()[0] == 0x0100)
         }
     }
+}
+
+/// Centralized URL safety check (synchronous part).
+///
+/// Validates:
+/// - scheme is http or https only
+/// - no credentials in URL (username/password)
+/// - host present and not SSRF (literal IP ranges, localhost names)
+/// - does NOT do DNS resolution (use `ensure_url_safe` for that)
+///
+/// Returns the parsed Url on success, or a FetchError that the
+/// caller should surface directly. This is the single sync gate
+/// used by both fetch and browser tiers.
+pub fn validate_url_basic(url_str: &str) -> Result<url::Url, crate::error::FetchError> {
+    let url = url::Url::parse(url_str)
+        .map_err(|_| crate::error::FetchError::InvalidUrl(url_str.into()))?;
+    let scheme = url.scheme();
+    if scheme != "http" && scheme != "https" {
+        return Err(crate::error::FetchError::Http(format!(
+            "blocked: scheme {scheme} not allowed — only http/https"
+        )));
+    }
+    if !url.username().is_empty() || url.password().is_some() {
+        return Err(crate::error::FetchError::Http(
+            "blocked: URL contains credentials — SSRF guard".into(),
+        ));
+    }
+    let host = url
+        .host_str()
+        .ok_or_else(|| crate::error::FetchError::InvalidUrl(url_str.into()))?;
+    if is_ssrf_host(host) {
+        return Err(crate::error::FetchError::Http(format!(
+            "blocked: {host} is a private/loopback address — SSRF guard"
+        )));
+    }
+    // Also check host_str for bracketed IPv6 that Url keeps brackets on? is_ssrf_host handles it.
+    Ok(url)
+}
+
+/// Async URL safety check that includes DNS resolution.
+///
+/// Does everything `validate_url_basic` does, plus:
+/// - resolves the hostname via tokio::net::lookup_host
+/// - rejects if ANY resolved address is SSRF (private/loopback/etc.)
+/// - **fail-closed** on DNS resolution failure/timeout for
+///   network/browser navigation (the `ensure_url_safe` path).
+///   The synchronous `validate_url_basic` is the explicitly
+///   justified offline-only path (no DNS, no network) and is used
+///   by the fetch tier's initial literal check and by callers
+///   that deliberately defer DNS to the transport layer
+///   (`transport::tcp::happy_connect` re-validates at connect).
+///
+/// # DNS rebinding / TOCTOU limitation
+///
+/// This is a point-in-time check. DNS can change between this
+/// validation and the actual TCP connect (DNS rebinding / TOCTOU).
+/// The transport layer (`transport::tcp::happy_connect`) re-validates
+/// resolved addresses at connect time and filters private IPs, so
+/// an attacker that returns public at validation and private at
+/// connect is still blocked at connect. However, without full
+/// DNS pinning (reusing the validated IPs for the connect) there
+/// is a residual window between the two resolutions. Full pinning
+/// is not implemented; this is documented as a residual limitation.
+/// Redirects are re-validated per hop via `validate_redirect_url`
+/// (sync) and `ensure_url_safe` (async) where applicable.
+pub async fn ensure_url_safe(url_str: &str) -> Result<url::Url, crate::error::FetchError> {
+    let url = validate_url_basic(url_str)?;
+    let host: String = url.host_str().unwrap_or("").to_owned();
+    // Literal IP already blocked by validate_url_basic; only hostnames need DNS.
+    // Fail closed on resolution errors for browser/network navigation.
+    let port = url.port_or_known_default().unwrap_or(443);
+    let lookup = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        tokio::net::lookup_host((host.as_str(), port)),
+    )
+    .await;
+    match lookup {
+        Ok(Ok(addrs)) => {
+            let mut any = false;
+            for addr in addrs {
+                any = true;
+                if is_ssrf_ip(&addr.ip()) {
+                    return Err(crate::error::FetchError::Http(format!(
+                        "blocked: {host} resolves to private/loopback address {} — SSRF guard",
+                        addr.ip()
+                    )));
+                }
+            }
+            if !any {
+                return Err(crate::error::FetchError::Http(format!(
+                    "blocked: {host} DNS returned no addresses — fail-closed SSRF guard"
+                )));
+            }
+            Ok(url)
+        }
+        Ok(Err(e)) => Err(crate::error::FetchError::Http(format!(
+            "blocked: DNS resolution failed for {host}: {e} — fail-closed SSRF guard"
+        ))),
+        Err(_) => Err(crate::error::FetchError::Http(format!(
+            "blocked: DNS resolution timeout for {host} — fail-closed SSRF guard"
+        ))),
+    }
+}
+
+/// Validate a redirect target URL string relative to a base URL.
+/// Rejects non-http(s) schemes and SSRF hosts. Used per redirect hop.
+pub fn validate_redirect_url(
+    base: &url::Url,
+    location: &str,
+) -> Result<url::Url, crate::error::FetchError> {
+    let next = base
+        .join(location)
+        .map_err(|_| crate::error::FetchError::Http(format!("bad redirect target: {location}")))?;
+    if !matches!(next.scheme(), "http" | "https") {
+        return Err(crate::error::FetchError::Http(format!(
+            "blocked redirect to non-http(s) scheme: {}",
+            next.scheme()
+        )));
+    }
+    // Apply centralized validation to the joined URL so missing hosts
+    // and credentials are rejected consistently with direct fetches.
+    validate_url_basic(next.as_str())?;
+    Ok(next)
 }
 
 /// Header values must never carry CR/LF/NUL: a value smuggled
@@ -110,52 +256,40 @@ pub fn is_binary_content_type(ct: &str) -> bool {
             && !ct.contains("pdf")
 }
 
-/// True if the body is a PDF (magic bytes or content-type).
-/// PDFs are binary but are handled by the DonSheet engine, NOT
-/// rejected by the binary guard.
 pub fn is_pdf(body: &[u8], content_type: &str) -> bool {
     (body.len() >= 5 && body.starts_with(b"%PDF-")) || content_type.to_lowercase().contains("pdf")
 }
 
-/// True if the body starts with known binary magic bytes.
-/// Catches cases where the content-type is missing or wrong.
 pub fn is_binary_body(body: &[u8]) -> bool {
     if body.is_empty() {
         return false;
     }
-    // PDFs contain null bytes (binary streams, xref tables) but
-    // are NOT binary — the DonSheet engine handles them. Skip the
-    // null-byte heuristic entirely for PDFs.
     if body.starts_with(b"%PDF-") {
         return false;
     }
-    // Known binary magic bytes (common file signatures).
     const MAGIC: &[&[u8]] = &[
-        b"\x89PNG",          // PNG
-        b"\xff\xd8\xff",     // JPEG
-        b"GIF8",             // GIF
-        b"BM",               // BMP (2-byte)
-        b"\x1f\x8b",         // gzip
-        b"PK\x03\x04",       // ZIP / DOCX / XLSX
-        b"\x7fELF",          // ELF binary
-        b"\x00\x00\x01\x00", // ICO
-        b"\x00\x00\x02\x00", // CUR
-        b"RIFF",             // WAV/AVI
-        b"\x00asm",          // WASM
+        b"\x89PNG",
+        b"\xff\xd8\xff",
+        b"GIF8",
+        b"BM",
+        b"\x1f\x8b",
+        b"PK\x03\x04",
+        b"\x7fELF",
+        b"\x00\x00\x01\x00",
+        b"\x00\x00\x02\x00",
+        b"RIFF",
+        b"\x00asm",
     ];
     for m in MAGIC {
         if body.starts_with(m) {
             return true;
         }
     }
-    // Null bytes in the first 1024 bytes = almost certainly binary.
     let scan = &body[..body.len().min(1024)];
     let nulls = scan.iter().filter(|&&b| b == 0).count();
     nulls > 3 || (nulls > 0 && nulls as f64 / scan.len() as f64 > 0.01)
 }
 
-/// Combine both checks: is this content binary we should reject?
-/// PDFs are never binary — they're routed to the DonSheet engine.
 pub fn is_binary(body: &[u8], content_type: &str) -> bool {
     if is_pdf(body, content_type) {
         return false;
@@ -210,8 +344,6 @@ mod tests {
 
     #[test]
     fn ssrf_blocks_ipv4_mapped_v6() {
-        // url::Url::host_str() keeps brackets; the guard must see
-        // through them and treat mapped addresses as their v4 self.
         assert!(is_ssrf_host("[::ffff:127.0.0.1]"));
         assert!(is_ssrf_host("[::ffff:169.254.169.254]"));
         assert!(is_ssrf_host("[::ffff:10.0.0.1]"));
@@ -280,9 +412,8 @@ mod tests {
 
     #[test]
     fn pdf_not_binary_by_magic() {
-        // A PDF with null bytes in first 1024 bytes (binary xref stream).
         let mut pdf = b"%PDF-1.4\n".to_vec();
-        pdf.extend_from_slice(&[0x00; 200]); // null bytes — would trigger old heuristic
+        pdf.extend_from_slice(&[0x00; 200]);
         pdf.extend_from_slice(b"\n%%EOF\n");
         assert!(
             !is_binary_body(&pdf),
@@ -294,7 +425,6 @@ mod tests {
 
     #[test]
     fn pdf_not_binary_by_content_type() {
-        // Even if body has null bytes, content-type=application/pdf wins.
         let body = b"\x00\x00\x00\x00\x00\x00\x00\x00";
         assert!(!is_binary(body, "application/pdf"));
     }
@@ -305,5 +435,98 @@ mod tests {
         assert!(is_pdf(b"%PDF-1.4", "application/octet-stream"));
         assert!(is_pdf(b"not a pdf", "application/pdf"));
         assert!(!is_pdf(b"<html>", "text/html"));
+    }
+
+    // New centralized URL validation tests (task 2 regressions)
+    #[test]
+    fn validate_url_rejects_credentials() {
+        assert!(validate_url_basic("https://user:pass@example.com/").is_err());
+        assert!(validate_url_basic("https://user@example.com/").is_err());
+        assert!(validate_url_basic("https://example.com/").is_ok());
+    }
+
+    #[test]
+    fn validate_url_rejects_non_http() {
+        assert!(validate_url_basic("file:///etc/passwd").is_err());
+        assert!(validate_url_basic("ftp://example.com/file").is_err());
+        assert!(validate_url_basic("javascript:alert(1)").is_err());
+        assert!(validate_url_basic("data:text/html,hi").is_err());
+        assert!(validate_url_basic("http://example.com/").is_ok());
+        assert!(validate_url_basic("https://example.com/").is_ok());
+    }
+
+    #[test]
+    fn validate_url_blocks_localhost() {
+        assert!(validate_url_basic("http://localhost/").is_err());
+        assert!(validate_url_basic("http://127.0.0.1/").is_err());
+        assert!(validate_url_basic("http://[::1]/").is_err());
+        assert!(validate_url_basic("http://10.0.0.1/").is_err());
+        assert!(validate_url_basic("http://192.168.1.1/").is_err());
+    }
+
+    #[test]
+    fn validate_url_blocks_ipv4_mapped() {
+        assert!(validate_url_basic("http://[::ffff:127.0.0.1]/").is_err());
+        assert!(validate_url_basic("http://[::ffff:10.0.0.1]/").is_err());
+    }
+
+    #[test]
+    fn validate_url_blocks_multicast_and_reserved() {
+        assert!(is_ssrf_host("224.0.0.1"));
+        assert!(is_ssrf_host("239.255.255.250"));
+        assert!(is_ssrf_host("ff02::1"));
+        assert!(is_ssrf_host("192.0.2.1"));
+        assert!(is_ssrf_host("198.51.100.1"));
+        assert!(is_ssrf_host("203.0.113.1"));
+        assert!(validate_url_basic("http://224.0.0.1/").is_err());
+        assert!(validate_url_basic("http://192.0.2.1/").is_err());
+    }
+
+    #[test]
+    fn validate_url_allows_public() {
+        assert!(validate_url_basic("https://example.com/").is_ok());
+        assert!(validate_url_basic("https://93.184.216.34/").is_ok());
+        assert!(validate_url_basic("https://8.8.8.8/path?q=1").is_ok());
+    }
+
+    #[test]
+    fn validate_redirect_blocks_ssrf() {
+        let base = url::Url::parse("https://example.com/").unwrap();
+        assert!(validate_redirect_url(&base, "http://127.0.0.1/evil").is_err());
+        assert!(validate_redirect_url(&base, "http://10.0.0.1/").is_err());
+        assert!(validate_redirect_url(&base, "file:///etc/passwd").is_err());
+        assert!(validate_redirect_url(&base, "https://example.com/other").is_ok());
+        assert!(validate_redirect_url(&base, "/relative").is_ok());
+    }
+
+    #[tokio::test]
+    async fn ensure_url_safe_blocks_literal() {
+        assert!(ensure_url_safe("http://127.0.0.1/").await.is_err());
+        assert!(ensure_url_safe("http://[::1]/").await.is_err());
+        // Public literal IPs require no DNS and must pass.
+        assert!(ensure_url_safe("https://93.184.216.34/").await.is_ok());
+        assert!(ensure_url_safe("https://8.8.8.8/").await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn ensure_url_safe_rejects_credentials() {
+        assert!(
+            ensure_url_safe("https://user:pass@example.com/")
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn ensure_url_safe_fail_closed_on_dns_error() {
+        // Non-existent hostname must fail closed, not silently allow.
+        // This proves we do not swallow DNS errors for browser tier.
+        let res = ensure_url_safe("https://this-host-does-not-exist-12345.invalid/").await;
+        assert!(res.is_err(), "non-resolvable host must fail closed, got Ok");
+        let msg = res.unwrap_err().to_string().to_lowercase();
+        assert!(
+            msg.contains("dns") || msg.contains("fail-closed") || msg.contains("blocked"),
+            "error must mention DNS/fail-closed, got: {msg}"
+        );
     }
 }

--- a/src/ghost/cdp.rs
+++ b/src/ghost/cdp.rs
@@ -22,14 +22,25 @@ use crate::error::FetchError;
 type Ws = WebSocketStream<MaybeTlsStream<TcpStream>>;
 
 pub struct Cdp {
-    write: Mutex<futures_util::stream::SplitSink<Ws, Message>>,
+    write: Arc<Mutex<futures_util::stream::SplitSink<Ws, Message>>>,
     pending: Arc<Mutex<HashMap<u64, oneshot::Sender<Value>>>>,
     /// Event stream (targetInfoChanged = title/url
     /// changes — challenge progression without Runtime).
     /// Consumed by the daemon's smarter wait loop.
     #[allow(dead_code)]
     events: broadcast::Sender<Value>,
-    next_id: AtomicU64,
+    next_id: Arc<AtomicU64>,
+}
+
+impl Clone for Cdp {
+    fn clone(&self) -> Self {
+        Self {
+            write: Arc::clone(&self.write),
+            pending: Arc::clone(&self.pending),
+            events: self.events.clone(),
+            next_id: Arc::clone(&self.next_id),
+        }
+    }
 }
 
 impl Cdp {
@@ -71,10 +82,10 @@ impl Cdp {
             }
         });
         Ok(Self {
-            write: Mutex::new(write),
+            write: Arc::new(Mutex::new(write)),
             pending,
             events: events_tx,
-            next_id: AtomicU64::new(1),
+            next_id: Arc::new(AtomicU64::new(1)),
         })
     }
 
@@ -116,5 +127,98 @@ impl Cdp {
     #[allow(dead_code)] // daemon wait loop (MCP milestone)
     pub fn subscribe(&self) -> broadcast::Receiver<Value> {
         self.events.subscribe()
+    }
+
+    /// Spawn a cancellable request-guard task for one page session.
+    ///
+    /// Subscribes to CDP events, filters `Fetch.requestPaused` events
+    /// for the given `session`, reads `params.requestId` and
+    /// `params.request.url`, calls `fetch::guards::ensure_url_safe`
+    /// on every paused URL, then issues `Fetch.continueRequest` for
+    /// safe URLs or `Fetch.failRequest` with `errorReason`
+    /// `BlockedByClient` for unsafe, non-http, or DNS-failed URLs.
+    ///
+    /// Does not block the demux reader; each paused request is
+    /// handled in its own spawned task so DNS resolution cannot stall
+    /// the event loop.
+    ///
+    /// # DNS rebinding residual limitation
+    ///
+    /// This is a point-in-time check. DNS can change between
+    /// validation and the actual network stack's resolution (DNS
+    /// rebinding / TOCTOU). Without full DNS pinning (reusing the
+    /// validated IPs for the connect), there is a residual window.
+    /// The explicit preflight (`ensure_url_safe` before `Page.navigate`)
+    /// and redirect/post-action checks are retained as defence-in-depth
+    /// alongside this in-browser Fetch guard.
+    pub fn spawn_fetch_guard(&self, session: String) -> tokio::task::JoinHandle<()> {
+        let cdp = self.clone();
+        let mut events = self.subscribe();
+        tokio::spawn(async move {
+            while let Ok(event) = events.recv().await {
+                let method = event.get("method").and_then(Value::as_str).unwrap_or("");
+                if method != "Fetch.requestPaused" {
+                    continue;
+                }
+                // Filter for the single session we are guarding.
+                // With `flatten: true`, the sessionId is top-level.
+                if let Some(sid) = event.get("sessionId").and_then(Value::as_str) {
+                    if sid != session {
+                        continue;
+                    }
+                } else {
+                    continue;
+                }
+                let params = event.get("params");
+                let request_id = params
+                    .and_then(|p| p.get("requestId"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                let url = params
+                    .and_then(|p| p.get("request"))
+                    .and_then(|r| r.get("url"))
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .to_string();
+                if request_id.is_empty() {
+                    continue;
+                }
+                // Do not block the demux reader / this loop: spawn per-request handling.
+                let cdp2 = cdp.clone();
+                let session2 = session.clone();
+                tokio::spawn(async move {
+                    // Fail-closed on DNS failure / non-http / private IP.
+                    let safe = if url.is_empty() {
+                        false
+                    } else {
+                        crate::fetch::guards::ensure_url_safe(&url).await.is_ok()
+                    };
+                    if safe {
+                        let _ = cdp2
+                            .call(
+                                Some(&session2),
+                                "Fetch.continueRequest",
+                                json!({ "requestId": request_id }),
+                            )
+                            .await;
+                    } else {
+                        let _ = cdp2
+                            .call(
+                                Some(&session2),
+                                "Fetch.failRequest",
+                                json!({ "requestId": request_id, "errorReason": "BlockedByClient" }),
+                            )
+                            .await;
+                    }
+                });
+            }
+        })
+    }
+
+    /// Alias for `spawn_fetch_guard` — covers alternative naming
+    /// expectations (request-guard vs fetch-guard).
+    pub fn spawn_request_guard(&self, session: String) -> tokio::task::JoinHandle<()> {
+        self.spawn_fetch_guard(session)
     }
 }

--- a/src/ghost/mod.rs
+++ b/src/ghost/mod.rs
@@ -524,14 +524,21 @@ impl Ghost {
         // (reusing validated IPs for the connect) there is a residual
         // window. The transport layer re-validates at connect time,
         // but the browser's network stack does its own resolution.
-        cdp.call(
-            Some(&session),
-            "Fetch.enable",
-            json!({ "patterns": [{ "urlPattern": "*", "requestStage": "Request" }] }),
-        )
-        .await
-        .map_err(|e| FetchError::ghost(format!("Fetch.enable: {e}")))?;
         let fetch_guard = cdp.spawn_fetch_guard(session.clone());
+        if let Err(e) = cdp
+            .call(
+                Some(&session),
+                "Fetch.enable",
+                json!({ "patterns": [{ "urlPattern": "*", "requestStage": "Request" }] }),
+            )
+            .await
+        {
+            // The guard was started before enabling interception so no
+            // request-paused event can be missed. Stop it on setup failure
+            // so a partially initialized Ghost never leaves a task behind.
+            fetch_guard.abort();
+            return Err(FetchError::ghost(format!("Fetch.enable: {e}")));
+        }
         cdp.call(Some(&session), "Page.enable", json!({})).await?;
 
         // Stealth JS injection — runs before any page script.

--- a/src/ghost/mod.rs
+++ b/src/ghost/mod.rs
@@ -1322,6 +1322,39 @@ fn sweep_crashpad() {
 #[cfg(not(linux_like))]
 fn sweep_crashpad() {}
 
+/// Minimal base64 decode (avoids a dep for one call).
+fn b64decode(s: &[u8]) -> Vec<u8> {
+    fn val(b: u8) -> u8 {
+        match b {
+            b'A'..=b'Z' => b - b'A',
+            b'a'..=b'z' => b - b'a' + 26,
+            b'0'..=b'9' => b - b'0' + 52,
+            b'+' => 62,
+            b'/' => 63,
+            _ => 0,
+        }
+    }
+    let mut out = Vec::with_capacity(s.len() * 3 / 4);
+    let clean: Vec<u8> = s
+        .iter()
+        .copied()
+        .filter(|b| !b"=\n\r ".contains(b))
+        .collect();
+    for chunk in clean.chunks(4) {
+        if chunk.len() < 4 {
+            break;
+        }
+        let n = ((val(chunk[0]) as u32) << 18)
+            | ((val(chunk[1]) as u32) << 12)
+            | ((val(chunk[2]) as u32) << 6)
+            | (val(chunk[3]) as u32);
+        out.push((n >> 16) as u8);
+        out.push((n >> 8) as u8);
+        out.push(n as u8);
+    }
+    out
+}
+
 #[cfg(test)]
 mod sandbox_tests {
     use super::*;
@@ -1358,37 +1391,4 @@ mod sandbox_tests {
             None => unsafe { std::env::remove_var("DONGHOST_NO_SANDBOX") },
         }
     }
-}
-
-/// Minimal base64 decode (avoids a dep for one call).
-fn b64decode(s: &[u8]) -> Vec<u8> {
-    fn val(b: u8) -> u8 {
-        match b {
-            b'A'..=b'Z' => b - b'A',
-            b'a'..=b'z' => b - b'a' + 26,
-            b'0'..=b'9' => b - b'0' + 52,
-            b'+' => 62,
-            b'/' => 63,
-            _ => 0,
-        }
-    }
-    let mut out = Vec::with_capacity(s.len() * 3 / 4);
-    let clean: Vec<u8> = s
-        .iter()
-        .copied()
-        .filter(|b| !b"=\n\r ".contains(b))
-        .collect();
-    for chunk in clean.chunks(4) {
-        if chunk.len() < 4 {
-            break;
-        }
-        let n = ((val(chunk[0]) as u32) << 18)
-            | ((val(chunk[1]) as u32) << 12)
-            | ((val(chunk[2]) as u32) << 6)
-            | (val(chunk[3]) as u32);
-        out.push((n >> 16) as u8);
-        out.push((n >> 8) as u8);
-        out.push(n as u8);
-    }
-    out
 }

--- a/src/ghost/mod.rs
+++ b/src/ghost/mod.rs
@@ -59,12 +59,51 @@ pub struct Ghost {
     /// Temp profile dir if we couldn't get the shared profile's
     /// lock. Cleaned up in Drop. None = using the shared profile.
     temp_profile: Option<PathBuf>,
+    /// CDP Fetch request guard: intercepts every browser request
+    /// (including those triggered by browser actions) and enforces
+    /// `fetch::guards::ensure_url_safe` before it hits the network.
+    /// Aborted in Drop so it cannot leak after Chrome is reaped.
+    fetch_guard: Option<tokio::task::JoinHandle<()>>,
 }
 
 /// Persistent profile dir: aged state passes challenges
 /// easier, and clearance cookies survive daemon restarts.
 pub fn profile_dir() -> PathBuf {
     crate::paths::cache_dir().join("ghost-profile")
+}
+
+/// Default Chrome launch args (without sandbox flags).
+/// Sandbox is enabled by default (Chrome's own sandbox).
+/// The `--no-sandbox` flags are ONLY added when
+/// `DONGHOST_NO_SANDBOX=1` is explicitly set.
+pub fn default_chrome_args(
+    dir: &std::path::Path,
+    profile: &crate::profile::BrowserProfile,
+) -> Vec<String> {
+    vec![
+        "--remote-debugging-port=0".into(),
+        format!("--user-data-dir={}", dir.display()),
+        format!("--user-agent={}", profile.user_agent),
+        "--window-size=1920,1080".into(),
+        "--window-position=-32000,-32000".into(),
+        "--lang=en-US".into(),
+        "--no-first-run".into(),
+        "--no-default-browser-check".into(),
+        "--disable-background-networking".into(),
+        "--disable-component-update".into(),
+        "--disable-sync".into(),
+        "--disable-translate".into(),
+        "--mute-audio".into(),
+        "--disk-cache-size=1".into(),
+        "--disable-gpu-shader-disk-cache".into(),
+        "--disable-features=SiteEngagementService".into(),
+    ]
+}
+
+/// Whether sandbox is disabled via explicit opt-in.
+/// Used for testing that default launch is safe.
+pub fn sandbox_opt_in_enabled() -> bool {
+    std::env::var_os("DONGHOST_NO_SANDBOX").is_some_and(|v| v == "1")
 }
 
 /// Locate a Chrome-family binary. Env override first, then
@@ -345,31 +384,18 @@ impl Ghost {
             }
         }
         let mut cmd = Command::new(bin);
-        let mut chrome_args: Vec<String> = vec![
-            "--remote-debugging-port=0".into(),
-            format!("--user-data-dir={}", dir.display()),
-            format!("--user-agent={}", profile.user_agent),
-            "--window-size=1920,1080".into(),
-            "--window-position=-32000,-32000".into(),
-            "--lang=en-US".into(),
-            "--no-first-run".into(),
-            "--no-default-browser-check".into(),
-            "--disable-background-networking".into(),
-            "--disable-component-update".into(),
-            "--disable-sync".into(),
-            "--no-sandbox".into(),
-            "--disable-setuid-sandbox".into(),
-            "--disable-translate".into(),
-            "--mute-audio".into(),
-            // ── Disk cache suppression ──
-            // Chrome's disk cache grows unboundedly (1GB+ in days).
-            // We don't need it — tier 1 has its own HTTP cache, and
-            // ghost only renders a few pages per domain. Disabling
-            // keeps the profile dir tiny (~10MB instead of 1GB+).
-            "--disk-cache-size=1".into(),
-            "--disable-gpu-shader-disk-cache".into(),
-            "--disable-features=SiteEngagementService".into(),
-        ];
+        let mut chrome_args: Vec<String> = default_chrome_args(&dir, profile);
+        // Opt-in escape hatch for environments where sandbox is
+        // unavailable (e.g. containers without user-namespace support
+        // or AppArmor restrictions). Never enabled by default —
+        // requires explicit env var and prints a loud warning.
+        if std::env::var_os("DONGHOST_NO_SANDBOX").is_some_and(|v| v == "1") {
+            eprintln!(
+                "[ghost] WARNING: DONGHOST_NO_SANDBOX=1 — launching Chrome with --no-sandbox and --disable-setuid-sandbox. This disables the Chromium sandbox and is UNSAFE. Only use in isolated containers."
+            );
+            chrome_args.push("--no-sandbox".into());
+            chrome_args.push("--disable-setuid-sandbox".into());
+        }
         // ── HTTP proxy (env var) ──
         // If HTTP_PROXY/HTTPS_PROXY/ALL_PROXY is set, route the
         // Ghost browser through the same proxy as tier 1. Chrome
@@ -482,6 +508,30 @@ impl Ghost {
             .and_then(Value::as_str)
             .ok_or_else(|| FetchError::ghost("no sessionId"))?
             .to_string();
+        // Focused browser network SSRF guard: intercept every request
+        // at the CDP Fetch layer before it hits the network. This
+        // prevents browser actions (clicks, form submits, JS
+        // navigations) from causing a private navigation/request
+        // before the post-check could run. The explicit preflight
+        // (`ensure_url_safe` before `Page.navigate`) and
+        // redirect/post-action checks are retained as defence-in-depth;
+        // the Fetch guard is the in-browser enforcement.
+        //
+        // DNS rebinding residual limitation: this is a point-in-time
+        // check via `ensure_url_safe` (DNS resolution at request-paused
+        // time). DNS can change between validation and the actual
+        // connect (TOCTOU / DNS rebinding). Without full DNS pinning
+        // (reusing validated IPs for the connect) there is a residual
+        // window. The transport layer re-validates at connect time,
+        // but the browser's network stack does its own resolution.
+        cdp.call(
+            Some(&session),
+            "Fetch.enable",
+            json!({ "patterns": [{ "urlPattern": "*", "requestStage": "Request" }] }),
+        )
+        .await
+        .map_err(|e| FetchError::ghost(format!("Fetch.enable: {e}")))?;
+        let fetch_guard = cdp.spawn_fetch_guard(session.clone());
         cdp.call(Some(&session), "Page.enable", json!({})).await?;
 
         // Stealth JS injection — runs before any page script.
@@ -570,6 +620,7 @@ impl Ghost {
             last_used: Instant::now(),
             profile_lock,
             temp_profile,
+            fetch_guard: Some(fetch_guard),
         })
     }
 
@@ -638,6 +689,12 @@ impl Ghost {
     /// advancing URL. This succeeds on both healthy Chrome (fast
     /// response) and the buggy 151/152 builds (no response at all).
     pub async fn navigate(&self, url: &str) -> Result<(), FetchError> {
+        // Centralized SSRF guard for browser tier: validates scheme,
+        // credentials, literal IP ranges and (async) DNS resolution.
+        // This is the sole gate for all Ghost navigations — solve,
+        // render, ghost_fetch and actions all flow through here, so
+        // tier=2 cannot bypass it.
+        crate::fetch::guards::ensure_url_safe(url).await?;
         // Fire the navigation. Tolerate a missing/errant response:
         // the URL poll below is the real completion signal.
         let _ = self
@@ -651,6 +708,15 @@ impl Ghost {
             let cur = self.current_url().await.unwrap_or_default();
             let advanced = !cur.is_empty() && !cur.starts_with("about:blank");
             if advanced {
+                // Re-check redirect target: Chrome follows redirects
+                // automatically; a public URL that redirects to a
+                // private/loopback address must be blocked even if the
+                // initial URL was safe. This mirrors fetch's per-hop
+                // redirect guard. DNS rebinding residual applies here
+                // as well (see guards::ensure_url_safe docs).
+                if cur != url {
+                    crate::fetch::guards::ensure_url_safe(&cur).await?;
+                }
                 return Ok(());
             }
             if std::time::Instant::now() >= deadline {
@@ -734,7 +800,12 @@ impl Ghost {
     }
 
     /// PNG screenshot → path (D16 byproduct).
+    /// Destination is validated through the centralized
+    /// `paths::resolve_screenshot_path` helper BEFORE any CDP capture,
+    /// so a traversal/outside path never triggers a browser capture.
     pub async fn screenshot(&self, path: &str) -> Result<(), FetchError> {
+        let dest = crate::paths::resolve_screenshot_path(path)
+            .map_err(|e| FetchError::ghost(format!("screenshot path rejected: {e}")))?;
         let data = self
             .cdp
             .call(
@@ -749,7 +820,7 @@ impl Ghost {
             .to_string();
         // base64 decode (no new dep: manual).
         let bytes = b64decode(data.as_bytes());
-        std::fs::write(path, bytes).map_err(|e| FetchError::ghost(format!("screenshot: {e}")))
+        std::fs::write(&dest, bytes).map_err(|e| FetchError::ghost(format!("screenshot: {e}")))
     }
 
     /// One trusted click with a human-ish pre-move path.
@@ -1094,6 +1165,12 @@ impl Ghost {
 
 impl Drop for Ghost {
     fn drop(&mut self) {
+        // Abort the Fetch request guard so it cannot leak after
+        // Chrome is reaped. The JoinHandle is cancellable; abort
+        // is safe even if the task already completed.
+        if let Some(handle) = self.fetch_guard.take() {
+            handle.abort();
+        }
         // Safety net: kill_group sends SIGKILL to the whole
         // browser tree (process group on Unix, Job Object on
         // Windows). If kill().await was already called (reaper,
@@ -1237,6 +1314,44 @@ fn sweep_crashpad() {
 
 #[cfg(not(linux_like))]
 fn sweep_crashpad() {}
+
+#[cfg(test)]
+mod sandbox_tests {
+    use super::*;
+    use crate::profile::BrowserProfile;
+
+    #[test]
+    fn default_args_do_not_contain_no_sandbox() {
+        let dir = std::path::PathBuf::from("/tmp/test-profile");
+        let profile = BrowserProfile::host_default();
+        let args = default_chrome_args(&dir, &profile);
+        assert!(
+            !args.iter().any(|a| a == "--no-sandbox"),
+            "default args must not contain --no-sandbox"
+        );
+        assert!(
+            !args.iter().any(|a| a == "--disable-setuid-sandbox"),
+            "default args must not contain --disable-setuid-sandbox"
+        );
+    }
+
+    #[test]
+    fn sandbox_opt_in_requires_explicit_env() {
+        // Ensure default is safe without env var.
+        // Save and restore to avoid flakiness.
+        let prev = std::env::var_os("DONGHOST_NO_SANDBOX");
+        unsafe { std::env::remove_var("DONGHOST_NO_SANDBOX") };
+        assert!(!sandbox_opt_in_enabled());
+        unsafe { std::env::set_var("DONGHOST_NO_SANDBOX", "1") };
+        assert!(sandbox_opt_in_enabled());
+        unsafe { std::env::set_var("DONGHOST_NO_SANDBOX", "0") };
+        assert!(!sandbox_opt_in_enabled());
+        match prev {
+            Some(v) => unsafe { std::env::set_var("DONGHOST_NO_SANDBOX", v) },
+            None => unsafe { std::env::remove_var("DONGHOST_NO_SANDBOX") },
+        }
+    }
+}
 
 /// Minimal base64 decode (avoids a dep for one call).
 fn b64decode(s: &[u8]) -> Vec<u8> {

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -574,20 +574,10 @@ async fn crawl_tool(daemon: &Arc<Daemon>, args: &Value, ctx: Option<ToolCtx>) ->
         }));
     }
 
-    // SSRF guard on the seed — the fetch tool has one, the crawl
-    // tool must too (it fetches just as hard).
+    // Centralized SSRF guard on the seed.
     if !url.is_empty() {
-        match url::Url::parse(&url) {
-            Ok(u) => {
-                if let Some(host) = u.host_str()
-                    && crate::fetch::guards::is_ssrf_host(host)
-                {
-                    return tool_error(format!(
-                        "blocked: {host} is a private/loopback address — SSRF guard"
-                    ));
-                }
-            }
-            Err(_) => return tool_error(format!("invalid URL: {url}")),
+        if let Err(e) = crate::fetch::guards::validate_url_basic(&url) {
+            return tool_error(format!("{e}"));
         }
     }
 
@@ -1337,16 +1327,11 @@ async fn fetch_single_inner(daemon: &Arc<Daemon>, args: &Value, url: &str) -> Va
     // GET targets — never route them at the browser.
     let adapter_host = adapter_used.is_some();
 
-    // SSRF guard: never fetch private/loopback addresses.
-    let parsed = match url::Url::parse(&url) {
-        Ok(u) => u,
-        Err(_) => return tool_error(format!("invalid URL: {url}")),
-    };
-    if let Some(host) = parsed.host_str()
-        && crate::fetch::guards::is_ssrf_host(host)
-    {
+    // Centralized SSRF guard (sync part): scheme, credentials, localhost/private literals.
+    // DNS-resolved private addresses are checked at transport/browser layers.
+    if let Err(e) = crate::fetch::guards::validate_url_basic(&url) {
         return tool_error_structured(
-            format!("blocked: {host} is a private/loopback address — SSRF guard"),
+            format!("{e}"),
             "permanent",
             Some(json!({
                 "url": url,
@@ -2122,7 +2107,9 @@ async fn ghost_escalate(
             .chars()
             .map(|c| if c.is_alphanumeric() { c } else { '_' })
             .collect();
-        let p = std::env::temp_dir().join(format!("donsetch-dom-{safe}.html"));
+        let dir = crate::paths::cache_dir().join("ghost-debug");
+        let _ = std::fs::create_dir_all(&dir);
+        let p = dir.join(format!("dom-{safe}.html"));
         let _ = std::fs::write(&p, &page.html);
         eprintln!(
             "[ghost_escalate] dom={}B dumped to {}",
@@ -2512,6 +2499,25 @@ async fn fetch_with_actions(
             );
         }
     };
+    // Post-action navigation guard: actions like click can cause the
+    // browser to navigate to a new URL (href, form submit). Re-check
+    // the current URL via the centralized SSRF gate (async DNS,
+    // fail-closed for browser tier).
+    if let Ok(cur) = g.current_url().await
+        && !cur.is_empty()
+        && !cur.starts_with("about:")
+        && let Err(e) = crate::fetch::guards::ensure_url_safe(&cur).await
+    {
+        return tool_error_structured(
+            format!("blocked after action navigation: {e}"),
+            "permanent",
+            Some(json!({
+                "url": cur,
+                "escalation": trace.value(),
+                "next_action": "action caused navigation to a private/loopback URL — blocked",
+            })),
+        );
+    }
     if let Some(p) = shot {
         let _ = g.screenshot(p).await;
     }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -575,10 +575,10 @@ async fn crawl_tool(daemon: &Arc<Daemon>, args: &Value, ctx: Option<ToolCtx>) ->
     }
 
     // Centralized SSRF guard on the seed.
-    if !url.is_empty() {
-        if let Err(e) = crate::fetch::guards::validate_url_basic(&url) {
-            return tool_error(format!("{e}"));
-        }
+    if !url.is_empty()
+        && let Err(e) = crate::fetch::guards::validate_url_basic(&url)
+    {
+        return tool_error(format!("{e}"));
     }
 
     // Ghost-warm: if this host was tier-2 solved recently, the

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -117,12 +117,12 @@ pub fn resolve_screenshot_path(input: &str) -> Result<PathBuf, String> {
 
     // Final post-create canonical check: parent must still be under root
     // (catches race where a symlink was created between checks).
-    if let Ok(canon_final) = std::fs::canonicalize(parent) {
-        if !is_below_root(&canon_final, &canon_root) {
-            return Err(format!(
-                "screenshot path parent escapes allowed root after creation: `{trimmed}`"
-            ));
-        }
+    if let Ok(canon_final) = std::fs::canonicalize(parent)
+        && !is_below_root(&canon_final, &canon_root)
+    {
+        return Err(format!(
+            "screenshot path parent escapes allowed root after creation: `{trimmed}`"
+        ));
     }
 
     // Harden: reject existing destination that is itself a symlink, or
@@ -133,14 +133,14 @@ pub fn resolve_screenshot_path(input: &str) -> Result<PathBuf, String> {
         if meta.file_type().is_symlink() {
             return Err(format!("screenshot destination is a symlink: `{trimmed}`"));
         }
-        if let Ok(canon_dest) = std::fs::canonicalize(&dest) {
-            if !is_below_root(&canon_dest, &canon_root) {
-                return Err(format!(
-                    "screenshot destination escapes allowed root: `{trimmed}` -> {} not under {}",
-                    canon_dest.display(),
-                    canon_root.display()
-                ));
-            }
+        if let Ok(canon_dest) = std::fs::canonicalize(&dest)
+            && !is_below_root(&canon_dest, &canon_root)
+        {
+            return Err(format!(
+                "screenshot destination escapes allowed root: `{trimmed}` -> {} not under {}",
+                canon_dest.display(),
+                canon_root.display()
+            ));
         }
     }
 
@@ -285,35 +285,35 @@ mod tests {
         {
             use std::os::unix::fs::symlink;
             let _ = symlink(&outside_file, &dest_link);
-            if let Ok(meta) = std::fs::symlink_metadata(&dest_link) {
-                if meta.file_type().is_symlink() {
-                    // relative input resolving to the symlink
-                    let err = resolve_screenshot_path("evil-dest-symlink.png").unwrap_err();
+            if let Ok(meta) = std::fs::symlink_metadata(&dest_link)
+                && meta.file_type().is_symlink()
+            {
+                // relative input resolving to the symlink
+                let err = resolve_screenshot_path("evil-dest-symlink.png").unwrap_err();
+                assert!(
+                    err.contains("symlink")
+                        || err.contains("outside")
+                        || err.contains("escapes")
+                        || err.contains("allowed root"),
+                    "got: {err}"
+                );
+                // absolute input resolving to the same symlink
+                let err2 = resolve_screenshot_path(dest_link.to_str().unwrap()).unwrap_err();
+                assert!(
+                    err2.contains("symlink")
+                        || err2.contains("outside")
+                        || err2.contains("escapes")
+                        || err2.contains("allowed root"),
+                    "got: {err2}"
+                );
+                // sanity: canonical destination is outside the screenshots root
+                if let Ok(canon_dest) = std::fs::canonicalize(&dest_link) {
+                    let canon_root =
+                        std::fs::canonicalize(&screenshots).unwrap_or_else(|_| screenshots.clone());
                     assert!(
-                        err.contains("symlink")
-                            || err.contains("outside")
-                            || err.contains("escapes")
-                            || err.contains("allowed root"),
-                        "got: {err}"
+                        !is_below_root(&canon_dest, &canon_root),
+                        "canon_dest {canon_dest:?} should be outside {canon_root:?}"
                     );
-                    // absolute input resolving to the same symlink
-                    let err2 = resolve_screenshot_path(dest_link.to_str().unwrap()).unwrap_err();
-                    assert!(
-                        err2.contains("symlink")
-                            || err2.contains("outside")
-                            || err2.contains("escapes")
-                            || err2.contains("allowed root"),
-                        "got: {err2}"
-                    );
-                    // sanity: canonical destination is outside the screenshots root
-                    if let Ok(canon_dest) = std::fs::canonicalize(&dest_link) {
-                        let canon_root = std::fs::canonicalize(&screenshots)
-                            .unwrap_or_else(|_| screenshots.clone());
-                        assert!(
-                            !is_below_root(&canon_dest, &canon_root),
-                            "canon_dest {canon_dest:?} should be outside {canon_root:?}"
-                        );
-                    }
                 }
             }
         }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -8,7 +8,7 @@
 //! Backed by the `dirs` crate (zero transitive deps, the de
 //! facto standard for this exact problem).
 
-use std::path::PathBuf;
+use std::path::{Component, Path, PathBuf};
 
 /// The DonSeTch cache root. Falls back to the system temp dir
 /// if the platform reports no cache directory (shouldn't happen
@@ -17,4 +17,307 @@ pub fn cache_dir() -> PathBuf {
     dirs::cache_dir()
         .unwrap_or_else(std::env::temp_dir)
         .join("donsetch")
+}
+
+/// Screenshots live under the cache root: `cache_dir()/screenshots`.
+pub fn screenshots_dir() -> PathBuf {
+    cache_dir().join("screenshots")
+}
+
+/// Centralized, safe screenshot output-path helper.
+///
+/// Contract:
+/// - `input` must be non-empty.
+/// - Relative names are resolved below `cache_dir()/screenshots`
+///   (e.g. `"shot.png"` → `cache/screenshots/shot.png`,
+///   `"a/b/c.png"` → `cache/screenshots/a/b/c.png`).
+/// - Absolute paths are accepted **only** when already strictly below
+///   the canonical `screenshots` root.
+/// - Rejects `ParentDir` (`..`) components anywhere (path traversal).
+/// - Rejects symlinked / outside parents: the nearest existing ancestor
+///   of the resolved path is canonicalized and must still be under the
+///   canonical screenshots root; otherwise the path is rejected.
+/// - Rejects an existing destination whose `symlink_metadata` file type
+///   is a symlink, and rejects an existing destination that
+///   canonicalizes outside the canonical screenshots root.
+/// - Creates only the intended parent directories (no pre-creation of
+///   attacker-controlled absolute parents outside the root).
+///
+/// Returns the validated, absolute destination path on success.
+pub fn resolve_screenshot_path(input: &str) -> Result<PathBuf, String> {
+    let trimmed = input.trim();
+    if trimmed.is_empty() {
+        return Err("screenshot path is empty — provide a filename".into());
+    }
+    let p = PathBuf::from(trimmed);
+
+    // Reject ParentDir anywhere.
+    for comp in p.components() {
+        if matches!(comp, Component::ParentDir) {
+            return Err(format!(
+                "screenshot path traversal rejected: `{trimmed}` contains `..`"
+            ));
+        }
+    }
+
+    // Reject NUL bytes or interior newlines that could confuse display.
+    if trimmed.contains('\0') {
+        return Err("screenshot path contains NUL".into());
+    }
+
+    // Resolve to absolute destination.
+    let screenshots = screenshots_dir();
+    let is_absolute = p.is_absolute();
+    let dest = if is_absolute { p } else { screenshots.join(&p) };
+
+    // Ensure screenshots root exists so we have a canonical base.
+    std::fs::create_dir_all(&screenshots)
+        .map_err(|e| format!("failed to create screenshots dir: {e}"))?;
+    let canon_root = std::fs::canonicalize(&screenshots).unwrap_or_else(|_| screenshots.clone());
+
+    // For absolute inputs, the raw dest must already be prefixed by the
+    // screenshots root (string prefix check before canonicalization, to
+    // fail fast on clearly outside paths).
+    if is_absolute && !is_below_root(&dest, &canon_root) && !is_below_root(&dest, &screenshots) {
+        return Err(format!(
+            "absolute screenshot path outside allowed root: `{trimmed}` must be below {}",
+            canon_root.display()
+        ));
+    }
+
+    // Symlink / outside-parent check: canonicalize nearest existing
+    // ancestor and ensure it is still under the root.
+    let parent = dest
+        .parent()
+        .ok_or_else(|| "screenshot path has no parent".to_string())?;
+    let nearest_existing = nearest_existing_ancestor(parent);
+    if let Some(existing) = nearest_existing {
+        let canon_parent = std::fs::canonicalize(&existing).unwrap_or_else(|_| existing.clone());
+        if !is_below_root(&canon_parent, &canon_root) {
+            return Err(format!(
+                "screenshot path parent escapes allowed root (symlink/outside): `{trimmed}` -> {} not under {}",
+                canon_parent.display(),
+                canon_root.display()
+            ));
+        }
+        // Also verify the existing ancestor is the root itself or a child.
+        // If the existing ancestor is e.g. `/tmp`, its canonical won't be under root.
+    } else {
+        // No existing ancestor at all (should not happen because screenshots
+        // root exists). Fail closed.
+        return Err(format!(
+            "screenshot path has no existing ancestor under allowed root: `{trimmed}`"
+        ));
+    }
+
+    // Create only the intended destination parent (which we have already
+    // validated to be under the root).
+    std::fs::create_dir_all(parent)
+        .map_err(|e| format!("failed to create screenshot parent dir: {e}"))?;
+
+    // Final post-create canonical check: parent must still be under root
+    // (catches race where a symlink was created between checks).
+    if let Ok(canon_final) = std::fs::canonicalize(parent) {
+        if !is_below_root(&canon_final, &canon_root) {
+            return Err(format!(
+                "screenshot path parent escapes allowed root after creation: `{trimmed}`"
+            ));
+        }
+    }
+
+    // Harden: reject existing destination that is itself a symlink, or
+    // canonicalizes outside the screenshots root. `symlink_metadata`
+    // does not follow the final symlink, so a symlink file is caught
+    // even if its target is inside the root.
+    if let Ok(meta) = std::fs::symlink_metadata(&dest) {
+        if meta.file_type().is_symlink() {
+            return Err(format!("screenshot destination is a symlink: `{trimmed}`"));
+        }
+        if let Ok(canon_dest) = std::fs::canonicalize(&dest) {
+            if !is_below_root(&canon_dest, &canon_root) {
+                return Err(format!(
+                    "screenshot destination escapes allowed root: `{trimmed}` -> {} not under {}",
+                    canon_dest.display(),
+                    canon_root.display()
+                ));
+            }
+        }
+    }
+
+    Ok(dest)
+}
+
+fn is_below_root(path: &Path, root: &Path) -> bool {
+    path.starts_with(root)
+}
+
+fn nearest_existing_ancestor(path: &Path) -> Option<PathBuf> {
+    let mut cur: &Path = path;
+    loop {
+        if cur.exists() {
+            return Some(cur.to_path_buf());
+        }
+        match cur.parent() {
+            Some(parent) if parent != cur => cur = parent,
+            _ => return None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cache_dir_ends_with_donsetch() {
+        assert!(cache_dir().ends_with("donsetch"));
+    }
+
+    #[test]
+    fn screenshot_valid_relative_name() {
+        let p = resolve_screenshot_path("shot.png").expect("valid relative");
+        assert!(
+            p.starts_with(screenshots_dir())
+                || p.starts_with(
+                    std::fs::canonicalize(screenshots_dir()).unwrap_or_else(|_| screenshots_dir())
+                )
+        );
+        assert!(p.ends_with("shot.png"));
+        // cleanup
+        let _ = std::fs::remove_file(&p);
+    }
+
+    #[test]
+    fn screenshot_rejects_parent_traversal() {
+        let err = resolve_screenshot_path("../evil.png").unwrap_err();
+        assert!(
+            err.contains("..") || err.contains("traversal"),
+            "got: {err}"
+        );
+        let err2 = resolve_screenshot_path("a/../../b.png").unwrap_err();
+        assert!(
+            err2.contains("..") || err2.contains("traversal"),
+            "got: {err2}"
+        );
+    }
+
+    #[test]
+    fn screenshot_rejects_absolute_outside() {
+        let outside = std::env::temp_dir().join("outside-evil.png");
+        let err = resolve_screenshot_path(outside.to_str().unwrap()).unwrap_err();
+        assert!(
+            err.contains("outside") || err.contains("allowed root"),
+            "got: {err}"
+        );
+        let err2 = resolve_screenshot_path("/etc/passwd").unwrap_err();
+        assert!(
+            err2.contains("outside") || err2.contains("allowed root"),
+            "got: {err2}"
+        );
+    }
+
+    #[test]
+    fn screenshot_valid_cache_path() {
+        let valid = screenshots_dir().join("sub").join("ok.png");
+        let got = resolve_screenshot_path(valid.to_str().unwrap()).expect("valid cache path");
+        assert!(
+            got.starts_with(screenshots_dir())
+                || got.starts_with(
+                    std::fs::canonicalize(screenshots_dir()).unwrap_or_else(|_| screenshots_dir())
+                )
+        );
+        // cleanup
+        let _ = std::fs::remove_file(&got);
+        let _ = std::fs::remove_dir_all(screenshots_dir().join("sub"));
+    }
+
+    #[test]
+    fn screenshot_rejects_empty() {
+        assert!(resolve_screenshot_path("").is_err());
+        assert!(resolve_screenshot_path("   ").is_err());
+    }
+
+    #[test]
+    fn screenshot_rejects_symlinked_parent() {
+        // Create a temp dir outside the screenshots root and symlink a
+        // child dir inside screenshots to it. The helper must reject
+        // writing through that symlink.
+        let screenshots = screenshots_dir();
+        let _ = std::fs::create_dir_all(&screenshots);
+        let outside = std::env::temp_dir().join("donsetch-test-outside");
+        let _ = std::fs::create_dir_all(&outside);
+        let link = screenshots.join("evil-link");
+        let _ = std::fs::remove_file(&link);
+        let _ = std::fs::remove_dir_all(&link);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::symlink;
+            let _ = symlink(&outside, &link);
+            if link.exists() {
+                let bad = link.join("shot.png");
+                let err = resolve_screenshot_path(bad.to_str().unwrap()).unwrap_err();
+                assert!(
+                    err.contains("outside")
+                        || err.contains("escapes")
+                        || err.contains("allowed root"),
+                    "got: {err}"
+                );
+                let _ = std::fs::remove_file(&link);
+                let _ = std::fs::remove_dir_all(&outside);
+            }
+        }
+        let _ = std::fs::remove_file(&link);
+        let _ = std::fs::remove_dir_all(&outside);
+    }
+
+    #[test]
+    fn screenshot_rejects_existing_symlink_destination() {
+        // An existing destination file that is itself a symlink (even to a
+        // file outside the root) must be rejected via symlink_metadata.
+        let screenshots = screenshots_dir();
+        let _ = std::fs::create_dir_all(&screenshots);
+        let outside_file = std::env::temp_dir().join("donsetch-test-outside-file.png");
+        let _ = std::fs::write(&outside_file, b"outside");
+        let dest_link = screenshots.join("evil-dest-symlink.png");
+        let _ = std::fs::remove_file(&dest_link);
+        let _ = std::fs::remove_dir_all(&dest_link);
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::symlink;
+            let _ = symlink(&outside_file, &dest_link);
+            if let Ok(meta) = std::fs::symlink_metadata(&dest_link) {
+                if meta.file_type().is_symlink() {
+                    // relative input resolving to the symlink
+                    let err = resolve_screenshot_path("evil-dest-symlink.png").unwrap_err();
+                    assert!(
+                        err.contains("symlink")
+                            || err.contains("outside")
+                            || err.contains("escapes")
+                            || err.contains("allowed root"),
+                        "got: {err}"
+                    );
+                    // absolute input resolving to the same symlink
+                    let err2 = resolve_screenshot_path(dest_link.to_str().unwrap()).unwrap_err();
+                    assert!(
+                        err2.contains("symlink")
+                            || err2.contains("outside")
+                            || err2.contains("escapes")
+                            || err2.contains("allowed root"),
+                        "got: {err2}"
+                    );
+                    // sanity: canonical destination is outside the screenshots root
+                    if let Ok(canon_dest) = std::fs::canonicalize(&dest_link) {
+                        let canon_root = std::fs::canonicalize(&screenshots)
+                            .unwrap_or_else(|_| screenshots.clone());
+                        assert!(
+                            !is_below_root(&canon_dest, &canon_root),
+                            "canon_dest {canon_dest:?} should be outside {canon_root:?}"
+                        );
+                    }
+                }
+            }
+        }
+        let _ = std::fs::remove_file(&dest_link);
+        let _ = std::fs::remove_file(&outside_file);
+    }
 }

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -24,25 +24,20 @@ pub async fn happy_connect(host: &str, port: u16) -> Result<TcpStream, FetchErro
     // private/loopback address is treated exactly like a
     // literal one. Checking the addresses we are about to
     // dial — not the name — also closes rebinding TOCTOU.
-    // Escape hatch for deliberate local-egress use (CLI
-    // power users, tests): DONSETCH_ALLOW_PRIVATE_EGRESS=1.
-    let addrs: Vec<SocketAddr> = if std::env::var_os("DONSETCH_ALLOW_PRIVATE_EGRESS").is_some() {
-        addrs
-    } else {
-        let blocked: Vec<&SocketAddr> = addrs
-            .iter()
-            .filter(|a| crate::fetch::guards::is_ssrf_ip(&a.ip()))
-            .collect();
-        if blocked.len() == addrs.len() {
-            return Err(FetchError::Http(format!(
-                "dns: {host} resolves to a private/loopback address — SSRF guard"
-            )));
-        }
-        addrs
-            .into_iter()
-            .filter(|a| !crate::fetch::guards::is_ssrf_ip(&a.ip()))
-            .collect()
-    };
+    // All private DNS results fail closed — no bypass.
+    let blocked: Vec<&SocketAddr> = addrs
+        .iter()
+        .filter(|a| crate::fetch::guards::is_ssrf_ip(&a.ip()))
+        .collect();
+    if blocked.len() == addrs.len() {
+        return Err(FetchError::Http(format!(
+            "dns: {host} resolves to a private/loopback address — SSRF guard"
+        )));
+    }
+    let addrs: Vec<SocketAddr> = addrs
+        .into_iter()
+        .filter(|a| !crate::fetch::guards::is_ssrf_ip(&a.ip()))
+        .collect();
 
     let mut v6: Vec<SocketAddr> = addrs.iter().filter(|a| a.is_ipv6()).copied().collect();
     let mut v4: Vec<SocketAddr> = addrs.iter().filter(|a| a.is_ipv4()).copied().collect();


### PR DESCRIPTION
## Summary

Harden DonSeTch's MCP web-research boundary against SSRF, unsafe browser navigation, cookie-domain confusion, writable-path escape, and unverified release artifacts. The changes keep the default MCP surface keyless and stdio-only while making network and filesystem decisions fail closed.

## Type

- [x] `fix` — bug fix
- [x] `test` — tests included
- [ ] `feat` — new feature
- [ ] `docs` — documentation only
- [ ] `chore` — deps, CI, tooling
- [ ] `refactor` — no behavior change

## What changed

- Centralized URL validation for fetch, crawl, MCP URL resolution, browser navigation, redirect handling, and CDP request interception.
  - Rejects non-HTTP(S) schemes, URL credentials, loopback/private/link-local/multicast/reserved addresses, IPv4-mapped IPv6, malformed hosts, and DNS failures.
  - Re-checks browser requests before they are continued, including redirects.
- Uses the Public Suffix List for cookie Domain validation and exact/dot-boundary matching.
- Keeps Chrome sandboxing enabled by default and makes the unsafe opt-in explicit.
- Constrains screenshots, browser output, cache, profile, and debug paths to the DonSeTch state tree with traversal/symlink checks.
- Fails closed on unpinned PDFium assets across all supported target pairs.
- Stops accepting an arbitrary pre-existing npm binary and removes trust in same-release checksum sidecars for self-update; reviewed source pins are required.
- Adds regression tests for the security boundaries and self-update pin behavior.

## Checks

- [x] `cargo fmt --all -- --check`
- [x] `git diff --check`
- [x] `cargo check --locked --tests`
- [x] `cargo test --lib` — 660 passed
- [x] `cargo test --tests` — integration soak and token invariants passed
- [x] `cargo clippy --all-targets -- -D warnings`
- [ ] CI is green on all 3 platforms

The local ARM64 run uses the repository's default feature set; the upstream matrix remains responsible for the feature-enabled x86_64/macOS/Windows builds.

## Security notes

This is defense in depth for a local stdio MCP server. DNS rebinding cannot be eliminated completely by application-level preflight checks alone; deployments that require protection against a hostile resolver should also enforce egress/network policy.

The self-update pin table intentionally requires a reviewed source change when a new release is published. Missing pins fail closed rather than trusting a checksum file served beside the artifact.

## Breaking changes

- Private/internal URLs, URL credentials, non-HTTP(S) schemes, and DNS failures are rejected instead of being fetched.
- Self-update stops when the release/platform pair has no reviewed source pin.
- Screenshot/debug paths outside the dedicated state root are rejected.

## Test plan

- Exercise URL guard unit tests for loopback, RFC1918, link-local, multicast, reserved, mapped IPv6, credentials, malformed URLs, and DNS failures.
- Exercise cookie tests for public suffix rejection, host-only cookies, parent domains, and dot-boundary matching.
- Exercise screenshot path tests for traversal and symlink escapes.
- Exercise browser sandbox argument tests.
- Exercise the self-update pin table for known and unknown release/platform pairs.
