### PR TITLE
feat(docker): enable the http transport in the image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to DonSeTch are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **HTTP transport in the Docker image.** The image now builds `--features ocr,rerank,http` (matching the linux-x64/macOS-arm64/Windows-x64 release binaries), `EXPOSE`s 8765, and the bundled compose file gains an opt-in `http` profile: `docker compose --profile http up -d donsetch-http` serves MCP at `http://localhost:8765/mcp` with a listener-based healthcheck. The port is published on `127.0.0.1` by default so an unset `DONSETCH_HTTP_TOKEN` never exposes unauthenticated MCP to the LAN. The stdio service is unchanged.
+
 ## [3.4.0] - 2026-08-28
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **HTTP transport in the Docker image.** The image now builds `--features ocr,rerank,http` (matching the linux-x64/macOS-arm64/Windows-x64 release binaries), `EXPOSE`s 8765, and the bundled compose file gains an opt-in `http` profile: `docker compose --profile http up -d donsetch-http` serves MCP at `http://localhost:8765/mcp` with a listener-based healthcheck. The port is published on `127.0.0.1` by default so an unset `DONSETCH_HTTP_TOKEN` never exposes unauthenticated MCP to the LAN. The stdio service is unchanged.
+- **HTTP transport in the Docker image.** The image now builds `--features ocr,rerank,http` (matching the linux-x64/macOS-arm64/Windows-x64 release binaries), `EXPOSE`s 8765, and the bundled compose file gains an opt-in `http` profile: `docker compose --profile http up -d donsetch-http` serves MCP at `http://localhost:8765/mcp` with a listener-based healthcheck. The profiled service carries its own `build:` block (it builds the image if it isn't there yet) and `restart: unless-stopped` (Docker-level crash recovery — the HTTP transport has no in-process supervisor). The port is published on `127.0.0.1` by default so an unset `DONSETCH_HTTP_TOKEN` never exposes unauthenticated MCP to the LAN. The stdio service is unchanged.
 
 ## [3.4.0] - 2026-08-28
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -102,7 +102,10 @@ RUN set -eu; \
 
 # Build all features (OCR + semantic reranking), locked to Cargo.lock
 ENV CARGO_TERM_COLOR=always
-RUN cargo build --release --features ocr,rerank --locked
+# All three features: ocr + rerank (ONNX) and http (axum/tower-http
+# streamable-HTTP transport, same set as the linux-x64/macOS-arm64/
+# Windows-x64 release binaries).
+RUN cargo build --release --features ocr,rerank,http --locked
 
 # Stage the ONNX Runtime shared library for the runtime image. Since
 # 3.2.5, ort loads ONNX Runtime dynamically: when ocr/rerank are
@@ -186,5 +189,11 @@ RUN if [ "$INSTALL_CHROME" = "true" ]; then \
 HEALTHCHECK --interval=30s --timeout=5s --start-period=5s --retries=3 \
     CMD donsetch --version || exit 1
 
+# Port for the HTTP transport (compose activates it via
+# DONSETCH_TRANSPORT=http in the http profile).
+EXPOSE 8765
+
 # Run the MCP server on stdio with crash-only supervisor.
+# HTTP mode: docker run -d -p 127.0.0.1:8765:8765 \
+#   -e DONSETCH_TRANSPORT=http -e DONSETCH_HTTP_HOST=0.0.0.0 donsetch-mcp
 CMD ["donsetch", "mcp", "--supervised"]

--- a/README.md
+++ b/README.md
@@ -251,7 +251,11 @@ docker compose run --rm donsetch
 stdio service above is unchanged), and MCP clients connect to
 `http://localhost:8765/mcp`. The port is published on `127.0.0.1` by
 default — set `DONSETCH_HTTP_TOKEN` before exposing it further (see
-the HTTP transport env vars in the MCP section).
+the HTTP transport env vars in the MCP section). The service carries
+`restart: unless-stopped`: the binary is `panic = "abort"` in release
+and the HTTP transport has no in-process supervisor (that's stdio
+`--supervised`), so Docker is the crash recovery — a panicking request
+restarts the container instead of leaving it down.
 
 **Docker Compose options.** The bundled `docker-compose.yml`:
 
@@ -261,7 +265,7 @@ the HTTP transport env vars in the MCP section).
 - A 45-second stop grace period so in-flight tier-2 fetches finish on
   `docker compose stop`.
 - An opt-in `http` profile running the same image as a long-lived
