### PR TITLE
feat(mcp): streamable-HTTP transport with sessions, cancellation, auth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to DonSeTch are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **HTTP transport (streamable-HTTP):** `donsetch mcp --http` (or `DONSETCH_TRANSPORT=http`) serves MCP over HTTP: JSON-RPC POST at `/mcp`, the GET SSE stream and DELETE session end that strict streamable-HTTP clients (OpenCode among them) require, and `GET /health` for probes. Both transports dispatch through the same handler, so tools behave identically to stdio. Sessions: `initialize` returns an `Mcp-Session-Id` header; clients that echo it get a dedicated cancellation registry (`notifications/cancelled` aborts in-flight calls, same semantics as stdio), session-less clients share a default registry. Session ids are 16-char random base62 tokens; idle sessions are dropped after 30 minutes, the table is bounded at 1024 with oldest-first eviction, and `DELETE /mcp` ends a session immediately. Hardening: optional bearer auth (`DONSETCH_HTTP_TOKEN`, constant-time compare), per-request timeout (`DONSETCH_HTTP_TIMEOUT_SECS`, default 300, returns a JSON-RPC error on expiry), CORS off by default with `DONSETCH_HTTP_CORS=1` to opt in (MCP clients are processes, not browsers; a permissive default would let any webpage in a local browser read responses from a localhost instance). Graceful shutdown: SIGTERM/SIGINT stops accepting requests, drains in-flight ones, and shuts the daemon down so no Chrome processes are orphaned.
+
 ## [3.2.5] - 2026-08-28
 
 The AVX fix release. ONNX Runtime is now dynamically loaded at runtime instead of statically linked, fixing SIGILL crashes on non-AVX CPUs (pre-2011 Intel, QEMU default, Docker VMs without AVX passthrough).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -40,9 +40,9 @@ dependencies = [
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "c982642fa9e8606056828ee9a8505737230110bb1099153c79efe865c59d12ba"
 dependencies = [
  "memchr",
 ]
@@ -146,6 +146,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-trait"
+version = "0.1.92"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82f6aeea286b8eb4dd3431a1be1b59d290ace00f5bfd8e2a159bc2a05e2c1667"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +212,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -211,6 +274,12 @@ name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
+name = "base64"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac07cdecf99051d9a5238b80f35af32cdeba5b336e55d957b318b50137e18da5"
 
 [[package]]
 name = "base64ct"
@@ -368,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -573,9 +642,9 @@ checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
 ]
@@ -671,12 +740,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+checksum = "ed17f5901b6630b993ca003def43f2f8ef4014fc13b047b57aad617ff32bc2ec"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
+ "darling_core 0.24.1",
+ "darling_macro 0.24.1",
 ]
 
 [[package]]
@@ -695,15 +764,15 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+checksum = "6837e2cf7485aaae18f86181d2f0e9a7ed297a025e220aeabf63fdebd3a2ddff"
 dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -719,13 +788,13 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.23.0"
+version = "0.24.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+checksum = "2ac7135c3ef02b2f7833bbeb1be5ba7f966dcde8a87c6b87f65a778d71a02785"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core 0.24.1",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -739,9 +808,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
 name = "der"
