### PR TITLE
perf(search): keep semantic reranking off async workers

### DIFF
--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -110,6 +110,22 @@ pub struct Searcher {
     prewarms: std::sync::Arc<std::sync::Mutex<PrewarmCache>>,
 }
 
+#[cfg(feature = "rerank")]
+/// Run synchronous ranking outside Tokio's async worker set.
+///
+/// Semantic reranking can enter ONNX inference and wait on the shared session
+/// mutex. The ranking API stays synchronous, so the blocking pool is the narrow
+/// boundary that keeps unrelated async work progressing.
+async fn run_blocking_ranking<F, T>(job: F) -> Result<T, FetchError>
+where
+    F: FnOnce() -> T + Send + 'static,
+    T: Send + 'static,
+{
+    tokio::task::spawn_blocking(job)
+        .await
+        .map_err(|e| FetchError::Http(format!("search: ranking worker failed: {e}")))
+}
+
 /// v3 F1: search→fetch warm handoff store.
 pub struct PrewarmCache {
     entries: HashMap<String, PrewarmEntry>,
@@ -602,6 +618,15 @@ impl Searcher {
         // max_results for the response. Without this, a first
         // search with max=2 caches only 2 results, and a later
         // search with max=10 returns the stale 2 from cache.
+        // With semantic reranking enabled, merge includes synchronous ONNX
+        // inference. Core builds keep the existing inline fast path below.
+        #[cfg(feature = "rerank")]
+        let mut results = {
+            let query = query.to_string();
+            run_blocking_ranking(move || rank::merge(&per_engine, &query, intent, &trust, 12))
+                .await?
+        };
+        #[cfg(not(feature = "rerank"))]
         let mut results = rank::merge(&per_engine, query, intent, &trust, 12);
         let weak = rank::is_weak(&results, total);
 
@@ -1255,6 +1280,22 @@ impl Drop for InflightGuard<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(feature = "rerank")]
+    #[tokio::test(flavor = "current_thread")]
+    async fn blocking_ranking_keeps_the_async_executor_responsive() {
+        let (tick_sender, tick_receiver) = std::sync::mpsc::channel();
+
+        let (worker_result, ()) = tokio::join!(
+            run_blocking_ranking(move || tick_receiver.recv_timeout(Duration::from_secs(1))),
+            async {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+                tick_sender.send(()).expect("blocking worker should wait");
+            }
+        );
+
+        assert!(worker_result.expect("blocking job should join").is_ok());
+    }
 
     #[test]
     fn governor_shrinks_width_under_stress() {


### PR DESCRIPTION
### Summary

With the `rerank` feature enabled, `rank::merge` enters synchronous ONNX
inference from the async search path. Under concurrent searches, one Tokio
worker runs inference while another can block on the shared ONNX session mutex,
leaving unrelated timers and I/O without an executor worker.

This change moves that existing synchronous ranking call to Tokio's blocking
pool. It deliberately keeps the ranking pipeline, result order, ONNX session,
thread configuration, and concurrency policy unchanged. Builds without
`rerank` retain the current inline fast path.

### Execution path

```mermaid
flowchart LR
  subgraph before["Before: synchronous ranking on an async worker"]
    direction LR
    A1["Search future<br/>Tokio worker"] --> B1["rank::merge<br/>RRF · BM25 · priors"]
    B1 --> C1["ONNX session mutex"]
    C1 --> D1["ONNX inference"]
    D1 --> E1["coverage · authority · diversity"]
    E1 --> F1["ranked results"]
    D1 -. "worker remains occupied" .-> G1["timers and I/O may stall<br/>when workers are saturated"]
  end

  subgraph after["After: same ranking on Tokio's blocking pool"]
    direction LR
    A2["Search future<br/>Tokio worker"] -->|"spawn_blocking + await"| B2["Blocking pool worker"]
    A2 -. "worker returns to scheduler" .-> G2["timers and I/O continue"]
    B2 --> C2["same rank::merge<br/>RRF · BM25 · priors"]
    C2 --> D2["same ONNX session mutex"]
    D2 --> E2["same ONNX inference"]
    E2 --> F2["same coverage · authority · diversity"]
    F2 -->|"JoinHandle result"| H2["search future resumes<br/>with identical ranked results"]
  end
```

### Type

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — deps, CI, tooling
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only

### Why this shape

I tested a few more elaborate alternatives before settling on this version:

- a dedicated ranking thread plus channel would duplicate lifecycle, shutdown,
  cancellation, and queue policy that Tokio's blocking pool already provides;
- an async semaphore before the blocking pool recovered only a few milliseconds
  in some saturated runs, was not consistent across repeated series, and would
  add a new global serialization policy even though the ONNX session mutex
  already serializes inference;
- `block_in_place` stayed responsive and occasionally saved a few milliseconds,
  but it requires a multi-thread runtime and can create replacement executor
  workers, making it a poor fit for inference plus mutex wait time;
- splitting `rank::merge` around only the ONNX call would make the patch much
  more invasive for a sub-millisecond-per-request opportunity.

The small `spawn_blocking` boundary achieved the actual goal without adding a
second scheduler or changing ranking semantics.

### Benchmark

Measured on DonSeTch `v3.4.2` in a Linux x86-64 container limited to 2 CPUs,
3 GiB memory, and two Tokio workers. The harness used the real ONNX Runtime and
MiniLM reranker, warmed the model before measurement, and ran balanced direct /
offloaded rounds over deterministic inputs.

For one ranking job, there was no measurable latency penalty:

| Path | Wall mean | CPU mean | Mean max heartbeat gap |
|---|---:|---:|---:|
| direct | 83.60 ms | 169.11 ms | 2.34 ms |
| `spawn_blocking` | 81.15 ms | 164.15 ms | 2.66 ms |

For eight concurrent ranking jobs (20 samples per path):

| Path | Wall mean | CPU mean | Mean max heartbeat gap | Worst gap |
|---|---:|---:|---:|---:|
| direct | 676.40 ms | 1,351.53 ms | 573.53 ms | 674.03 ms |
| `spawn_blocking` | 681.30 ms | 1,364.02 ms | 3.49 ms | 6.30 ms |

That is a 99.39% reduction in the mean maximum executor stall. The saturated
batch cost was 4.9 ms total, about 0.61 ms per ranking job, with a 0.92% CPU
difference. A separate earlier 20-sample series showed the same large stall
reduction.

Every mode and round produced the same SHA-256 digest over result title, URL,
and exact `f64::to_bits` score:

```text
000c1920354ee404831beb2313be7efc7eead766c47765151ba627034f2126ab
```

### Checks

- [x] `cargo test --features ocr,rerank` passes
- [x] `cargo clippy --all-targets --features ocr,rerank -- -Dwarnings` passes
- [x] `cargo fmt --all -- --check` passes
- [ ] CI is green on all platforms

Additional Linux release-profile evidence with `ocr,rerank,http`:

- 713 unit tests passed;
- soak test passed;
- 4 token-invariant tests passed;
- exact current-thread regression test passed;
- release-profile Clippy passed with zero warnings.

The regression test runs on a single-thread Tokio runtime. Its blocking closure
waits for a signal sent by an async timer. If ranking is accidentally moved back
onto the async worker, the signal cannot run and the test times out; through the
blocking pool it completes immediately.

### Breaking changes

None. Tool schemas, output, ranking order, feature behavior, and configuration
remain unchanged.

### Test plan

1. Build with and without the `rerank` feature.
2. Run the current-thread responsiveness regression test.
3. Run the complete `ocr,rerank,http` suite and Clippy.
4. Exercise real ONNX inference under a two-worker, two-CPU container.
5. Compare direct and offloaded output digests and runtime heartbeat latency.
