### PR TITLE
fix(mcp): fail loudly when --http is requested but the feature isn't compiled in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to DonSeTch are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Loud failure for `--http` without the feature.** In a binary built without the `http` cargo feature (the linux-arm64 and macOS-x64 prebuilts, and any plain `cargo build`), `donsetch mcp --http` and `DONSETCH_TRANSPORT=http` silently fell through to stdio — a client configured for HTTP would hang waiting on a listener that never came up. Both paths now exit immediately with an error naming the missing cargo feature and how to get a binary that includes it.
+
 ## [3.4.0] - 2026-08-28
 
 ### Added

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,6 +42,21 @@ async fn main() {
                 }
                 return;
             }
+            // Without the `http` cargo feature the checks above compile
+            // out, so a requested HTTP transport would silently fall
+            // through to stdio — fail loudly instead. (The linux-arm64
+            // and macOS-x64 prebuilt binaries are core-only.)
+            #[cfg(not(feature = "http"))]
+            if args.iter().any(|a| a == "--http")
+                || std::env::var("DONSETCH_TRANSPORT").as_deref() == Ok("http")
+            {
+                eprintln!(
+                    "mcp: HTTP transport requested (--http / DONSETCH_TRANSPORT=http), but this \
+                     binary was built without the `http` cargo feature. Rebuild with \
+                     --features http, or use a prebuilt binary that includes it."
+                );
+                std::process::exit(1);
+            }
             let _ = std::env::var("DONSETCH_TRANSPORT");
             if args.iter().any(|a| a == "--supervised") {
                 // v3 crash-only design: `--supervised` spawns a child


### PR DESCRIPTION
## Summary

Fixes #67 (the primary ask; the secondary question there — hard error vs warning on unrecognized `mcp` flags generally — is deliberately out of scope pending your call).

In a build without the `http` cargo feature (the linux-arm64 and macOS-x64 prebuilts, and any plain `cargo build`), the transport-selection block in `src/main.rs` compiles out entirely — `donsetch mcp --http` and `DONSETCH_TRANSPORT=http` silently fall through to stdio. A client configured for HTTP then hangs waiting on a listener that never comes up, and nothing on the server side says why.

The `#[cfg(not(feature = "http"))]` counterpart now checks both entry paths and exits with:

```
mcp: HTTP transport requested (--http / DONSETCH_TRANSPORT=http), but this
binary was built without the `http` cargo feature. Rebuild with
--features http, or use a prebuilt binary that includes it.
```

Builds with the feature are unchanged; plain `mcp` and `--supervised` are untouched.

## Type

- [x] `fix` — bug fix

## Checks

- [x] `cargo test --features ocr,rerank` passes
- [x] `cargo clippy --all-targets --features ocr,rerank -- -Dwarnings` passes
- [x] `cargo fmt --all -- --check` passes
- [ ] CI is green on all 3 platforms (Linux, macOS, Windows)

Also gated beyond CI's configs: `cargo clippy --all-targets -- -Dwarnings` on the default (no features) build — the configuration where the guard actually compiles — and with `--features ocr,rerank,http`; `cargo test` on the default build (676 passed).

## Breaking changes

None for binaries that include the feature. A no-feature binary launched with `--http` now exits 1 instead of silently serving stdio — that is the fix.

## Test plan

Behavioral, against dev-profile binaries on linux-x64:

- Default build (no features) + `mcp --http --host 127.0.0.1 --port 9999` → the error above, exit 1.
- Default build + `DONSETCH_TRANSPORT=http mcp` → same, exit 1.
- Default build + plain `mcp` → stdio behavior unchanged (clean EOF exit).
- `--features http` build + `--http` → listener up, `GET /health` → 200; SIGTERM drains in-flight requests and shuts down cleanly.