@@ -855,13 +924,14 @@ checksum = "c6232dd377dcc64799954cbd3a9bb882e9cdc1308ccd87b1c098f1fb2eaf82a8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
 name = "donsetch"
 version = "3.2.5"
 dependencies = [
+ "axum",
  "boring",
  "boring-sys",
  "brotli",
@@ -892,6 +962,7 @@ dependencies = [
  "tokio",
  "tokio-boring",
  "tokio-tungstenite",
+ "tower-http 0.5.2",
  "unicode-bidi",
  "url",
  "windows-sys 0.61.2",
@@ -921,9 +992,9 @@ checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
-version = "1.17.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5e8f6c15a24b9a3ee5efec809ccd006d3b30e8b3bb63c39af737c7f87daa1d"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
 
 [[package]]
 name = "encode_unicode"
@@ -1026,9 +1097,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "flate2"
@@ -1073,7 +1144,7 @@ checksum = "ea5190182e6915eb873ddbc16e23b711b6eb1f9c00a0d0a3a91b5f6228475225"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1115,9 +1186,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "262590f4fe6afeb0bc83be1daa64e52657fe185690a958af7f3ad0e92085c5ae"
+checksum = "b1f9e3d69d39e4862ffed03ed071a76f9a13ba1d9109d355b0f0aa6b15e393c4"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1143,7 +1214,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1262,9 +1333,9 @@ checksum = "f70749695b063ecbf6b62949ccccde2e733ec3ecbbd71d467dca4e5c6c97cca0"
 
 [[package]]
 name = "glam"
-version = "0.33.3"
+version = "0.33.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7360bd2cd76e0cd9032d42cf2922155cecea2685b0cfa4630c3246df030bcfd6"
+checksum = "c426daf70099baff33fac0ba85151c42424861c56828cef9ba02dacb78eb6b26"
 
 [[package]]
 name = "glob"
@@ -1321,9 +1392,9 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9f41fd6a08e4d4ec69df65976da761afd5ad5e58a9d4acb46bd1c953a9e3ff2"
+checksum = "23169fe34a5fbcdd3f3862e78fb9b6fccd5f02a6dc6f732547005d45631ce71c"
 dependencies = [
  "bytes",
  "futures-core",
@@ -1337,6 +1408,12 @@ name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+
+[[package]]
+name = "httpdate"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hybrid-array"
@@ -1360,6 +1437,7 @@ dependencies = [
  "http",
  "http-body",
  "httparse",
+ "httpdate",
  "itoa",
  "pin-project-lite",
  "smallvec",
@@ -1408,9 +1486,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
+checksum = "fa68d21081c4a05d5a901a1c62add574c77048b6a1c67be3b50ce0b60d4ca513"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1422,9 +1500,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
+checksum = "d56e28588da92eee5c3201a6eff33fabdd49b62269c8938d4ff050ce4d900deb"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1435,9 +1513,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
+checksum = "12f9cf5f235641ed274641dd81c3f28d870e276763d0797aeeab72317b1c646f"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1449,16 +1527,17 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
+checksum = "1563da1ed3e0b3bf3d74c9b85917ac9c56464d2f57242270c09c9e752f8021a0"
 
 [[package]]
 name = "icu_properties"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
+checksum = "7e7ca276ad3145661a65914e6daf131ca5120cd3dcee8f8f3214b8875184a148"
 dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
@@ -1469,15 +1548,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.2.0"
+version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
+checksum = "e590f038c1464a96894fd6d10127e90a8be4509f56ff7ecef851b15cee0b7caa"
 
 [[package]]
 name = "icu_provider"
-version = "2.2.0"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
+checksum = "d27bbb9d3abbefac45d55f647c9de1d44aafcd1186eb91879afef17c396c3e73"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1600,9 +1679,9 @@ dependencies = [
 
 [[package]]
 name = "ipnet"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
+checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
 
 [[package]]
 name = "itertools"
@@ -1649,9 +1728,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
+checksum = "0e0c1080212aad755ea003d18543e8768dd432c48819efd73a7bf1e39b7a5a3a"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1714,9 +1793,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.19"
+version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2026a5056764a10b2bf5d56488cba40da507f5493a6a429340e2004d9ed085fa"
+checksum = "28d0a00925a9f930d679b6789b721e3a7f9ed110f41b86d2497caa780c3a070a"
 dependencies = [
  "libc",
 ]
@@ -1729,9 +1808,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+checksum = "47d9d19d1d6efa0109d2f65ff4c85cddd50bd572e5a00127ab10987290bcefae"
 
 [[package]]
 name = "lock_api"
@@ -1744,9 +1823,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "loop9"
@@ -1816,6 +1895,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
 name = "matrixmultiply"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1840,6 +1925,12 @@ name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
+
+[[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
 name = "minimal-lexical"
@@ -1932,7 +2023,7 @@ dependencies = [
  "glam 0.30.10",
  "glam 0.31.1",
  "glam 0.32.1",
- "glam 0.33.3",
+ "glam 0.33.5",
  "matrixmultiply",
  "nalgebra-macros",
  "num-complex",
@@ -2080,9 +2171,9 @@ dependencies = [
 
 [[package]]
 name = "num-integer"
-version = "0.1.46"
+version = "0.1.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+checksum = "7ce2d95d4b3734dc35aa2f45e1aa22cd416814592a4f9d9205e11affd5b8e10b"
 dependencies = [
  "num-traits",
 ]
@@ -2163,14 +2254,14 @@ dependencies = [
 
 [[package]]
 name = "oar-ocr-derive"
-version = "0.9.0"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b964d897d38ecea0533dba8a143668d5b83b4b61b499328469c29437cdd8aa5"
+checksum = "e1d868d12ee353e68e30d1edbf363f938a6f4e5195ddba43125acbe577971b3f"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.24.1",
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -2401,9 +2492,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "png"
@@ -2420,9 +2511,9 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d20d5497ef88037a52ff98267d066e7f11fcc5e99bbfbd58a42336193aacec3"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
 
 [[package]]
 name = "portable-atomic-util"
@@ -2435,9 +2526,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
+checksum = "d83eb9bc6d8e5cf568e7a1101d60ee05e81ed50ea106026f3d18deeb046d7661"
 dependencies = [
  "zerovec",
 ]
@@ -2575,9 +2666,9 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.16"
+version = "0.11.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f4bfc015262b9df63c8845072ce59068853ff5872180c2ce2f13038b970e560"
+checksum = "04759210543be93709136e28212294a659ef5001836ff4eab4d663e4529bba83"
 dependencies = [
  "bytes",
  "getrandom 0.4.3",
@@ -2831,9 +2922,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.16"
+version = "0.4.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fcfdb36bda0c880c5931cdc7a2bcdc8ba4556847b9d912bca70bc94708711ad"
+checksum = "ad8553b9b26413251cbf30e620595c7a41b3887f03da04579c0e6b0d6a06b4b2"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -2877,7 +2968,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower",
- "tower-http",
+ "tower-http 0.6.11",
  "tower-service",
  "url",
  "wasm-bindgen",
@@ -2995,9 +3086,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -3018,9 +3109,9 @@ checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "safe_arch"
-version = "1.1.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a52ec151f024d703f9fd65abb7cbe81e7cdb39f18917a3a37e3014470dc7c59"
+checksum = "42c6efa15875e6ecb39ca61fb0b0c1a40b84fac5a5ffe71eef7d1000c8eb3f5f"
 dependencies = [
  "bytemuck",
 ]
@@ -3130,7 +3221,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3144,6 +3235,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3233,9 +3335,9 @@ dependencies = [
 
 [[package]]
 name = "simba"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "834a9952211d4a60ff10ac1d20cc01640a75bdc0a0c688d62f359ea7d17459f3"
+checksum = "f1a7200d82ff1c7b4235efd12f11e2537a402c91cf83a5cb97ce80eef787fde7"
 dependencies = [
  "approx",
  "num-complex",
@@ -3376,9 +3478,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3446,22 +3548,22 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09a43598840e33d5b0331f38c5e30d13bb11c11210a4b58f0d9b18a5a5eefcd9"
+checksum = "ec86235f5fcc2a73650310756d2ac5b138a5780bbbdfae3eeccec992c435ba4f"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.19"
+version = "2.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43cbfe0cf76104d42a574802844187e84a305e531ed54455f11fbde0f10541cd"
+checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3489,9 +3591,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
+checksum = "b1e27c91459209c2986af3dcf603a5a74a4368754ce37414f59acc971167f643"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3582,7 +3684,7 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -3633,6 +3735,23 @@ dependencies = [
  "tokio",
  "tower-layer",
  "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags",
+ "bytes",
+ "http",
+ "http-body",
+ "http-body-util",
+ "pin-project-lite",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3828,11 +3947,11 @@ checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
 name = "ureq"
-version = "3.3.0"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+checksum = "972d7902c8735f2695410b8aed7df6ed12a47394aa1c8d7af49f0497b731a94d"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "der",
  "log",
  "native-tls",
@@ -3846,11 +3965,11 @@ dependencies = [
 
 [[package]]
 name = "ureq-proto"
-version = "0.6.0"
+version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+checksum = "da5f78b09e6941e1a0f2e30e695e4b120377b54d5e0aec11b594bb57b3971613"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.23.1",
  "http",
  "httparse",
  "log",
@@ -3935,9 +4054,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
+checksum = "1b70935747edd64d89de3efa29d73789b806c15798f8e7dca4d8ac356b50ce70"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3948,9 +4067,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.76"
+version = "0.4.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c62df1340f32221cb9c54d6a27b030e3dba64361d4a95bed55f9aacb44da291d"
+checksum = "6b7777d5cc23d0e91404e53ce2d5e8ec7acae3026b16233dba62cd3246457950"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3958,9 +4077,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
+checksum = "77775f8f3f7217702089053b94958f8f54061a3f663417df76e19cbdcca29bc1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3968,9 +4087,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
+checksum = "e11d33f857dc2fb11b8bc75aee111aa9cbeb12cd9f25efd3d4c2a3dd4e235284"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3981,18 +4100,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.126"
+version = "0.2.127"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
+checksum = "7ef64dbcc55df09c7e5a46182d181c2cfa3e925f3da937ea764728b4bbb9dcbf"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.103"
+version = "0.3.104"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
+checksum = "c435338968042f4f59a557f690a253676d47ce13ceb55d70100e7facf6620a30"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4010,9 +4129,9 @@ dependencies = [
 
 [[package]]
 name = "web_atoms"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "075474b12bcb3d2e3d4546580e9de478eeeead668a1761e2a8860c836b7ef297"
+checksum = "ba8b815c1b593dc0baf78dd0f4fc8fdb2de53198fb1163738093e9a311c33fb3"
 dependencies = [
  "phf",
  "phf_codegen",
@@ -4172,9 +4291,9 @@ checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
+checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
 
 [[package]]
 name = "xattr"
@@ -4217,18 +4336,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5a105cd7b140f6eeec8acff2ea38135d3cab283ada58540f629fe51e46696eb"
+checksum = "556764e583adb45a9f8d413c2a147fa7e8d821e48e12b14fd560b607998b75eb"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.55"
+version = "0.8.56"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fe976fb70c78cd64cccfe3a6fc142244e8a77b70959b30faf9d0ac37ee228eb"
+checksum = "f2ab42fc20575779bd240faa45f94a74256f755c0fa9e89f0ede20d91d0cdfc1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4264,9 +4383,9 @@ checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 
 [[package]]
 name = "zerotrie"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
+checksum = "4ea269c3bd32f0a32c321907a2ae912ba6f4649bb0fc764a15627e99a7095a3f"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4275,9 +4394,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.6"
+version = "0.11.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
+checksum = "bb0464e17806c1d976d5cba29399c7f08e516e279e2ba493f63123b5fca67dd8"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4286,13 +4405,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.3"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
+checksum = "34df6fc39dbd26ddc9c10e6a2984476e13acce22e64e4487636ef494369225da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.119",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -4331,9 +4450,9 @@ dependencies = [
 
 [[package]]
 name = "zune-core"
-version = "0.5.1"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+checksum = "d56377fd46368984a170bc5aac5567e52ca5da874caa60bea39fcbca78fb658b"
 
 [[package]]
 name = "zune-inflate"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,9 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio-tungstenite = "0.30"
 futures-util = "0.3"
+# HTTP server for MCP HTTP transport (axum, SSE)
+axum = { version = "0.7", default-features = false, features = ["http1", "tokio", "json"] }
+tower-http = { version = "0.5", features = ["cors", "trace"] }
 libc = "0.2"
 dirs = "6"
 unicode-bidi = "0.3"

--- a/README.md
+++ b/README.md
@@ -231,6 +231,75 @@ Or use `npx` without global install:
 
 Works with Claude Code, Cursor, OpenCode, Pi, Windsurf, and any client that speaks MCP. Three tools: `web_fetch`, `web_search`, `web_crawl`.
 
+### HTTP transport (remote clients and debugging)
+
+DonSeTch also speaks MCP over HTTP (the streamable-HTTP transport:
+JSON-RPC via POST, plus the GET SSE stream and DELETE session end that
+strict clients expect). Both transports dispatch through the same
+handler, so tools behave identically. HTTP is opt-in:
+
+```bash
+# Flags
+donsetch mcp --http --host 0.0.0.0 --port 8765
+
+# Env vars (identical effect; flags win over env when both are set)
+DONSETCH_TRANSPORT=http DONSETCH_HTTP_HOST=0.0.0.0 donsetch mcp
+```
+
+MCP clients connect to `http://localhost:8765/mcp`:
+
+```json
+{
+  "mcpServers": {
+    "donsetch": { "url": "http://localhost:8765/mcp" }
+  }
+}
+```
+
+**Testing with curl:**
+
+```bash
+# Health check (always unauthenticated, for probes)
+curl http://localhost:8765/health
+
+# Test the MCP endpoint
+curl -X POST http://localhost:8765/mcp \
+  -H "Content-Type: application/json" \
+  -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}'
+```
+
+**Sessions and cancellation.** The `initialize` response carries an
+`Mcp-Session-Id` header. Echo it back on subsequent requests to get a
+dedicated cancellation registry: posting `notifications/cancelled`
+with the session header while a tool call is in flight aborts it (same
+semantics as stdio). Session-less clients share one default registry —
+cancellation still works, but request ids share a namespace. Unknown
+or expired session ids get a 404. Sessions idle for 30 minutes are
+dropped; `DELETE /mcp` with the session header ends one immediately.
+
+```bash
+# Cancel request 42 during a long call (with a session header)
+curl -X POST http://localhost:8765/mcp \
+  -H "Content-Type: application/json" \
+  -H "Mcp-Session-Id: <from initialize>" \
+  -d '{"jsonrpc":"2.0","method":"notifications/cancelled","params":{"requestId":42}}'
+```
+
+**Environment variables** (HTTP mode):
+
+| Variable | Default | Effect |
+|---|---|---|
+| `DONSETCH_TRANSPORT` | `stdio` | `stdio` or `http` — same as the `--http` flag |
+| `DONSETCH_HTTP_HOST` | `127.0.0.1` | Bind address (use `0.0.0.0` to accept remote clients) |
+| `DONSETCH_HTTP_PORT` | `8765` | Listen port — same as `--port` |
+| `DONSETCH_HTTP_TOKEN` | unset | When set, `/mcp` requires `Authorization: Bearer <token>`; `/health` stays open |
+| `DONSETCH_HTTP_TIMEOUT_SECS` | `300` | Per-request timeout; timed-out calls return a JSON-RPC error |
+| `DONSETCH_HTTP_CORS` | off | `1`/`true`/`on` allows cross-origin requests. Off by default: MCP clients are processes, not browsers, and a permissive layer would let any webpage in a local browser read responses from a localhost instance |
+
+On SIGTERM/SIGINT the server stops accepting new requests, drains
+in-flight ones, and shuts the daemon down (no orphan Chrome
+processes).
+
 ### CLI (for humans and scripts)
 
 ```bash

--- a/src/handles.rs
+++ b/src/handles.rs
@@ -94,13 +94,23 @@ pub fn handles_enabled() -> bool {
     !matches!(std::env::var("DONSETCH_URL_HANDLES").as_deref(), Ok("off"))
 }
 
-/// Generate a random, unguessable handle ID: prefix + 8 base62 chars.
+/// Generate a random, unguessable handle ID: prefix + 8 base62 chars
+/// (see [`random_base62`]).
+fn gen_id(prefix: char) -> String {
+    let mut id = String::with_capacity(ID_LEN + 1);
+    id.push(prefix);
+    id.push_str(&random_base62(ID_LEN));
+    id
+}
+
+/// Random `len`-char base62 string.
 ///
 /// Entropy sources (all process-internal, invisible to a remote
 /// page): nanosecond timestamp, PID, atomic counter, ASLR stack
 /// address. SHA-256 output is indistinguishable from random to
-/// anyone who cannot observe the input.
-fn gen_id(prefix: char) -> String {
+/// anyone who cannot observe the input. Shared by handle IDs
+/// (`S…`/`L…`) and MCP HTTP session ids.
+pub(crate) fn random_base62(len: usize) -> String {
     static COUNTER: AtomicU64 = AtomicU64::new(0);
     let n = COUNTER.fetch_add(1, Ordering::Relaxed);
     let ts = SystemTime::now()
@@ -118,9 +128,8 @@ fn gen_id(prefix: char) -> String {
     hasher.update(stack_addr.to_le_bytes());
     let digest = hasher.finalize();
 
-    let mut id = String::with_capacity(ID_LEN + 1);
-    id.push(prefix);
-    for i in 0..ID_LEN {
+    let mut id = String::with_capacity(len);
+    for i in 0..len {
         id.push(BASE62[digest[i] as usize % 62] as char);
     }
     id

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,13 +19,32 @@ async fn main() {
 
         // ── Management ──
         "mcp" => {
-            // v3 crash-only design: `--supervised` spawns a child
-            // daemon and proxies stdio; a panic-abort (release runs
-            // panic=abort — one dead request would otherwise kill
-            // the whole MCP session) restarts the child instead.
-            // Persistent state (handles, history, profiles) reloads
-            // from disk; the client sees a blip, not a death.
-            if args.iter().any(|a| a == "--supervised") {
+            // Transport selection: the --http flag wins, then the
+            // DONSETCH_TRANSPORT env (stdio|http) for launchers that
+            // can't pass flags, then stdio. Host/port: flags, then
+            // env, then defaults.
+            let env_http = std::env::var("DONSETCH_TRANSPORT").as_deref() == Ok("http");
+            if args.iter().any(|a| a == "--http") || env_http {
+                let host = get_arg_value(&args, "--host")
+                    .or_else(|| std::env::var("DONSETCH_HTTP_HOST").ok())
+                    .unwrap_or("127.0.0.1".to_string());
+                let port = get_arg_value(&args, "--port")
+                    .or_else(|| std::env::var("DONSETCH_HTTP_PORT").ok())
+                    .unwrap_or("8765".to_string())
+                    .parse()
+                    .unwrap_or(8765);
+                eprintln!("[mcp] starting HTTP server on {}:{}", host, port);
+                if let Err(e) = mcp::http::run(host, port).await {
+                    eprintln!("mcp HTTP server: {e}");
+                    std::process::exit(1);
+                }
+            } else if args.iter().any(|a| a == "--supervised") {
+                // v3 crash-only design: `--supervised` spawns a child
+                // daemon and proxies stdio; a panic-abort (release runs
+                // panic=abort — one dead request would otherwise kill
+                // the whole MCP session) restarts the child instead.
+                // Persistent state (handles, history, profiles) reloads
+                // from disk; the client sees a blip, not a death.
                 eprintln!("[supervisor] donsetch mcp --supervised");
                 if let Err(e) = mcp::supervisor::run() {
                     eprintln!("[supervisor] {e}");
@@ -146,9 +165,28 @@ async fn route_help(cmd: &str) {
             println!("  Shows build info and checks for updates.");
         }
         "mcp" => {
-            println!("Usage: donsetch mcp");
+            println!("Usage: donsetch mcp [--http] [--host HOST] [--port PORT] [--supervised]");
             println!();
-            println!("  Starts the MCP server on stdio (JSON-RPC). Connect from your MCP client.");
+            println!("  Starts the MCP server (stdio or HTTP mode).");
+            println!();
+            println!("Options:");
+            println!("  --http              Start HTTP server instead of stdio");
+            println!("  --host HOST         Bind to this address (default: 127.0.0.1)");
+            println!("  --port PORT         Listen on this port (default: 8765)");
+            println!("  --supervised        Run with crash-recovery supervisor (stdio only)");
+            println!();
+            println!("Stdio mode (default): JSON-RPC over stdin/stdout");
+            println!("HTTP mode: JSON-RPC POST at http://HOST:PORT/mcp (plus the");
+            println!("            GET SSE stream and DELETE session end required by");
+            println!("            streamable-HTTP clients)");
+            println!();
+            println!("Environment (flags win over env):");
+            println!("  DONSETCH_TRANSPORT=http       Same as --http (stdio is the default)");
+            println!("  DONSETCH_HTTP_HOST=HOST       Same as --host");
+            println!("  DONSETCH_HTTP_PORT=PORT       Same as --port");
+            println!("  DONSETCH_HTTP_TOKEN=TOKEN     Require Authorization: Bearer TOKEN on /mcp");
+            println!("  DONSETCH_HTTP_TIMEOUT_SECS=N  Per-request timeout (default 300)");
+            println!("  DONSETCH_HTTP_CORS=1          Allow cross-origin requests (default off)");
         }
         "tools" => {
             println!("Usage: donsetch tools");
@@ -159,6 +197,30 @@ async fn route_help(cmd: &str) {
             cli::tool::print_top_help();
         }
     }
+}
+
+/// Helper function to extract argument value from args.
+/// Returns None if the argument is not present or has no value.
+fn get_arg_value(args: &[String], flag: &str) -> Option<String> {
+    let mut iter = args.iter().peekable();
+    while let Some(arg) = iter.next() {
+        if arg == flag {
+            // Check if there's a next argument that's not another flag
+            if let Some(next) = iter.peek()
+                && !next.starts_with("--")
+            {
+                return Some((**next).clone());
+            }
+            return None;
+        }
+        // Handle --flag=value format
+        if let Some(rest) = arg.strip_prefix(flag)
+            && let Some(rest) = rest.strip_prefix("=")
+        {
+            return Some(rest.to_string());
+        }
+    }
+    None
 }
 
 // ── Dev commands ─────────────────────────────────────────────

--- a/src/mcp/http.rs
+++ b/src/mcp/http.rs
@@ -1,0 +1,650 @@
+//! HTTP transport for the MCP server.
+//!
+//! POST /mcp speaks JSON-RPC 2.0 exactly like stdio: every request is
+//! dispatched through the same daemon handler, so initialize
+//! negotiation, tools/list and full tool calls behave identically on
+//! both transports. GET /health is a liveness probe for orchestrators
+//! and load balancers.
+//!
+//! GET /mcp opens the server-initiated SSE stream that streamable-HTTP
+//! clients expect after initialize (OpenCode among them fails the whole
+//! connection on a bare 405 here). DonSeTch never pushes unsolicited
+//! messages — no server tools, no sampling requests — so the stream
+//! carries keep-alive comments only. It self-terminates just inside
+//! SESSION_TTL: graceful shutdown is never blocked by an idle stream,
+//! clients simply reconnect per SSE convention, and each reconnect
+//! refreshes the session's idle timer. DELETE /mcp terminates a session
+//! per the spec.
+//!
+//! Sessions: the server assigns an `Mcp-Session-Id` response header on
+//! `initialize`. Clients that echo it back get a dedicated cancellation
+//! registry, so a `notifications/cancelled` posted while a tool call is
+//! in flight reaches it (mirroring stdio's shared registry). Clients
+//! that ignore sessions — curl, simple integrators — share one default
+//! registry; cancellation still works, they just share a request-id
+//! namespace with other session-less clients. Unknown or expired
+//! session ids get a 404, per the MCP streamable-HTTP convention.
+//!
+//! Hardening: optional bearer auth via `DONSETCH_HTTP_TOKEN`, a
+//! configurable per-request timeout via `DONSETCH_HTTP_TIMEOUT_SECS`
+//! (default 300), and JSON-RPC error envelopes for malformed bodies.
+//! The server drains in-flight requests on SIGTERM/SIGINT before
+//! shutting the daemon down.
+
+use std::collections::HashMap;
+use std::convert::Infallible;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use axum::{
+    Json, Router,
+    body::Bytes,
+    extract::State,
+    http::{HeaderMap, StatusCode, header::AUTHORIZATION},
+    response::{
+        IntoResponse, Response,
+        sse::{Event, KeepAlive, Sse},
+    },
+    routing::{get, post},
+};
+use futures_util::Stream;
+use serde_json::{Value, json};
+use tokio::sync::mpsc;
+use tower_http::{
+    cors::{Any, CorsLayer},
+    trace::TraceLayer,
+};
+
+use crate::mcp::server::{CancelMap, Daemon, handle};
+
+/// Idle sessions are dropped after this long, so cancelled-tool
+/// registries cannot leak forever for clients that vanish mid-call.
+const SESSION_TTL: Duration = Duration::from_secs(30 * 60);
+/// Upper bound on tracked sessions; the oldest are evicted beyond it.
+const MAX_SESSIONS: usize = 1024;
+/// Default per-request timeout when DONSETCH_HTTP_TIMEOUT_SECS is unset.
+const DEFAULT_TIMEOUT_SECS: u64 = 300;
+/// The GET /mcp SSE stream closes itself after this long (just inside
+/// SESSION_TTL): an unbounded idle stream would hold graceful shutdown
+/// open forever, and a closed stream is a routine reconnect for SSE
+/// clients — one that usefully refreshes the session idle timer.
+const SSE_MAX_LIFETIME: Duration = Duration::from_secs(25 * 60);
+
+struct Session {
+    cancels: CancelMap,
+    last_seen: Instant,
+}
+
+/// Session-id → cancellation-registry table with idle-TTL GC and a
+/// bounded size. Split out of the server state so the registry logic
+/// can be tested without constructing a Daemon.
+struct SessionTable {
+    sessions: Mutex<HashMap<String, Session>>,
+}
+
+/// Shared HTTP server state.
+#[derive(Clone)]
+struct HttpState {
+    daemon: Arc<Daemon>,
+    sessions: Arc<SessionTable>,
+    /// When set, requests must carry `Authorization: Bearer <token>`.
+    auth_token: Option<String>,
+    timeout: Duration,
+}
+
+/// Run the HTTP MCP server until SIGTERM/SIGINT.
+pub async fn run(host: String, port: u16) -> Result<(), Box<dyn std::error::Error>> {
+    let daemon = Arc::new(Daemon::new().await.map_err(|e| e.to_string())?);
+    let auth_token = std::env::var("DONSETCH_HTTP_TOKEN")
+        .ok()
+        .filter(|t| !t.is_empty());
+    let auth_enabled = auth_token.is_some();
+    let timeout = Duration::from_secs(
+        std::env::var("DONSETCH_HTTP_TIMEOUT_SECS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_TIMEOUT_SECS),
+    );
+    let state = HttpState {
+        daemon: Arc::clone(&daemon),
+        sessions: Arc::new(SessionTable {
+            sessions: Mutex::new(HashMap::new()),
+        }),
+        auth_token,
+        timeout,
+    };
+
+    // CORS is off by default: MCP clients are processes, not browsers,
+    // and a permissive layer would let any webpage open in a local
+    // browser POST to a localhost instance and read the responses.
+    // Browser-based clients can opt in with DONSETCH_HTTP_CORS.
+    let cors_enabled = matches!(
+        std::env::var("DONSETCH_HTTP_CORS").as_deref(),
+        Ok("1" | "true" | "on")
+    );
+
+    let app = Router::new()
+        .route("/health", get(health_handler))
+        .route(
+            "/mcp",
+            post(mcp_handler).get(sse_handler).delete(delete_handler),
+        )
+        .layer(TraceLayer::new_for_http());
+    let app = if cors_enabled {
+        app.layer(
+            CorsLayer::new()
+                .allow_origin(Any)
+                .allow_methods(Any)
+                .allow_headers(Any),
+        )
+    } else {
+        app
+    };
+    let app = app.with_state(state);
+
+    let listener = tokio::net::TcpListener::bind((host.as_str(), port)).await?;
+    if auth_enabled {
+        eprintln!("[mcp] HTTP server listening on http://{host}:{port} (bearer auth enabled)");
+    } else {
+        eprintln!("[mcp] HTTP server listening on http://{host}:{port}");
+    }
+
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+
+    // Drain done; stop the daemon so no orphan browsers survive.
+    eprintln!("[mcp] draining complete, shutting daemon down");
+    daemon.shutdown().await;
+    Ok(())
+}
+
+/// Resolve SIGTERM/SIGINT into a future that completes on either.
+async fn shutdown_signal() {
+    let ctrl_c = async {
+        let _ = tokio::signal::ctrl_c().await;
+    };
+    #[cfg(unix)]
+    let terminate = async {
+        use tokio::signal::unix::{SignalKind, signal};
+        match signal(SignalKind::terminate()) {
+            Ok(mut sig) => {
+                sig.recv().await;
+            }
+            Err(_) => std::future::pending::<()>().await,
+        }
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
+    }
+    eprintln!("[mcp] shutdown signal received; draining in-flight requests");
+}
+
+/// Liveness probe for orchestrators and load balancers.
+async fn health_handler() -> impl IntoResponse {
+    Json(json!({ "status": "ok", "transport": "http" }))
+}
+
+/// Bearer-auth check shared by every /mcp method (health stays open).
+fn authorized(state: &HttpState, headers: &HeaderMap) -> bool {
+    token_ok(state.auth_token.as_deref(), headers)
+}
+
+/// Pure form of the bearer check so tests don't need server state.
+fn token_ok(expected: Option<&str>, headers: &HeaderMap) -> bool {
+    let Some(expected) = expected else {
+        return true; // no token configured: auth is off
+    };
+    match headers
+        .get(AUTHORIZATION)
+        .and_then(|v| v.to_str().ok())
+        .and_then(|v| v.strip_prefix("Bearer "))
+    {
+        Some(presented) => constant_time_eq(presented.as_bytes(), expected.as_bytes()),
+        None => false,
+    }
+}
+
+/// Constant-time equality (XOR fold, no early exit on the bytes). The
+/// length check up front is deliberate: token length is not a secret
+/// worth protecting, and folding equal-length buffers without a
+/// byte-wise early exit removes the timing oracle on the token itself.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
+}
+
+/// A stream that stays silent for `max` and then ends. While silent, the
+/// SSE body emits keep-alive comments; ending triggers the client's
+/// routine reconnect.
+fn silent_stream(max: Duration) -> impl Stream<Item = Result<Event, Infallible>> {
+    futures_util::stream::unfold((), move |()| async move {
+        tokio::time::sleep(max).await;
+        None
+    })
+}
+
+/// Server-initiated stream half of the streamable-HTTP transport.
+///
+/// DonSeTch has nothing server-initiated to say, so this exists purely
+/// so clients that open the stream after initialize (per spec they MAY)
+/// get a live SSE connection instead of a 405 that some clients —
+/// OpenCode notably — treat as fatal. See the module docs for the
+/// lifetime/reconnect reasoning.
+async fn sse_handler(State(state): State<HttpState>, headers: HeaderMap) -> Response {
+    if !authorized(&state, &headers) {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    // Unknown or expired session ids get a 404, per the same convention
+    // as POST. No header (curl, plain probes) opens an anonymous stream.
+    if let Some(sid) = headers.get("mcp-session-id").and_then(|v| v.to_str().ok())
+        && !sid.is_empty()
+        && state.sessions.registry(sid).is_none()
+    {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    Sse::new(silent_stream(SSE_MAX_LIFETIME))
+        .keep_alive(
+            KeepAlive::new()
+                .interval(Duration::from_secs(15))
+                .text("keep-alive"),
+        )
+        .into_response()
+}
+
+/// Session termination: drop the cancellation registry so a vanished
+/// client's entry cannot linger until the idle TTL collects it.
+async fn delete_handler(State(state): State<HttpState>, headers: HeaderMap) -> Response {
+    if !authorized(&state, &headers) {
+        return StatusCode::UNAUTHORIZED.into_response();
+    }
+    let status = match headers
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .filter(|s| !s.is_empty())
+    {
+        Some(sid) => {
+            let removed = state.sessions.remove(sid);
+            if removed {
+                StatusCode::NO_CONTENT
+            } else {
+                StatusCode::NOT_FOUND
+            }
+        }
+        None => StatusCode::NO_CONTENT, // nothing to terminate
+    };
+    status.into_response()
+}
+
+fn rpc_error(status: StatusCode, code: i32, message: &str) -> Response {
+    (
+        status,
+        Json(json!({
+            "jsonrpc": "2.0",
+            "id": null,
+            "error": { "code": code, "message": message }
+        })),
+    )
+        .into_response()
+}
+
+/// Generate an opaque, unguessable session id: 16 base62 chars (~95
+/// bits) from the same entropy pool as handle IDs. Sequential or
+/// timestamp-derived ids would let a client guess other sessions' ids;
+/// the id is not itself an auth token, but unpredictability costs
+/// nothing and removes the question.
+fn new_session_id() -> String {
+    crate::handles::random_base62(16)
+}
+
+impl SessionTable {
+    /// Registry for an existing session id, or None if unknown.
+    fn registry(&self, id: &str) -> Option<CancelMap> {
+        let mut sessions = self.sessions.lock().unwrap();
+        self.gc_locked(&mut sessions);
+        let s = sessions.get_mut(id)?;
+        s.last_seen = Instant::now();
+        Some(Arc::clone(&s.cancels))
+    }
+
+    /// Registry for `id`, creating it on first use. The empty id is
+    /// the shared default registry for session-less clients; it is
+    /// never a candidate for MAX_SESSIONS eviction.
+    fn registry_or_create(&self, id: &str) -> CancelMap {
+        let mut sessions = self.sessions.lock().unwrap();
+        self.gc_locked(&mut sessions);
+        if let Some(s) = sessions.get_mut(id) {
+            s.last_seen = Instant::now();
+            return Arc::clone(&s.cancels);
+        }
+        if sessions.len() >= MAX_SESSIONS && !id.is_empty() {
+            // Evict the oldest session to bound memory.
+            if let Some(oldest) = sessions
+                .iter()
+                .filter(|(k, _)| !k.is_empty())
+                .min_by_key(|(_, s)| s.last_seen)
+                .map(|(k, _)| k.clone())
+            {
+                sessions.remove(&oldest);
+            }
+        }
+        let cancels: CancelMap = Arc::new(Mutex::new(HashMap::new()));
+        sessions.insert(
+            id.to_string(),
+            Session {
+                cancels: Arc::clone(&cancels),
+                last_seen: Instant::now(),
+            },
+        );
+        cancels
+    }
+
+    /// Remove a session; true if it existed.
+    fn remove(&self, id: &str) -> bool {
+        self.sessions.lock().unwrap().remove(id).is_some()
+    }
+
+    /// Drop sessions idle beyond TTL. Called with the lock held.
+    fn gc_locked(&self, sessions: &mut HashMap<String, Session>) {
+        self.gc_locked_with(sessions, SESSION_TTL);
+    }
+
+    /// TTL-parameterized form so tests can sweep with a tiny window
+    /// (production TTLs are longer than a fresh host's uptime, which
+    /// makes backdating an `Instant` by the real TTL unrepresentable).
+    fn gc_locked_with(&self, sessions: &mut HashMap<String, Session>, ttl: Duration) {
+        sessions.retain(|_, s| s.last_seen.elapsed() < ttl);
+    }
+}
+
+impl HttpState {
+    /// Registry for session-less clients; created on first use.
+    fn default_cancels(&self) -> CancelMap {
+        self.sessions.registry_or_create("")
+    }
+}
+
+/// JSON-RPC request handler.
+///
+/// Accepts MCP JSON-RPC requests via POST and returns responses. Every
+/// request is routed through the same daemon handler as stdio, so
+/// initialize, ping, tools/list and tools/call (fetch, search, crawl)
+/// all work identically on both transports. See the module docs for
+/// the session and cancellation model.
+async fn mcp_handler(State(state): State<HttpState>, headers: HeaderMap, body: Bytes) -> Response {
+    // Auth gate: applies to /mcp only; /health stays open for probes.
+    if !authorized(&state, &headers) {
+        return rpc_error(StatusCode::UNAUTHORIZED, -32000, "unauthorized");
+    }
+
+    // Parse before dispatch: malformed bodies get a JSON-RPC -32700
+    // envelope instead of a bare transport-layer 400.
+    let req: Value = match serde_json::from_slice(&body) {
+        Ok(v) => v,
+        Err(_) => return rpc_error(StatusCode::BAD_REQUEST, -32700, "Parse error"),
+    };
+    let line = req.to_string();
+    let method = req.get("method").and_then(Value::as_str).unwrap_or("");
+    let is_notification = req.get("id").is_none();
+    let sid_header = headers
+        .get("mcp-session-id")
+        .and_then(|v| v.to_str().ok())
+        .map(str::to_string);
+
+    // Cancellation notifications are handled inline — they must reach
+    // the running tool NOW, not after a full dispatch round-trip.
+    // Mirrors the stdio transport's inline handling.
+    if is_notification && method == "notifications/cancelled" {
+        let cancels = resolve_cancels(&state, sid_header.as_deref());
+        if let Some(rid) = req.pointer("/params/requestId").and_then(Value::as_i64)
+            && let Some(sender) = cancels.lock().unwrap().remove(&rid)
+        {
+            let _ = sender.send(true);
+        }
+        // 202 Accepted, not 204: the streamable-HTTP spec mandates 202
+        // for notification-only POSTs.
+        return StatusCode::ACCEPTED.into_response();
+    }
+
+    // Session resolution: header wins; unknown ids are expired per
+    // streamable-HTTP convention. initialize without a header mints a
+    // new session echoed back on the response.
+    let mut new_session: Option<String> = None;
+    let cancels = match sid_header.as_deref() {
+        Some(sid) if !sid.is_empty() => match state.sessions.registry(sid) {
+            Some(c) => c,
+            None => return rpc_error(StatusCode::NOT_FOUND, -32001, "session expired or unknown"),
+        },
+        _ => {
+            if method == "initialize" {
+                let sid = new_session_id();
+                new_session = Some(sid.clone());
+                state.sessions.registry_or_create(&sid)
+            } else {
+                state.default_cancels()
+            }
+        }
+    };
+
+    // Writer sink for in-flight progress notifications. Each request
+    // gets a fresh channel; nothing else consumes it.
+    let (progress_tx, mut progress_rx) = mpsc::channel::<String>(256);
+    let request_id = req.get("id").and_then(Value::as_i64);
+
+    let outcome = tokio::time::timeout(
+        state.timeout,
+        handle(&state.daemon, &line, &cancels, &progress_tx),
+    )
+    .await;
+
+    let mut response = match outcome {
+        Err(_) => {
+            // Timed out: drop any registry entry so the id can be
+            // reused without leaking a dead watch sender.
+            if let Some(rid) = request_id
+                && let Some(sender) = cancels.lock().unwrap().remove(&rid)
+            {
+                drop(sender);
+            }
+            rpc_error(
+                StatusCode::GATEWAY_TIMEOUT,
+                -32603,
+                &format!("request timed out after {}s", state.timeout.as_secs()),
+            )
+        }
+        Ok(Some(resp_line)) => {
+            let resp: Value = serde_json::from_str(&resp_line).unwrap_or_else(|_| {
+                json!({
+                    "jsonrpc": "2.0", "id": null,
+                    "error": { "code": -32603, "message": "internal error" }
+                })
+            });
+            Json(resp).into_response()
+        }
+        Ok(None) => {
+            // Notification: no body, 202 Accepted per the streamable-HTTP
+            // spec (204 would also be "no content", but the spec names
+            // 202 for notification-only POSTs). The sender MUST be
+            // dropped before draining — recv() only returns None once
+            // every sender is gone, and progress_tx is still in scope
+            // here, so draining first would wait forever. (This exact
+            // deadlock hung the notifications/initialized POST and with
+            // it every streamable-HTTP client's connect; it also would
+            // have hung POSTs for cancelled tools/call requests.)
+            drop(progress_tx);
+            while progress_rx.recv().await.is_some() {}
+            StatusCode::ACCEPTED.into_response()
+        }
+    };
+
+    if let Some(sid) = new_session
+        && let Ok(hv) = sid.parse()
+    {
+        response.headers_mut().insert("mcp-session-id", hv);
+    }
+    response
+}
+
+/// Resolve the cancellation registry for a cancellation notification.
+/// Unknown session ids fall back to the shared default registry: a
+/// notification cannot carry a JSON-RPC error, so it is absorbed.
+fn resolve_cancels(state: &HttpState, sid: Option<&str>) -> CancelMap {
+    match sid {
+        Some(s) if !s.is_empty() => state
+            .sessions
+            .registry(s)
+            .unwrap_or_else(|| state.default_cancels()),
+        _ => state.default_cancels(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::http::HeaderValue;
+
+    fn headers_with_bearer(token: Option<&str>) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        if let Some(t) = token {
+            h.insert(
+                AUTHORIZATION,
+                HeaderValue::from_str(&format!("Bearer {t}")).unwrap(),
+            );
+        }
+        h
+    }
+
+    #[test]
+    fn token_ok_no_token_configured_allows_all() {
+        assert!(token_ok(None, &HeaderMap::new()));
+        assert!(token_ok(None, &headers_with_bearer(Some("anything"))));
+        // run() filters empty env tokens, but the pure function still
+        // treats a configured (even empty) token as auth-on.
+        assert!(!token_ok(Some(""), &HeaderMap::new()));
+    }
+
+    #[test]
+    fn token_ok_requires_bearer_when_configured() {
+        let expected = Some("s3cret-token");
+        assert!(!token_ok(expected, &HeaderMap::new()));
+        assert!(!token_ok(expected, &headers_with_bearer(Some("wrong"))));
+        assert!(token_ok(
+            expected,
+            &headers_with_bearer(Some("s3cret-token"))
+        ));
+        // Non-Bearer schemes don't match.
+        let mut h = HeaderMap::new();
+        h.insert(
+            AUTHORIZATION,
+            HeaderValue::from_str("Basic czM6Y3JldA==").unwrap(),
+        );
+        assert!(!token_ok(expected, &h));
+        // Length mismatch is rejected by the length check.
+        assert!(!token_ok(
+            expected,
+            &headers_with_bearer(Some("s3cret-token "))
+        ));
+    }
+
+    #[test]
+    fn constant_time_eq_basics() {
+        assert!(constant_time_eq(b"abc", b"abc"));
+        assert!(constant_time_eq(b"", b""));
+        assert!(!constant_time_eq(b"abc", b"abd"));
+        assert!(!constant_time_eq(b"abc", b"ab"));
+        assert!(!constant_time_eq(b"ab", b"abc"));
+    }
+
+    #[test]
+    fn session_ids_are_base62_and_unique() {
+        let ids: std::collections::HashSet<String> = (0..1000).map(|_| new_session_id()).collect();
+        assert_eq!(ids.len(), 1000, "session ids must not repeat");
+        for id in &ids {
+            assert_eq!(id.len(), 16);
+            assert!(id.bytes().all(|b| b.is_ascii_alphanumeric()));
+        }
+    }
+
+    fn backdate(table: &SessionTable, id: &str, by: Duration) -> bool {
+        // False when the host booted more recently than `by` (Instant
+        // arithmetic would underflow); callers skip such assertions.
+        let Some(old) = Instant::now().checked_sub(by) else {
+            return false;
+        };
+        table
+            .sessions
+            .lock()
+            .unwrap()
+            .get_mut(id)
+            .unwrap()
+            .last_seen = old;
+        true
+    }
+
+    fn table_with(ids: &[&str]) -> SessionTable {
+        let table = SessionTable {
+            sessions: Mutex::new(HashMap::new()),
+        };
+        for id in ids {
+            table.registry_or_create(id);
+        }
+        table
+    }
+
+    #[test]
+    fn registry_unknown_is_none_known_roundtrips() {
+        let table = table_with(&["sess-1"]);
+        assert!(table.registry("sess-1").is_some());
+        assert!(table.registry("nope").is_none());
+        // Same registry comes back on the second lookup.
+        let a = table.registry("sess-1").unwrap();
+        let b = table.registry("sess-1").unwrap();
+        assert!(Arc::ptr_eq(&a, &b));
+    }
+
+    #[test]
+    fn remove_reports_existence() {
+        let table = table_with(&["sess-1"]);
+        assert!(table.remove("sess-1"));
+        assert!(!table.remove("sess-1"));
+        assert!(table.registry("sess-1").is_none());
+    }
+
+    #[test]
+    fn gc_drops_idle_sessions() {
+        let table = table_with(&["old", "fresh"]);
+        if !backdate(&table, "old", Duration::from_secs(2)) {
+            return; // host booted <2s ago; underflow, skip
+        }
+        let mut sessions = table.sessions.lock().unwrap();
+        table.gc_locked_with(&mut sessions, Duration::from_secs(1));
+        drop(sessions);
+        assert!(table.registry("old").is_none(), "idle session must be GC'd");
+        assert!(table.registry("fresh").is_some());
+    }
+
+    #[test]
+    fn eviction_bounds_table_and_spares_default() {
+        let table = table_with(&[""]);
+        // Fill with one more than MAX_SESSIONS named sessions, oldest
+        // first so eviction order is deterministic.
+        for i in 0..=MAX_SESSIONS {
+            table.registry_or_create(&format!("s{i:04}"));
+        }
+        // The oldest named entries were evicted as the table filled.
+        let live = table.sessions.lock().unwrap();
+        assert!(
+            live.len() <= MAX_SESSIONS,
+            "table must stay bounded, has {}",
+            live.len()
+        );
+        assert!(live.contains_key(""), "default registry is never evicted");
+        assert!(!live.contains_key("s0000"), "oldest named entry evicted");
+        assert!(live.contains_key(&format!("s{MAX_SESSIONS:04}")));
+    }
+}

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1,9 +1,12 @@
-//! DonSeTch MCP daemon — JSON-RPC 2.0 over stdio (NDJSON).
+//! DonSeTch MCP daemon — JSON-RPC 2.0 over stdio (NDJSON) and HTTP/SSE.
 //!
-//! One message per line. Requests spawn tasks; responses
-//! funnel through a single writer task so lines never
-//! interleave. The daemon never dies on bad input.
+//! Stdio mode: one message per line. Requests spawn tasks; responses
+//! funnel through a single writer task so lines never interleave.
+//!
+//! HTTP mode: SSE streaming for responses and progress notifications.
 
+pub mod http;
 pub mod server;
+pub mod stdio;
 pub mod supervisor;
 pub mod tools;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -4,7 +4,6 @@
 use std::sync::Arc;
 
 use serde_json::{Value, json};
-use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::sync::{Mutex, mpsc};
 
 use futures_util::FutureExt;
@@ -141,76 +140,10 @@ impl Daemon {
     }
 }
 
-/// Run the daemon until stdin closes. Never returns Err
-/// on client garbage — only on fatal IO.
+/// Note: The stdio transport implementation has been moved to `stdio.rs`.
+/// This function is kept for backward compatibility but delegates to the stdio module.
 pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
-    let daemon = Arc::new(Daemon::new().await?);
-    let (tx, mut rx) = mpsc::channel::<String>(256);
-
-    // Single writer: response lines can never interleave.
-    let writer = tokio::spawn(async move {
-        let mut out = tokio::io::stdout();
-        while let Some(line) = rx.recv().await {
-            // A broken stdout (client died, pipe closed) must not be
-            // swallowed: every later response would be silently
-            // dropped while the daemon pretends to serve. Log the
-            // real cause and stop — the client is gone.
-            if let Err(e) = out.write_all(line.as_bytes()).await {
-                eprintln!("[mcp] stdout write failed, shutting down: {e}");
-                std::process::exit(1);
-            }
-            if let Err(e) = out.write_all(b"\n").await {
-                eprintln!("[mcp] stdout write failed, shutting down: {e}");
-                std::process::exit(1);
-            }
-            if let Err(e) = out.flush().await {
-                eprintln!("[mcp] stdout flush failed, shutting down: {e}");
-                std::process::exit(1);
-            }
-        }
-    });
-
-    // Cancellation registry: request-id → cancel sender. The MCP
-    // client fires notifications/cancelled with a requestId; the
-    // in-flight tool observes it (fetch/search abort via select,
-    // crawl stops its workers gracefully and persists its resume
-    // token before returning).
-    let cancels: Arc<
-        std::sync::Mutex<std::collections::HashMap<i64, tokio::sync::watch::Sender<bool>>>,
-    > = Arc::new(std::sync::Mutex::new(std::collections::HashMap::new()));
-
-    let mut lines = BufReader::new(tokio::io::stdin()).lines();
-    while let Ok(Some(line)) = lines.next_line().await {
-        let line = line.trim().to_string();
-        if line.is_empty() {
-            continue;
-        }
-        // Cancellation notifications are handled inline — they must
-        // reach the running tool NOW, not after a spawn.
-        if let Ok(v) = serde_json::from_str::<Value>(&line)
-            && v.get("id").is_none()
-            && v.get("method").and_then(Value::as_str) == Some("notifications/cancelled")
-            && let Some(rid) = v.pointer("/params/requestId").and_then(Value::as_i64)
-            && let Some(sender) = cancels.lock().unwrap().remove(&rid)
-        {
-            let _ = sender.send(true);
-            continue;
-        }
-        let daemon = Arc::clone(&daemon);
-        let tx = tx.clone();
-        let cancels = Arc::clone(&cancels);
-        tokio::spawn(async move {
-            if let Some(resp) = handle(&daemon, &line, &cancels, &tx).await {
-                let _ = tx.send(resp).await;
-            }
-        });
-    }
-
-    // stdin EOF: graceful shutdown, no orphan browsers.
-    drop(tx);
-    daemon.ghost_mgr.shutdown().await;
-    let _ = writer.await;
-    Ok(())
+    crate::mcp::stdio::run().await
 }
 
 /// Per-request tool context (v3): cancellation signal + progress
@@ -310,13 +243,13 @@ where
     }
 }
 
-type CancelMap =
+pub type CancelMap =
     Arc<std::sync::Mutex<std::collections::HashMap<i64, tokio::sync::watch::Sender<bool>>>>;
 
 /// Handle one line. Returns Some(response) for requests,
 /// None for notifications and cancelled requests (per MCP spec,
 /// a cancelled request gets no response).
-async fn handle(
+pub async fn handle(
     daemon: &Arc<Daemon>,
     line: &str,
     cancels: &CancelMap,

--- a/src/mcp/stdio.rs
+++ b/src/mcp/stdio.rs
@@ -1,0 +1,82 @@
+//! stdio transport for the MCP server.
+//!
+//! Handles stdin/stdout I/O for the MCP JSON-RPC protocol.
+
+use std::sync::{Arc, Mutex};
+
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
+use tokio::sync::mpsc;
+
+use serde_json::Value;
+
+use crate::mcp::server::{CancelMap, Daemon, handle};
+
+/// Run the stdio MCP daemon until stdin closes.
+/// Never returns Err on client garbage — only on fatal IO.
+pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
+    let daemon = Arc::new(Daemon::new().await?);
+    let (tx, mut rx) = mpsc::channel::<String>(256);
+
+    // Single writer: response lines can never interleave.
+    let writer = tokio::spawn(async move {
+        let mut out = tokio::io::stdout();
+        while let Some(line) = rx.recv().await {
+            // A broken stdout (client died, pipe closed) must not be
+            // swallowed: every later response would be silently
+            // dropped while the daemon pretends to serve. Log the
+            // real cause and stop — the client is gone.
+            if let Err(e) = out.write_all(line.as_bytes()).await {
+                eprintln!("[mcp] stdout write failed, shutting down: {e}");
+                std::process::exit(1);
+            }
+            if let Err(e) = out.write_all(b"\n").await {
+                eprintln!("[mcp] stdout write failed, shutting down: {e}");
+                std::process::exit(1);
+            }
+            if let Err(e) = out.flush().await {
+                eprintln!("[mcp] stdout flush failed, shutting down: {e}");
+                std::process::exit(1);
+            }
+        }
+    });
+
+    // Cancellation registry: request-id → cancel sender. The MCP
+    // client fires notifications/cancelled with a requestId; the
+    // in-flight tool observes it (fetch/search abort via select,
+    // crawl stops its workers gracefully and persists its resume
+    // token before returning).
+    let cancels: CancelMap = Arc::new(Mutex::new(std::collections::HashMap::new()));
+
+    let mut lines = BufReader::new(tokio::io::stdin()).lines();
+    while let Ok(Some(line)) = lines.next_line().await {
+        let line = line.trim().to_string();
+        if line.is_empty() {
+            continue;
+        }
+        // Cancellation notifications are handled inline — they must
+        // reach the running tool NOW, not after a spawn.
+        if let Ok(v) = serde_json::from_str::<Value>(&line)
+            && v.get("id").is_none()
+            && v.get("method").and_then(Value::as_str) == Some("notifications/cancelled")
+            && let Some(rid) = v.pointer("/params/requestId").and_then(Value::as_i64)
+            && let Some(sender) = cancels.lock().unwrap().remove(&rid)
+        {
+            let _ = sender.send(true);
+            continue;
+        }
+        let daemon = Arc::clone(&daemon);
+        let tx = tx.clone();
+        let cancels = Arc::clone(&cancels);
+        tokio::spawn(async move {
+            if let Some(resp) = handle(&daemon, &line, &cancels, &tx).await {
+                let _ = tx.send(resp).await;
+            }
+        });
+    }
+
+    // stdin EOF: graceful shutdown, no orphan browsers.
+    drop(tx);
+    daemon.shutdown().await;
+    let _ = writer.await;
+    Ok(())
+}


### PR DESCRIPTION
**Summary**

Adds a second MCP transport: streamable-HTTP. donsetch mcp --http (or DONSETCH_TRANSPORT=http) serves the full tool surface over HTTP — JSON-RPC POST at /mcp, the GET SSE stream and DELETE-session endpoints that strict streamable-HTTP clients (OpenCode among them) require, and GET /health for probes. Both transports dispatch through the same request handler, so tools behave identically to stdio.

- **Sessions:** initialize returns an Mcp-Session-Id header. Clients that echo it get a dedicated cancellation registry (notifications/cancelled aborts in-flight calls, same semantics as stdio); session-less clients share a default registry. Ids are 16-char random base62 tokens, idle sessions are GC'd after 30 minutes, the table is bounded at 1024 with oldest-first eviction, and DELETE /mcp ends a session immediately.
- **Hardening:** optional bearer auth (DONSETCH_HTTP_TOKEN, constant-time compare), per-request timeout (DONSETCH_HTTP_TIMEOUT_SECS, default 300, returns a JSON-RPC error on expiry), and CORS off by default with DONSETCH_HTTP_CORS=1 to opt in — MCP clients are processes, not browsers, and a permissive default would let any webpage in a local browser read responses from a localhost instance.
- **Graceful shutdown:** SIGTERM/SIGINT stops accepting requests, drains in-flight ones, and shuts the daemon down so no Chrome processes are orphaned.
- Deps: axum 0.7 / tower-http 0.5 (0.8 is current; happy to bump if preferred).

**Type**

- [x] feat — new feature

**Checks**

- [x] cargo test --features ocr,rerank passes (686 tests)
- [x] cargo clippy --all-targets --features ocr,rerank -- -Dwarnings passes (zero warnings)
- [x] cargo fmt --all -- --check passes
- [ ] CI is green on all 3 platforms (Linux, macOS, Windows)

**Breaking changes**

None. stdio remains the default; HTTP is opt-in via --http / DONSETCH_TRANSPORT=http.

**Test plan**

- 8 unit tests in src/mcp/http.rs: auth gate (token set/unset), constant-time compare, session-id format + uniqueness, registry roundtrip + removal, idle GC.
- End-to-end against a release build over HTTP, driven as a real client: initialize → session echo → tools/list → web_fetch → web_search → S-handle round-trip → fabricated-handle rejection → GET SSE stream → DELETE session → dead-session rejected (12/12).
- Auth gate e2e: no token configured = open; token configured = 401 without or with a wrong bearer, 200 with the right one (4/4).
- Notification-only POSTs return 202 Accepted per the streamable-HTTP spec (verified: not 204).
- Behavioral note from stdio testing (pre-existing, not introduced here): a client that closes stdin immediately after queueing requests drops in-flight responses; real MCP clients hold stdin open.

