### PR TITLE
feat(dev): --links/--media flags for `dev extract`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to DonSeTch are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`--links`/`--media` flags for `dev extract`:** expose `include_links` and `include_media` on the local-file extraction command, matching the `links`/`media` parameters of the `fetch` tool. Both default off (token savers), so link/media rendering issues could not be reproduced offline before. The usage line now also documents the existing `--url` flag.
+
 ## [3.4.0] - 2026-08-28
 
 ### Added

--- a/src/dev.rs
+++ b/src/dev.rs
@@ -51,6 +51,12 @@ async fn extract_cmd(args: &[String]) {
                 i += 1;
                 opts.selector = args.get(i).cloned();
             }
+            "--links" => {
+                opts.include_links = true;
+            }
+            "--media" => {
+                opts.include_media = true;
+            }
             "--input" => {
                 i += 1;
                 input_file = args.get(i).cloned();
@@ -65,7 +71,7 @@ async fn extract_cmd(args: &[String]) {
     }
     let Some(path) = input_file else {
         eprintln!(
-            "usage: donsetch dev extract --input <file> [--focus q] [--max n] [--offset n] [--selector css]"
+            "usage: donsetch dev extract --input <file> [--url base] [--focus q] [--max n] [--offset n] [--selector css] [--links] [--media]"
         );
         return;
     };


### PR DESCRIPTION


## Summary

Both extraction options default off as token savers, so `dev extract` could not reproduce link/media rendering offline — e.g. the output quoted in issue #74 required patching the source to verify. Flags mirror the fetch tool's `links`/`media` params. Usage line now also documents the existing --url flag.

## Type

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — deps, CI, tooling
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only

## Checks

- [x] `cargo test --features ` passes (676+4 tests) ( didn't test ocr,rerank features as this commit is not from branch with #68 fix)
- [x] `cargo clippy --all-targets --features ocr,rerank -- -Dwarnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes
- [ ] CI is green on all 3 platforms (Linux, macOS, Windows)

## Breaking changes

none

## Test plan

`donsetch dev extract  --links --media --input path-to-file.html`
