### PR TITLE
feat(search): add SerpApi as a BYOK search provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **SerpApi BYOK provider:** `donsetch keys add serpapi <key>` wires
+  up [SerpApi](https://serpapi.com) as a Google-SERP BYOK backend,
+  alongside the existing Serper.dev provider. Routes by intent like
+  the other providers: `google_scholar` engine for paper queries,
+  `tbm=nws` for news.
+
 ### Fixed
 
 - **Xvfb install hint printed on macOS/Windows every session

--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ required:
 donsetch keys add tavily tvly-...       # Tavily
 donsetch keys add exa sk-exa-...        # Exa (stackable)
 donsetch keys add serper ...            # Serper.dev
+donsetch keys add serpapi ...           # SerpApi
 donsetch keys add tinyfish sk-...       # TinyFish (free tier)
 donsetch keys add parallel nKil3...     # Parallel AI (fast mode)
 donsetch keys add bd 576d013c...        # Bright Data SERP

--- a/src/cli/keys.rs
+++ b/src/cli/keys.rs
@@ -9,7 +9,7 @@
 //!   donsetch keys import <path>            Import keys from a file
 //!   donsetch keys clear                     Remove all keys
 //!
-//! Providers: tavily, exa, serper, tinyfish, parallel, brightdata, unlocker
+//! Providers: tavily, exa, serper, serpapi, tinyfish, parallel, brightdata, unlocker
 
 use super::{bold, dim, green, red};
 
@@ -465,6 +465,7 @@ fn print_help() {
     println!("    tavily     Tavily Search API (api.tavily.com)");
     println!("    exa        Exa AI Search (api.exa.ai)");
     println!("    serper     Serper.dev Google SERP (google.serper.dev)");
+    println!("    serpapi    SerpApi Google SERP (serpapi.com)");
     println!("    tinyfish   TinyFish Search (api.search.tinyfish.ai)");
     println!("    parallel   Parallel AI Search (api.parallel.ai) — fast mode");
     println!("    brightdata Bright Data SERP API (api.brightdata.com)");

--- a/src/search/byok/mod.rs
+++ b/src/search/byok/mod.rs
@@ -1,7 +1,7 @@
 //! Bring Your Own Keys (BYOK) — provider search with key rotation.
 //!
 //! When the user configures API keys for external search providers
-//! (Tavily, Exa, Serper.dev, TinyFish, Parallel AI, Bright Data), the entire local 5-engine
+//! (Tavily, Exa, Serper.dev, SerpApi, TinyFish, Parallel AI, Bright Data), the entire local 5-engine
 //! search system is bypassed. The provider handles everything:
 //! search, IP, rate limiting. DonSeTch just sends the query and
 //! normalizes the results.
@@ -16,6 +16,7 @@
 mod brightdata;
 mod exa;
 mod parallel;
+mod serpapi;
 mod serper;
 pub mod store;
 mod tavily;
@@ -254,6 +255,7 @@ async fn dispatch(
         "tavily" => tavily::search(client, key, query, max, intent).await,
         "exa" => exa::search(client, key, query, max, intent).await,
         "serper" => serper::search(client, key, query, max, intent).await,
+        "serpapi" => serpapi::search(client, key, query, max, intent).await,
         "tinyfish" => tinyfish::search(client, key, query, max, intent).await,
         "parallel" => parallel::search(client, key, query, max, intent).await,
         "brightdata" => brightdata::search(client, key, query, max, intent).await,

--- a/src/search/byok/serpapi.rs
+++ b/src/search/byok/serpapi.rs
@@ -112,6 +112,14 @@ pub async fn search(
     if status == 401 || status == 403 {
         return Err(KeyError::InvalidKey);
     }
+    if status == 402 {
+        return Err(KeyError::CreditDepleted);
+    }
+    // SerpApi is documented to use 429 for both per-second rate
+    // limiting and monthly-plan exhaustion; message-sniffing here
+    // (like serper.rs's generic 4xx branch below) is unverified
+    // against a live account — adjust the substrings if a real
+    // account's wording differs.
     if status == 429 {
         let lower = text.to_lowercase();
         if lower.contains("run out") || lower.contains("plan") || lower.contains("quota") {

--- a/src/search/byok/serpapi.rs
+++ b/src/search/byok/serpapi.rs
@@ -1,0 +1,222 @@
+//! SerpApi (serpapi.com) search provider adapter.
+//!
+//! GET https://serpapi.com/search
+//! Auth: api_key=<key> (query parameter, not a header)
+//! Params: q, engine, num, api_key, [tbm=nws for news]
+//! Response: { organic_results: [{ position, title, link, snippet }] }
+//!           news (tbm=nws) uses `news_results` instead.
+//!           paper intent switches engine to google_scholar, still
+//!           returns `organic_results`.
+
+use std::time::Instant;
+
+use serde_json::Value;
+
+use super::{KeyError, ProviderResult, SearchHit};
+
+const BASE: &str = "https://serpapi.com/search";
+const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Extract hits from the results array named by `key`
+/// (`organic_results` or `news_results`). Pure function so it's
+/// testable without a live API call.
+fn parse_results(json: &Value, key: &str) -> Vec<SearchHit> {
+    json.get(key)
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|r| {
+                    let title = r
+                        .get("title")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string();
+                    let url = r
+                        .get("link")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string();
+                    if url.is_empty() {
+                        return None;
+                    }
+                    let snippet = r
+                        .get("snippet")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string();
+                    let position = r.get("position").and_then(Value::as_u64).unwrap_or(1) as f32;
+                    // SerpApi doesn't return a relevance score;
+                    // derive one from position (1 → ~1.0, 10 → ~0.1).
+                    let score = 1.0 / position.max(1.0);
+                    Some(SearchHit {
+                        title,
+                        url,
+                        snippet,
+                        score,
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+pub async fn search(
+    client: &reqwest::Client,
+    key: &str,
+    query: &str,
+    max: usize,
+    intent: &crate::search::intent::Intent,
+) -> ProviderResult {
+    let started = Instant::now();
+
+    // Route by intent: paper → google_scholar engine, news → the
+    // google engine's news vertical (tbm=nws), else plain google.
+    let mut params = vec![
+        ("q".to_string(), query.to_string()),
+        ("num".to_string(), max.min(10).to_string()),
+        ("api_key".to_string(), key.to_string()),
+    ];
+    let results_key = match intent {
+        crate::search::intent::Intent::Paper => {
+            params.push(("engine".to_string(), "google_scholar".to_string()));
+            "organic_results"
+        }
+        crate::search::intent::Intent::News => {
+            params.push(("engine".to_string(), "google".to_string()));
+            params.push(("tbm".to_string(), "nws".to_string()));
+            "news_results"
+        }
+        _ => {
+            params.push(("engine".to_string(), "google".to_string()));
+            "organic_results"
+        }
+    };
+
+    let resp = client
+        .get(BASE)
+        .query(&params)
+        .timeout(TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| {
+            if e.is_timeout() {
+                KeyError::NetworkError
+            } else {
+                KeyError::UnknownError(format!("network: {e}"))
+            }
+        })?;
+
+    let status = resp.status().as_u16();
+    let text = resp.text().await.unwrap_or_default();
+
+    if status == 401 || status == 403 {
+        return Err(KeyError::InvalidKey);
+    }
+    if status == 429 {
+        let lower = text.to_lowercase();
+        if lower.contains("run out") || lower.contains("plan") || lower.contains("quota") {
+            return Err(KeyError::CreditDepleted);
+        }
+        return Err(KeyError::RateLimited);
+    }
+    if status >= 500 {
+        return Err(KeyError::ServerError(format!("HTTP {status}")));
+    }
+    if status >= 400 {
+        let lower = text.to_lowercase();
+        if lower.contains("invalid") && lower.contains("key") {
+            return Err(KeyError::InvalidKey);
+        }
+        if lower.contains("run out") || lower.contains("quota") || lower.contains("plan") {
+            return Err(KeyError::CreditDepleted);
+        }
+        return Err(KeyError::UnknownError(format!("HTTP {status}: {text}")));
+    }
+
+    let json: Value = serde_json::from_str(&text)
+        .map_err(|e| KeyError::UnknownError(format!("parse error: {e}")))?;
+
+    // SerpApi returns HTTP 200 with an `error` field for some
+    // failure modes (e.g. unsupported engine/param combos) instead
+    // of a non-2xx status.
+    if let Some(err) = json.get("error").and_then(Value::as_str) {
+        let lower = err.to_lowercase();
+        if lower.contains("invalid") && lower.contains("key") {
+            return Err(KeyError::InvalidKey);
+        }
+        return Err(KeyError::UnknownError(err.to_string()));
+    }
+
+    let results = parse_results(&json, results_key);
+
+    let ms = started.elapsed().as_millis() as u64;
+    Ok((results, ms))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_results_organic() {
+        let body = json!({
+            "organic_results": [
+                { "position": 1, "title": "Rust", "link": "https://rust-lang.org", "snippet": "a systems language" },
+                { "position": 2, "title": "Rust book", "link": "https://doc.rust-lang.org/book", "snippet": "the book" },
+            ]
+        });
+        let hits = parse_results(&body, "organic_results");
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].title, "Rust");
+        assert_eq!(hits[0].url, "https://rust-lang.org");
+        assert_eq!(hits[0].snippet, "a systems language");
+        assert!(
+            hits[0].score > hits[1].score,
+            "earlier position scores higher"
+        );
+    }
+
+    #[test]
+    fn parse_results_news_key() {
+        let body = json!({
+            "news_results": [
+                { "position": 1, "title": "Breaking", "link": "https://news.example.com/a", "snippet": "s" },
+            ]
+        });
+        let hits = parse_results(&body, "news_results");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].title, "Breaking");
+    }
+
+    #[test]
+    fn parse_results_drops_entries_without_link() {
+        let body = json!({
+            "organic_results": [
+                { "position": 1, "title": "No URL" },
+                { "position": 2, "title": "Has URL", "link": "https://example.com" },
+            ]
+        });
+        let hits = parse_results(&body, "organic_results");
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].title, "Has URL");
+    }
+
+    #[test]
+    fn parse_results_missing_key_returns_empty() {
+        let body = json!({ "search_metadata": {} });
+        assert!(parse_results(&body, "organic_results").is_empty());
+    }
+
+    #[test]
+    fn parse_results_defaults_missing_position_to_one() {
+        let body = json!({
+            "organic_results": [
+                { "title": "No position field", "link": "https://example.com" },
+            ]
+        });
+        let hits = parse_results(&body, "organic_results");
+        assert_eq!(hits.len(), 1);
+        assert!((hits[0].score - 1.0).abs() < 0.001);
+    }
+}

--- a/src/search/byok/store.rs
+++ b/src/search/byok/store.rs
@@ -26,6 +26,7 @@ pub const PROVIDERS: &[&str] = &[
     "tavily",
     "exa",
     "serper",
+    "serpapi",
     "tinyfish",
     "parallel",
     "brightdata",


### PR DESCRIPTION
## Summary

Adds [SerpApi](https://serpapi.com) as a new BYOK search provider (`donsetch keys add serpapi <key>`), alongside the existing Serper.dev provider. Follows the exact same adapter pattern as `src/search/byok/serper.rs`: intent-based routing (google_scholar engine for paper queries, tbm=nws for news), and the same key-state error classification (invalid/rate-limited/credit-depleted) as the other providers.

Differs from `serper.rs` in one structural way: SerpApi authenticates via an `api_key` query parameter rather than a header — reqwest's `.query()` percent-encodes it safely.

## Type

- [x] `feat` — new feature

## Checks

- [x] `cargo test --lib` passes (703/703, including 5 new unit tests for the JSON-parsing logic in `serpapi.rs`)
- [x] `cargo clippy --lib -- -Dwarnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes
- [ ] `cargo test --features ocr,rerank` / `cargo clippy --all-targets --features ocr,rerank -- -Dwarnings` — not run locally (heavy native/ML deps not set up in my environment); this change only touches `src/search/byok/` and `src/cli/keys.rs`, unrelated to the ocr/rerank features, but I'd appreciate CI confirming the full matrix.
- [ ] CI on all 3 platforms — pending, will watch after opening this PR.

## Breaking changes

None. Purely additive: a new opt-in BYOK provider, registered in `PROVIDERS`/the dispatcher, doesn't touch existing provider behavior.

## Test plan

- Added `parse_results()` as a pure, testable function (mirroring the `parse_key()` convention in `brightdata.rs`, since these HTTP adapters aren't otherwise unit-tested in this codebase) and covered it with 5 unit tests: organic results, news results (different JSON key), entries missing a `link` (dropped), a missing results key (empty output), and a missing `position` field (defaults to score 1.0).
- Confirmed the output `SearchHit` shape is compatible with the existing `to_merged()` dedup/ranking pipeline in `mod.rs` (no changes needed there).
- **Caveat:** I don't have a live SerpApi account, so the HTTP status/error-body classification (particularly the 429 message-sniffing for rate-limit vs. plan-exhaustion, and the "HTTP 200 with an `error` JSON field" fallback path) is based on SerpApi's public docs, not verified against a real account. Flagged in a code comment; happy to adjust once someone can test against a live key.

## Contributor note

This is my first contribution here — found via CONTRIBUTING.md's "BYOK providers... requests for specific ones are both welcome." Went with SerpApi since it's a well-known, close structural match to the existing `serper.rs` adapter. Let me know if you'd rather see a different provider or a different shape for this.