-  HTTP server (see above).
+  HTTP server with `restart: unless-stopped` (see above).
 
 **Architecture notes.** Multi-stage build (`rust:slim` →
 `debian:trixie-slim`, kept on the same glibc generation — ort-sys's

--- a/README.md
+++ b/README.md
@@ -246,6 +246,13 @@ and resource limits):
 docker compose run --rm donsetch
 ```
 
+**HTTP transport.** The image also serves the HTTP transport:
+`docker compose --profile http up -d donsetch-http` starts it (the
+stdio service above is unchanged), and MCP clients connect to
+`http://localhost:8765/mcp`. The port is published on `127.0.0.1` by
+default — set `DONSETCH_HTTP_TOKEN` before exposing it further (see
+the HTTP transport env vars in the MCP section).
+
 **Docker Compose options.** The bundled `docker-compose.yml`:
 
 - A cache volume persisting fetch/search state across restarts.
@@ -253,11 +260,15 @@ docker compose run --rm donsetch
   crawls) and an init process to reap zombies.
 - A 45-second stop grace period so in-flight tier-2 fetches finish on
   `docker compose stop`.
+- An opt-in `http` profile running the same image as a long-lived
+  HTTP server (see above).
 
 **Architecture notes.** Multi-stage build (`rust:slim` →
 `debian:trixie-slim`, kept on the same glibc generation — ort-sys's
-prebuilt ONNX Runtime needs glibc 2.38+ symbols on both sides), all
-features enabled, PDFium acquired at build time by the repo's own
+prebuilt ONNX Runtime needs glibc 2.38+ symbols on both sides), built
+with `--features ocr,rerank,http` (the same feature set as the
+linux-x64, macOS-arm64, and Windows-x64 release binaries), PDFium
+acquired at build time by the repo's own
 `build.rs` (sha256-verified), Go installed per-target-arch for
 BoringSSL's build system (amd64 and arm64). Single ~36MB binary in a
 minimal runtime image — no Python, no Playwright.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,19 @@
 # DonSeTch MCP server — docker compose
 #
-# stdio mode, for MCP clients that launch the server as a subprocess
-# (Claude Code, Cursor, etc.):
+# stdio mode (default), for MCP clients that launch the server as a
+# subprocess (Claude Code, Cursor, etc.):
 #
 #   docker compose build
 #   docker compose run --rm donsetch
 #
 # and point your MCP client at the wrapper command:
 #   docker run -i --rm donsetch-mcp donsetch mcp --supervised
+#
+# HTTP mode (the `http` profile below), for remote/debug use:
+#
+#   docker compose --profile http up -d donsetch-http
+#   curl http://localhost:8765/health
+#   MCP clients connect to: http://localhost:8765/mcp
 
 services:
   donsetch:
@@ -51,6 +57,47 @@ services:
 
     # Memory ceiling: OCR + semantic reranking peak around 1-2GB
     # under heavy crawls. Adjust to taste; 2g is a comfortable ceiling.
+    deploy:
+      resources:
+        limits:
+          memory: 2g
+
+  # ── HTTP transport (opt-in profile) ─────────────────────────────
+  # docker compose --profile http up -d donsetch-http
+  # Serves MCP at http://localhost:8765/mcp (streamable-HTTP).
+  # Same image and cache volume as the stdio service; only the
+  # transport differs. See README → "HTTP transport" for the env vars.
+  donsetch-http:
+    profiles: ["http"]
+    image: donsetch-mcp:latest
+    container_name: donsetch-http
+    environment:
+      DONSETCH_TRANSPORT: "http"
+      # Listen on all interfaces inside the container; the published
+      # port below decides who can actually reach it.
+      DONSETCH_HTTP_HOST: "0.0.0.0"
+      # Require `Authorization: Bearer <token>` on /mcp — set this
+      # before publishing the port beyond localhost. /health stays
+      # open for probes.
+      # DONSETCH_HTTP_TOKEN: "change-me"
+      NO_COLOR: "1"
+    # Bound to 127.0.0.1 by default so an unset DONSETCH_HTTP_TOKEN
+    # never publishes unauthenticated MCP to the LAN. To serve remote
+    # clients, change to "8765:8765" AND set DONSETCH_HTTP_TOKEN.
+    ports:
+      - "127.0.0.1:8765:8765"
+    # Prove the listener (not just the binary) is up. bash /dev/tcp
+    # because the slim runtime image has no curl/wget.
+    healthcheck:
+      test: ["CMD", "bash", "-c", "</dev/tcp/127.0.0.1/8765"]
+      interval: 30s
+      timeout: 3s
+      retries: 3
+      start_period: 5s
+    stop_grace_period: 45s
+    init: true
+    volumes:
+      - donsetch-cache:/home/donsetch/.cache/donsetch
     deploy:
       resources:
         limits:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -69,6 +69,14 @@ services:
   # transport differs. See README → "HTTP transport" for the env vars.
   donsetch-http:
     profiles: ["http"]
