### PR TITLE
feat(docker): production image + compose service (stdio)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,54 @@
+# Docker ignore patterns for DonSeTch
+
+# Git
+.git
+.gitignore
+.gitattributes
+
+# CI/CD
+.github
+
+# Rust
+target/
+**/target/
+
+# Fuzzing (development-only)
+fuzz/
+
+# Benchmarks (development-only)
+bench/
+
+# Scripts (development-only)
+scripts/
+
+# Assets (not needed for runtime)
+assets/
+
+# npm package (installed separately)
+npm/
+
+# Documentation (not needed for runtime)
+docs/
+*.md
+!README.md
+
+# IDE
+.vscode
+.idea
+*.swp
+*.swo
+*~
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Docker files (don't copy into image)
+docker-compose*.yml
+.dockerignore
+Dockerfile*
+
+# Development files
+*.log
+.env.*
+!.env.example

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to DonSeTch are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Docker image and compose service:** multi-stage build (`rust:slim` builder → `debian:trixie-slim` runtime on the same glibc generation, arch-aware Go install for BoringSSL) with all features enabled, `--locked` to `Cargo.lock`, non-root runtime user, optional `INSTALL_CHROME=true` build arg for tier 2 escalation. `docker-compose.yml` runs stdio out of the box with a persistent cache volume, 2GB memory ceiling, init for zombie reaping, and a 45s stop grace period.
+
 ## [3.2.5] - 2026-08-28
 
 The AVX fix release. ONNX Runtime is now dynamically loaded at runtime instead of statically linked, fixing SIGILL crashes on non-AVX CPUs (pre-2011 Intel, QEMU default, Docker VMs without AVX passthrough).

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,8 @@
 #   Cursor/OpenCode: stdio MCP configuration
 #
 # Note: build.rs downloads and sha256-verifies the PDFium static archive
-# at build time, exactly as the upstream CI does (curl + tar are needed).
+# and the ONNX Runtime archive at build time, exactly as the upstream CI
+# does (curl + tar are needed).
 # ─────────────────────────────────────────────────────────────────────────────
 
 # Optional: install Chrome for tier 2 browser escalation (bot-wall bypass).
@@ -103,6 +104,20 @@ RUN set -eu; \
 ENV CARGO_TERM_COLOR=always
 RUN cargo build --release --features ocr,rerank --locked
 
+# Stage the ONNX Runtime shared library for the runtime image. Since
+# 3.2.5, ort loads ONNX Runtime dynamically: when ocr/rerank are
+# enabled, build.rs builds vendor/onnx/libonnxruntime.so from the pyke
+# CDN archive and the binary dlopens it at runtime (searched next to
+# the executable first, then the cache dir). Stage only the .so — the
+# vendor/onnx dir also holds the large static archive, which the
+# runtime image does not need. arm64 has no ONNX prebuilt: stage an
+# empty dir there so the runtime COPY is a no-op and ocr/rerank
+# self-disable at runtime with a notice instead of failing the build.
+RUN mkdir -p /stage-onnx \
+    && if [ -f vendor/onnx/libonnxruntime.so ]; then \
+           cp vendor/onnx/libonnxruntime.so /stage-onnx/; \
+       fi
+
 # ── Runtime stage ─────────────────────────────────────────────────────────────
 # Minimal Debian image for runtime — trixie, matching the builder stage's
 # glibc generation (see the glibc note on the builder stage above)
@@ -124,6 +139,13 @@ RUN if [ "$INSTALL_CHROME" = "true" ]; then \
 
 # Copy binary from builder
 COPY --from=builder /build/target/release/donsetch /usr/local/bin/donsetch
+
+# ONNX Runtime shared library (ocr + rerank features, dynamic since
+# 3.2.5). The binary looks for it next to the executable first, then
+# $cache_dir/onnx/ — /usr/local/bin satisfies the first even when an
+# older cache volume shadows the second. Empty dir on arm64: nothing
+# is copied and the features degrade at runtime.
+COPY --from=builder /stage-onnx/ /usr/local/bin/
 
 # Verify binary works
 RUN donsetch --version

--- a/Dockerfile
+++ b/Dockerfile
@@ -144,6 +144,14 @@ WORKDIR /home/donsetch
 # The server resolves it as $HOME/.cache/donsetch (XDG_CACHE_HOME is
 # honoured too); no env var is needed. VOLUME makes plain `docker run`
 # persist it in an anonymous volume.
+
+# Chromium's sandbox cannot initialize inside a default Docker container
+# (no unprivileged user namespaces): the browser dies at launch before the
+# DevTools handshake. Upstream's documented container escape hatch
+# (`DONGHOST_NO_SANDBOX=1`, see ghost docs) is therefore the correct
+# default for this image. The container boundary + non-root user provide
+# the isolation the sandbox would on a host.
+ENV DONGHOST_NO_SANDBOX=1
 VOLUME /home/donsetch/.cache/donsetch
 
 # Set Chrome path if Chrome was installed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,160 @@
+# syntax=docker/dockerfile:1
+# ─────────────────────────────────────────────────────────────────────────────
+# DonSeTch MCP server — production image
+#
+# Builds from the local source tree (this repo).
+#
+# Build:    docker build -t donsetch-mcp .
+# Run:      docker compose run --rm donsetch     (recommended — see docker-compose.yml)
+#   or:     docker run -i --rm --init donsetch-mcp donsetch mcp --supervised
+#
+# Optional Chrome for tier 2 browser escalation:
+#   docker build --build-arg INSTALL_CHROME=true -t donsetch-mcp .
+#
+# The container runs the MCP server on stdio. Connect from your MCP
+# client:
+#   Claude Code: mcp server config using "docker run -i --rm donsetch-mcp donsetch mcp --supervised"
+#   Cursor/OpenCode: stdio MCP configuration
+#
+# Note: build.rs downloads and sha256-verifies the PDFium static archive
+# at build time, exactly as the upstream CI does (curl + tar are needed).
+# ─────────────────────────────────────────────────────────────────────────────
+
+# Optional: install Chrome for tier 2 browser escalation (bot-wall bypass).
+# Adds ~350MB. Enable with:  docker build --build-arg INSTALL_CHROME=true .
+ARG INSTALL_CHROME=false
+
+# ── Builder stage ─────────────────────────────────────────────────────────────
+# Use Rust slim image (Debian-based, edition2024 support in Rust 1.82+)
+#
+# Both stages must share one modern Debian generation. The ort-sys
+# prebuilt ONNX Runtime archives reference glibc 2.38+ symbols
+# (__isoc23_strtoll/strtoull), so they will not link against an older
+# glibc — and a binary built against a newer glibc will not run on one.
+# rust:slim and debian:trixie-slim track Debian trixie together.
+FROM rust:slim AS builder
+
+# Install build dependencies for boring-sys (BoringSSL) and PDFium.
+# Go is required by BoringSSL's build system; NASM builds the x86_64
+# crypto assembly; libclang drives bindgen.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        cmake \
+        g++ \
+        gcc \
+        gnupg \
+        libclang-dev \
+        libssl-dev \
+        make \
+        nasm \
+        curl \
+        tar \
+        git \
+        pkg-config \
+        && rm -rf /var/lib/apt/lists/*
+
+# Install Go (required for BoringSSL's build system). TARGETARCH
+# (amd64/arm64, injected by BuildKit; falls back to the host arch for
+# classic builds) selects the tarball so arm64 builds work too.
+ARG TARGETARCH
+RUN arch="${TARGETARCH:-$(dpkg --print-architecture)}" \
+    && curl -fsSL "https://go.dev/dl/go1.23.4.linux-${arch}.tar.gz" -o /tmp/go.tar.gz \
+    && tar -C /usr/local -xzf /tmp/go.tar.gz \
+    && rm /tmp/go.tar.gz
+
+ENV PATH="/usr/local/go/bin:${PATH}"
+
+WORKDIR /build
+
+# Copy source code (build.rs must ship: it acquires + links PDFium
+# and emits the linux_like cfg)
+COPY Cargo.toml Cargo.lock README.md LICENSE ./
+COPY build.rs ./
+COPY src/ ./src/
+COPY tests/ ./tests/
+
+# Pre-fetch PDFium before cargo build. build.rs vendors the library
+# under vendor/pdfium and skips its own download once lib/libpdfium.a
+# exists — but its curl path gives up on a single mid-transfer reset
+# (curl 35 is not retried without --retry-all-errors). Filtered or
+# flaky networks that stall then reset long transfers die there, so
+# fetch here first with aggressive retries and stall detection, and
+# verify the same sha256 pins build.rs enforces (KNOWN_HASHES) to
+# keep the download fail-closed.
+ARG TARGETARCH
+RUN set -eu; \
+    arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+    pair="linux-x64"; \
+    hash="13908bb2d40a6e017c4c5a6a7baecc6efd7b1c30392c8a79e80072d2b48b18eb"; \
+    if [ "$arch" = "arm64" ] || [ "$arch" = "aarch64" ]; then \
+        pair="linux-arm64"; \
+        hash="abe1c3d5b168ec2baaafc7a8fcddfda1a09417f39199c7993fd28d34d3a7f70e"; \
+    fi; \
+    url="https://github.com/kognitos/pdfium-static/releases/download/chromium/7809/pdfium-${pair}-static.tgz"; \
+    mkdir -p vendor/pdfium; \
+    curl -fSL --proto '=https' --proto-redir '=https' \
+         --retry 8 --retry-all-errors --retry-delay 3 \
+         --connect-timeout 20 --speed-time 30 --speed-limit 1024 \
+         -o /tmp/pdfium.tgz "$url"; \
+    echo "${hash}  /tmp/pdfium.tgz" | sha256sum -c -; \
+    tar -xzf /tmp/pdfium.tgz -C vendor/pdfium; \
+    rm /tmp/pdfium.tgz
+
+# Build all features (OCR + semantic reranking), locked to Cargo.lock
+ENV CARGO_TERM_COLOR=always
+RUN cargo build --release --features ocr,rerank --locked
+
+# ── Runtime stage ─────────────────────────────────────────────────────────────
+# Minimal Debian image for runtime — trixie, matching the builder stage's
+# glibc generation (see the glibc note on the builder stage above)
+FROM debian:trixie-slim
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        libgcc-s1 \
+    && rm -rf /var/lib/apt/lists/*
+
+# Optional: install Chrome for tier 2 browser escalation
+ARG INSTALL_CHROME=false
+RUN if [ "$INSTALL_CHROME" = "true" ]; then \
+        apt-get update && \
+        apt-get install -y --no-install-recommends chromium xvfb && \
+        rm -rf /var/lib/apt/lists/*; \
+    fi
+
+# Copy binary from builder
+COPY --from=builder /build/target/release/donsetch /usr/local/bin/donsetch
+
+# Verify binary works
+RUN donsetch --version
+
+# ── Non-root runtime user ────────────────────────────────────────────────────
+# The cache dir must exist and be donsetch-owned before the VOLUME
+# declaration below: when it is absent from the image, the daemon
+# creates a root-owned mountpoint and fresh volumes stay root-owned,
+# so the non-root user can neither write the fetch cache nor download
+# the rerank model on first use.
+RUN useradd -m -u 1000 donsetch \
+    && mkdir -p /home/donsetch/.cache/donsetch \
+    && chown -R donsetch:donsetch /home/donsetch/.cache
+USER donsetch
+WORKDIR /home/donsetch
+
+# Cache directory for fetch/search results and ghost browser profile.
+# The server resolves it as $HOME/.cache/donsetch (XDG_CACHE_HOME is
+# honoured too); no env var is needed. VOLUME makes plain `docker run`
+# persist it in an anonymous volume.
+VOLUME /home/donsetch/.cache/donsetch
+
+# Set Chrome path if Chrome was installed
+RUN if [ "$INSTALL_CHROME" = "true" ]; then \
+        echo "chromium found at $(which chromium)" && \
+        echo "Set DONGHOST_CHROME=/usr/bin/chromium for browser escalation"; \
+    fi
+
+# Healthcheck: verify binary responds to version check
+HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
+    CMD donsetch --version || exit 1
+
+# Run the MCP server on stdio with crash-only supervisor.
+CMD ["donsetch", "mcp", "--supervised"]

--- a/README.md
+++ b/README.md
@@ -176,6 +176,91 @@ Binary lands at `target/release/donsetch`. First build takes ~2 min (compiling B
 
 </details>
 
+### Option 5 — Docker
+
+For isolated deployment, a consistent runtime environment, and easy updates:
+
+```bash
+git clone https://github.com/dondai44423/donsetch.git
+cd donsetch
+docker compose build
+```
+
+**Optional build choice — Chromium.** The default image excludes
+Chromium; tier 2 browser escalation only activates when a browser is
+configured. To bake Chromium in (~+350MB) for tier 2 bot-wall bypass:
+
+```bash
+docker build --build-arg INSTALL_CHROME=true -t donsetch-mcp .
+```
+
+Then point the server at it at runtime with
+`-e DONGHOST_CHROME=/usr/bin/chromium` (the bundled compose file ships
+this as a commented entry).
+
+**stdio (default transport).** MCP clients launch the server as a
+subprocess:
+
+```bash
+docker run -i --rm --init donsetch-mcp donsetch mcp --supervised
+```
+
+stdio MCP client config (Docker flavor):
+
+```json
+{
+  "mcpServers": {
+    "donsetch": {
+      "command": "docker",
+      "args": ["run", "-i", "--rm", "--init", "donsetch-mcp", "donsetch", "mcp", "--supervised"]
+    }
+  }
+}
+```
+
+OpenCode uses a stricter MCP schema — a `type` discriminator, a single
+`command` array, and an explicit `enabled` — in
+`~/.config/opencode/opencode.json`:
+
+```json
+{
+  "mcp": {
+    "donsetch": {
+      "type": "local",
+      "command": ["docker", "run", "-i", "--rm", "--init", "donsetch-mcp", "donsetch", "mcp", "--supervised"],
+      "enabled": true,
+      "timeout": 120000
+    }
+  }
+}
+```
+
+`timeout` is optional but recommended: OpenCode defaults MCP requests
+to 5 seconds, and tier 1 fetches regularly run longer.
+
+Or via the bundled compose service (adds the persistent cache volume
+and resource limits):
+
+```bash
+docker compose run --rm donsetch
+```
+
+**Docker Compose options.** The bundled `docker-compose.yml`:
+
+- A cache volume persisting fetch/search state across restarts.
+- A 2GB memory ceiling (OCR + reranking peak around 1–2GB under heavy
+  crawls) and an init process to reap zombies.
+- A 45-second stop grace period so in-flight tier-2 fetches finish on
+  `docker compose stop`.
+
+**Architecture notes.** Multi-stage build (`rust:slim` →
+`debian:trixie-slim`, kept on the same glibc generation — ort-sys's
+prebuilt ONNX Runtime needs glibc 2.38+ symbols on both sides), all
+features enabled, PDFium acquired at build time by the repo's own
+`build.rs` (sha256-verified), Go installed per-target-arch for
+BoringSSL's build system (amd64 and arm64). Single ~36MB binary in a
+minimal runtime image — no Python, no Playwright.
+
 ---
 
 ## 🔀 HTTP Proxy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,60 @@
+# DonSeTch MCP server — docker compose
+#
+# stdio mode, for MCP clients that launch the server as a subprocess
+# (Claude Code, Cursor, etc.):
+#
+#   docker compose build
+#   docker compose run --rm donsetch
+#
+# and point your MCP client at the wrapper command:
+#   docker run -i --rm donsetch-mcp donsetch mcp --supervised
+
+services:
+  donsetch:
+    build:
+      context: .
+      # Uncomment to include Chrome for tier 2 browser escalation:
+      # args:
+      #   INSTALL_CHROME: "true"
+    image: donsetch-mcp:latest
+    container_name: donsetch
+
+    environment:
+      # ── Fetch/search tuning ─────────────────────────────────────
+      # Optional: disable disk persistence for self-improving fetch state
+      # DONSEEK_NO_DISK_STATE: "1"
+
+      # Optional: Chrome path for tier 2 browser escalation
+      # (if built with INSTALL_CHROME=true)
+      # DONGHOST_CHROME: "/usr/bin/chromium"
+
+      # Optional: search proxy rotation (comma-separated)
+      # DONSEEK_PROXIES: "http://proxy1:8080,socks5://proxy2:1080"
+
+      NO_COLOR: "1"
+
+    # Room to finish long in-flight tier-2 fetches on
+    # `docker compose stop` before the SIGKILL.
+    stop_grace_period: 45s
+
+    # Reap zombie processes (PID 1 init).
+    init: true
+
+    volumes:
+      # Persist the fetch/search cache and ghost browser profile across runs
+      - donsetch-cache:/home/donsetch/.cache/donsetch
+
+    # DNS settings to avoid ad-blocking interference if needed
+    # dns:
+    #   - 1.1.1.1
+    #   - 9.9.9.9
+
+    # Memory ceiling: OCR + semantic reranking peak around 1-2GB
+    # under heavy crawls. Adjust to taste; 2g is a comfortable ceiling.
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+
+volumes:
+  donsetch-cache:


### PR DESCRIPTION
**Summary**

Adds a production Docker image and a compose service running the MCP server on stdio, so MCP clients can use the server without a local Rust toolchain.
- Multi-stage rust:slim builder → debian:trixie-slim runtime on the same glibc generation (the ort-sys prebuilt archives reference glibc 2.38+ symbols); arch-aware Go install for BoringSSL (amd64/arm64 via TARGETARCH); builds all features --locked to Cargo.lock; non-root runtime user (uid 1000).
- **PDFium pre-fetch:** build.rs sha256-pins and downloads the PDFium static archive, but its curl path gives up on a single mid-transfer reset (curl 35 is not retried without --retry-all-errors). The Dockerfile pre-fetches it with aggressive retries (8 attempts, all errors, stall detection) and verifies the same KNOWN_HASHES pins, keeping builds fail-closed on flaky networks.
- **ONNX shared library shipping:** since 3.2.5, ort loads ONNX Runtime dynamically — build.rs builds vendor/onnx/libonnxruntime.so and the binary dlopens it at runtime, searching next to the executable first. The image stages and ships the .so next to the binary so OCR/rerank work in-container (verified: donsetch doctor reports ONNX Runtime — AVX detected, shared library present). On arm64, where no ONNX prebuilt exists, the staged dir is empty, the copy is a no-op, and the features self-disable at runtime instead of failing the build. Only the .so is staged, not the large static archive that also lives in vendor/onnx.
- **Cache volume ownership:** the cache dir is created and chowned in the image *before* the VOLUME declaration — without that, fresh volumes get a root-owned mountpoint and the non-root user can neither write the fetch cache nor download the rerank model on first use.
- DONGHOST_NO_SANDBOX=1 is set by default: Chromium's sandbox cannot initialize inside a default Docker container (no unprivileged user namespaces) and the browser dies before the DevTools handshake. The container boundary + non-root user provide the isolation. This is upstream's documented escape hatch ("only use in isolated containers").
- Optional INSTALL_CHROME=true build arg for tier 2 browser escalation (chromium + xvfb, ~350 MB).
- compose: persistent cache volume, 2 GB memory ceiling, init for zombie reaping, 45 s stop grace period.

Heads-up: this PR and the HTTP transport PR both add an entry under ## [Unreleased] in CHANGELOG.md; whichever merges second gets a trivial 3-line conflict there.

**Type**

- [x] feat — new feature

**Checks**

- [x] cargo test --features ocr,rerank passes
- [x] cargo clippy --all-targets --features ocr,rerank -- -Dwarnings passes
- [x] cargo fmt --all -- --check passes
- [ ] CI is green on all 3 platforms (Linux, macOS, Windows)

No Rust sources are touched (Dockerfile, compose, .dockerignore, README, CHANGELOG), but the gates were run on this tree.

**Breaking changes**

None.

**Test plan**

Built on linux/amd64 and validated in-container, driven as a real stdio MCP client (stdin held open, --supervised):

- initialize / tools/list OK (web_fetch, web_search, web_crawl).
- web_fetch https://example.com → 200, tier 1, content_ok: true.
- web_search → results with minted S-handles; web_fetch via S-handle resolves prewarmed in ~6 ms; fabricated handle SZZZZZZ99 rejected.
- donsetch doctor in the image: ✓ ONNX Runtime — AVX detected, shared library present; stderr shows [onnx] Runtime loaded from /usr/local/bin/libonnxruntime.so.
- Fresh cache volume: rerank model + tokenizer download and cache under the non-root user (model cached. tokenizer cached.).