+    # Own build block so `--profile http up -d donsetch-http` works on
+    # machines that haven't built the image yet (otherwise compose tries
+    # to pull donsetch-mcp from Docker Hub and fails).
+    build:
+      context: .
+      # Uncomment to include Chrome for tier 2 browser escalation:
+      # args:
+      #   INSTALL_CHROME: "true"
     image: donsetch-mcp:latest
     container_name: donsetch-http
     environment:
@@ -94,6 +102,12 @@ services:
       timeout: 3s
       retries: 3
       start_period: 5s
+    # Crash recovery: the binary is panic=abort in release and the HTTP
+    # transport has no in-process supervisor (that's stdio
+    # `--supervised`) — one panicking request aborts the process, so
+    # Docker restarts the container. `unless-stopped` keeps a manual
+    # `docker compose stop` stopped.
+    restart: unless-stopped
     stop_grace_period: 45s
     init: true
     volumes:


### PR DESCRIPTION
## Summary

Refs #67 — the Docker repro there (image built `--features ocr,rerank`, `mcp --http` answering over stdio) goes away at the root once the image builds with the feature.

The image was the only distribution building without the `http` feature — the natural deployment for a remote transport (a container) was the one build that couldn't serve it. This builds the image with `--features ocr,rerank,http --locked`, matching the linux-x64/macOS-arm64/Windows-x64 release binaries.

- `EXPOSE 8765` + a `docker run` HTTP-mode comment; stdio stays the default CMD.
- compose: an opt-in `http` profile (`donsetch-http`) running the same image with `DONSETCH_TRANSPORT=http` and `DONSETCH_HTTP_HOST=0.0.0.0` in-container. The port is published on `127.0.0.1:8765` by default so an unset `DONSETCH_HTTP_TOKEN` never exposes unauthenticated MCP to the LAN — switch to `8765:8765` together with a token to serve remote clients. Listener-based healthcheck (bash `/dev/tcp` — the slim runtime image has no curl/wget). The existing stdio service is untouched.
- README: the Docker section (Option 5) documents the HTTP mode and the profile; architecture notes updated to the three-feature build.

Measured build-time delta from adding axum + tower-http: **3m 43s** on a warm cache (baseline cold release build `--features ocr,rerank`: 6m 53s; no-op rebuild after: 0.45s, so the cache does the work once).

Self-contained — deliberately not stacked on the docs PR for #66 (they touch different README regions, so either can land first). The only shared file region is the CHANGELOG's `[Unreleased]` heading; if #66's PR lands first this may need a one-line de-dup on rebase, happy to do that on request.

## Type

- [x] `feat` — new feature

## Checks

- [x] `cargo test --features ocr,rerank` passes (no Rust sources touched: Dockerfile, compose, README, CHANGELOG)
- [x] `cargo clippy --all-targets --features ocr,rerank -- -Dwarnings` passes
- [x] `cargo fmt --all -- --check` passes
- [ ] CI is green on all 3 platforms (Linux, macOS, Windows)

## Breaking changes

None — stdio remains the default CMD and the default compose flow is unchanged.

## Test plan

Built the image on linux/amd64 (`cargo build --release --features ocr,rerank,http --locked` confirmed in the build log) and drove the compose `http` profile with docker compose v2:

- `docker compose config --profiles` lists `http`; `--profile http up -d donsetch-http` starts **only** the HTTP service — the stdio service is not pulled into `up`.
- `GET /health` → 200 from outside the container; the compose healthcheck flips the container to `healthy`.
- `POST /mcp initialize` → 200 + `Mcp-Session-Id` header; `notifications/initialized` → 202; `tools/list` with the session header → full tool surface.
- Auth gate with `DONSETCH_HTTP_TOKEN` set: no bearer → 401, wrong bearer → 401, right bearer → 200, `/health` stays open.
- `docker compose --profile http down` tears down cleanly; the stdio flow (`docker compose run --rm donsetch`) is untouched by the profile.
