### PR TITLE
feat(mcp): instructions blurb at initialize, honest focus docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **MCP `instructions` at initialize:** the handshake now carries a
+  short server blurb — one line per tool, generated from the spec
+  table — so a client injects it into the agent's context alongside
+  the system prompt. This is what an agent sees on harnesses with
+  deferred tool loading, which show only tool NAMES up front and
+  fetch schemas on demand: without it, nothing tells the agent
+  these tools exist or when to reach for one. Kept deliberately
+  small (~100 tokens) since it is resident in every session whether
+  or not the server is used, and gated at 150 tokens by a new
+  invariant in `tests/token_invariants.rs` — the first gate in that
+  file on what we send at handshake time rather than on what a
+  response costs. A golden fixture (`tests/fixtures/initialize.json`)
+  pins the whole initialize result; the package version is held as
+  a sentinel there so a release bump never has to re-bless it.
+
 ### Fixed
+
+- **`focus` was described as doing more than it does:** both tool
+  descriptions claimed "hybrid keyword + semantic matching"
+  unconditionally. On `web_fetch` the cross-encoder pass in fact
+  runs only on pages of ≤80 blocks AND only when the rerank model
+  is already cached from prior search use — plain BM25 otherwise,
+  never a download mid-fetch. On `web_crawl` there is no semantic
+  matching at all: frontier candidates are scored by token overlap
+  against link text and URL path (page content isn't fetched yet),
+  and a link sharing no token with the query is never enqueued —
+  a hard gate the old text didn't mention, though it decides what
+  the crawl reaches. Both descriptions now match the code, so an
+  agent can phrase a query for the matcher it actually gets.
 
 - **Xvfb install hint printed on macOS/Windows every session
   (issue #81):** the "install xvfb" advice belongs to Linux-family

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -364,6 +364,7 @@ fn initialize(params: &Value) -> Value {
     json!({
         "protocolVersion": version,
         "capabilities": { "tools": {} },
+        "instructions": tools::instructions(),
         "serverInfo": {
             "name": tools::SERVER_NAME,
             "version": tools::SERVER_VERSION
@@ -3920,5 +3921,65 @@ mod error_code_tests {
             "crawl.resume"
         );
         assert_eq!(error_code("fetch: invalid URL", None), "fetch.invalid");
+    }
+}
+
+#[cfg(test)]
+mod initialize_tests {
+    use super::{initialize, tools};
+    use serde_json::{Value, json};
+
+    /// The package version moves every release; the fixture holds a
+    /// sentinel there so a version bump never touches it.
+    const VERSION_SENTINEL: &str = "<CARGO_PKG_VERSION>";
+
+    fn fixture() -> Value {
+        let raw = std::fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/fixtures/initialize.json"
+        ))
+        .expect("read fixture");
+        let mut v: Value = serde_json::from_str(&raw).expect("parse fixture");
+        // Patch the one moving field on the parsed value, never on
+        // the text: a textual substitution would also hit the
+        // version wherever else it appeared.
+        let slot = &mut v["serverInfo"]["version"];
+        assert_eq!(slot, VERSION_SENTINEL, "fixture lost its version sentinel");
+        *slot = json!(tools::SERVER_VERSION);
+        v
+    }
+
+    /// Golden fixture: the whole initialize result — capabilities,
+    /// serverInfo, and the `instructions` blurb the client injects
+    /// into every session's context. If this fails, the handshake
+    /// an agent sees changed; bless the fixture deliberately.
+    #[test]
+    fn initialize_matches_fixture() {
+        // Unknown protocol version → we answer with our newest.
+        let got = initialize(&json!({ "protocolVersion": "1999-01-01" }));
+        assert_eq!(got, fixture(), "initialize result drifted from fixture");
+    }
+
+    /// Generated from the spec table, so a new tool must announce
+    /// itself with no prose edit — and announce itself once: zero
+    /// means an agent never learns the tool exists (deferred-loading
+    /// clients see only names up front), twice is paid-for noise.
+    #[test]
+    fn instructions_list_every_tool_once() {
+        let text = tools::instructions();
+        for t in crate::spec::TOOLS {
+            let hits = text.matches(t.name).count();
+            assert_eq!(hits, 1, "{} announced {hits}x, expected once", t.name);
+        }
+    }
+
+    #[test]
+    fn known_protocol_version_is_echoed() {
+        for v in tools::PROTOCOL_VERSIONS {
+            assert_eq!(
+                initialize(&json!({ "protocolVersion": v }))["protocolVersion"],
+                json!(v)
+            );
+        }
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -24,6 +24,30 @@ pub const PROTOCOL_VERSIONS: &[&str] = &[
 pub const SERVER_NAME: &str = "donsetch";
 pub const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
+/// The `instructions` string sent at initialize. Generated from
+/// the spec table — a new tool appears here with no prose edit.
+pub fn instructions() -> String {
+    // Name + summary, one per line. Summaries are already
+    // one-liners — they double as the `--help` subcommand listing.
+    let tools = crate::spec::TOOLS
+        .iter()
+        .map(|t| format!("- {0}: {1}", t.name, t.summary))
+        .collect::<Vec<_>>()
+        .join("\n");
+    // Clients inject this alongside the system prompt, and unlike
+    // tool descriptions it arrives unconditionally: harnesses with
+    // deferred tool loading (Claude Code's ToolSearch) show only
+    // tool NAMES up front and fetch schemas on demand, so this is
+    // what tells an agent we exist. It is resident in every
+    // session whether or not we are used — keep it short.
+    // tests/token_invariants.rs gates the size.
+    format!(
+        "Web access: fetch, search, crawl — one URL, many URLs, or a whole site.\
+        \n\n{tools}\n\n\
+        Output is the page's own markdown — full wording, code blocks and tables preserved."
+    )
+}
+
 /// tools/list payload — generated from the spec table.
 pub fn list() -> Value {
     json!({

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -83,7 +83,8 @@ pub struct ToolSpec {
     pub name: &'static str,
     /// CLI subcommand (`fetch`).
     pub cli_cmd: &'static str,
-    /// One-liner for `donsetch --help` listing.
+    /// One-liner — `donsetch --help` listing AND the MCP
+    /// `instructions` blurb sent at initialize.
     pub summary: &'static str,
     /// Full description — MCP tool description AND CLI long help.
     pub description: &'static str,
@@ -117,7 +118,7 @@ const FETCH_PARAMS: &[ParamSpec] = &[
         kind: ParamKind::Str,
         cli: CliKind::Flag,
         required: false,
-        help: "Relevance query — returns ONLY blocks relevant to your question, cutting tokens 50-80% on long pages. Hybrid keyword + semantic matching catches blocks with different vocabulary than your query. If nothing matches, returns full page with a notice. ALWAYS set when you know what you're looking for — #1 token saver.",
+        help: "Relevance query — returns ONLY blocks that score against it, cutting tokens 50-80% on long pages. Scoring is BM25 keyword matching, so phrase the query in the page's own vocabulary. A cross-encoder pass also catches blocks that use different words, but only on pages of 80 blocks or fewer AND only when the rerank model is already cached from prior search use — plain BM25 otherwise, never a download mid-fetch. If nothing matches, returns the full page with an inline notice. ALWAYS set when you know what you're looking for — #1 token saver.",
     },
     ParamSpec {
         name: "max_chars",
@@ -319,7 +320,7 @@ const CRAWL_PARAMS: &[ParamSpec] = &[
         kind: ParamKind::Str,
         cli: CliKind::Flag,
         required: false,
-        help: "Relevance query — rank pages by relevance and crawl only matching ones. Uses hybrid keyword + semantic matching. Essential for large sites; without it the crawl wastes budget on noise. Set this whenever you have a specific topic in mind.",
+        help: "Relevance query — ranks the frontier and crawls only matching pages. Scored by token overlap on LINK TEXT + URL PATH (content isn't fetched yet), so word it as the site does in URLs and link labels; a link sharing no token is never enqueued. Fetched pages are then focus-filtered as in web_fetch. Essential on large sites — without it the crawl burns budget on noise.",
     },
     ParamSpec {
         name: "max_pages",
@@ -445,7 +446,7 @@ pub static TOOLS: &[ToolSpec] = &[
         name: "web_crawl",
         cli_cmd: "crawl",
         summary: "Crawl a site into markdown (sitemap-aware, focus-ranked, resumable)",
-        description: "Crawl a site from a seed — for multi-page extraction (docs, API refs, wikis). Single page → web_fetch; finding sites → web_search.\n\nTwo-phase: sitemap discovery (cheap URL inventory) first, then focus-ranked page fetching with adaptive per-host pacing. Docs sites (mkdocs/docusaurus/sphinx/antora) get their nav as the site map automatically.\n\nModes: full (default) = map + content · map = URL inventory only, very cheap — see what a site has before committing · content = BFS from seed, no sitemap (use when sitemap is missing). PDF pages auto-parsed, not skipped.\n\nBudgets: focus (topic) ranks pages by keyword+semantic relevance and crawls only matches — set it whenever you have a topic. max_pages / max_total_chars / deadline_s cap the run; resume tokens continue across calls. since_last=true skips pages unchanged since your last crawl of the site (fingerprint memory — returns only what moved). Send _meta.progressToken for live per-page progress (\"12 pages, 34 queued\"); cancellation stops gracefully and keeps the resume token.\n\nResponse: map (if any) + pages as markdown. structuredContent = {seed, pages:[{url,title,kind,chars,quality}], map, queued, filtered_out, skipped:[{url,reason}], stop, elapsed_s, resume}. stop = FrontierEmpty (done) | MaxPages|CharBudget|DepthLimit|Deadline (budget — resume to continue) | ThrottledOut (site pushed back — wait, then resume) | Cancelled (resume token kept)",
+        description: "Crawl a site from a seed — for multi-page extraction (docs, API refs, wikis). Single page → web_fetch; finding sites → web_search.\n\nTwo-phase: sitemap discovery (cheap URL inventory) first, then focus-ranked page fetching with adaptive per-host pacing. Docs sites (mkdocs/docusaurus/sphinx/antora) get their nav as the site map automatically.\n\nModes: full (default) = map + content · map = URL inventory only, very cheap — see what a site has before committing · content = BFS from seed, no sitemap (use when sitemap is missing). PDF pages auto-parsed, not skipped.\n\nBudgets: focus (topic) ranks the frontier by link-text/URL-path keyword overlap and crawls only matches — set it whenever you have a topic. max_pages / max_total_chars / deadline_s cap the run; resume tokens continue across calls. since_last=true skips pages unchanged since your last crawl of the site (fingerprint memory — returns only what moved). Send _meta.progressToken for live per-page progress (\"12 pages, 34 queued\"); cancellation stops gracefully and keeps the resume token.\n\nResponse: map (if any) + pages as markdown. structuredContent = {seed, pages:[{url,title,kind,chars,quality}], map, queued, filtered_out, skipped:[{url,reason}], stop, elapsed_s, resume}. stop = FrontierEmpty (done) | MaxPages|CharBudget|DepthLimit|Deadline (budget — resume to continue) | ThrottledOut (site pushed back — wait, then resume) | Cancelled (resume token kept)",
         params: CRAWL_PARAMS,
         examples: &[
             "donsetch crawl https://docs.site.com --topic \"authentication\"",

--- a/tests/fixtures/initialize.json
+++ b/tests/fixtures/initialize.json
@@ -1,0 +1,11 @@
+{
+  "capabilities": {
+    "tools": {}
+  },
+  "instructions": "Web access: fetch, search, crawl — one URL, many URLs, or a whole site.\n\n- web_fetch: Fetch a URL as clean markdown (auto bot-wall bypass, PDF, JS render)\n- web_search: Web search — 5 keyless engines merged + reranked, or your API keys\n- web_crawl: Crawl a site into markdown (sitemap-aware, focus-ranked, resumable)\n\nOutput is the page's own markdown — full wording, code blocks and tables preserved.",
+  "protocolVersion": "2026-07-28",
+  "serverInfo": {
+    "name": "donsetch",
+    "version": "<CARGO_PKG_VERSION>"
+  }
+}

--- a/tests/fixtures/tools_list.json
+++ b/tests/fixtures/tools_list.json
@@ -29,7 +29,7 @@
             "type": "integer"
           },
           "focus": {
-            "description": "Relevance query — returns ONLY blocks relevant to your question, cutting tokens 50-80% on long pages. Hybrid keyword + semantic matching catches blocks with different vocabulary than your query. If nothing matches, returns full page with a notice. ALWAYS set when you know what you're looking for — #1 token saver.",
+            "description": "Relevance query — returns ONLY blocks that score against it, cutting tokens 50-80% on long pages. Scoring is BM25 keyword matching, so phrase the query in the page's own vocabulary. A cross-encoder pass also catches blocks that use different words, but only on pages of 80 blocks or fewer AND only when the rerank model is already cached from prior search use — plain BM25 otherwise, never a download mid-fetch. If nothing matches, returns the full page with an inline notice. ALWAYS set when you know what you're looking for — #1 token saver.",
             "type": "string"
           },
           "image_text": {
@@ -156,7 +156,7 @@
       "name": "web_search"
     },
     {
-      "description": "Crawl a site from a seed — for multi-page extraction (docs, API refs, wikis). Single page → web_fetch; finding sites → web_search.\n\nTwo-phase: sitemap discovery (cheap URL inventory) first, then focus-ranked page fetching with adaptive per-host pacing. Docs sites (mkdocs/docusaurus/sphinx/antora) get their nav as the site map automatically.\n\nModes: full (default) = map + content · map = URL inventory only, very cheap — see what a site has before committing · content = BFS from seed, no sitemap (use when sitemap is missing). PDF pages auto-parsed, not skipped.\n\nBudgets: focus (topic) ranks pages by keyword+semantic relevance and crawls only matches — set it whenever you have a topic. max_pages / max_total_chars / deadline_s cap the run; resume tokens continue across calls. since_last=true skips pages unchanged since your last crawl of the site (fingerprint memory — returns only what moved). Send _meta.progressToken for live per-page progress (\"12 pages, 34 queued\"); cancellation stops gracefully and keeps the resume token.\n\nResponse: map (if any) + pages as markdown. structuredContent = {seed, pages:[{url,title,kind,chars,quality}], map, queued, filtered_out, skipped:[{url,reason}], stop, elapsed_s, resume}. stop = FrontierEmpty (done) | MaxPages|CharBudget|DepthLimit|Deadline (budget — resume to continue) | ThrottledOut (site pushed back — wait, then resume) | Cancelled (resume token kept)",
+      "description": "Crawl a site from a seed — for multi-page extraction (docs, API refs, wikis). Single page → web_fetch; finding sites → web_search.\n\nTwo-phase: sitemap discovery (cheap URL inventory) first, then focus-ranked page fetching with adaptive per-host pacing. Docs sites (mkdocs/docusaurus/sphinx/antora) get their nav as the site map automatically.\n\nModes: full (default) = map + content · map = URL inventory only, very cheap — see what a site has before committing · content = BFS from seed, no sitemap (use when sitemap is missing). PDF pages auto-parsed, not skipped.\n\nBudgets: focus (topic) ranks the frontier by link-text/URL-path keyword overlap and crawls only matches — set it whenever you have a topic. max_pages / max_total_chars / deadline_s cap the run; resume tokens continue across calls. since_last=true skips pages unchanged since your last crawl of the site (fingerprint memory — returns only what moved). Send _meta.progressToken for live per-page progress (\"12 pages, 34 queued\"); cancellation stops gracefully and keeps the resume token.\n\nResponse: map (if any) + pages as markdown. structuredContent = {seed, pages:[{url,title,kind,chars,quality}], map, queued, filtered_out, skipped:[{url,reason}], stop, elapsed_s, resume}. stop = FrontierEmpty (done) | MaxPages|CharBudget|DepthLimit|Deadline (budget — resume to continue) | ThrottledOut (site pushed back — wait, then resume) | Cancelled (resume token kept)",
       "inputSchema": {
         "properties": {
           "deadline_s": {
@@ -171,7 +171,7 @@
             "type": "array"
           },
           "focus": {
-            "description": "Relevance query — rank pages by relevance and crawl only matching ones. Uses hybrid keyword + semantic matching. Essential for large sites; without it the crawl wastes budget on noise. Set this whenever you have a specific topic in mind.",
+            "description": "Relevance query — ranks the frontier and crawls only matching pages. Scored by token overlap on LINK TEXT + URL PATH (content isn't fetched yet), so word it as the site does in URLs and link labels; a link sharing no token is never enqueued. Fetched pages are then focus-filtered as in web_fetch. Essential on large sites — without it the crawl burns budget on noise.",
             "type": "string"
           },
           "include_paths": {

--- a/tests/token_invariants.rs
+++ b/tests/token_invariants.rs
@@ -108,6 +108,24 @@ fn probe_output_stays_tiny() {
 }
 
 #[test]
+fn mcp_instructions_stay_cheap() {
+    // The handshake blurb is the one string an agent pays for in
+    // every session, whether or not it ever calls us — so it is a
+    // token invariant like any response size. Generated live, not
+    // read from the fixture: a fixture is only as fresh as its
+    // last blessing, so measuring it would pass on stale text and
+    // report the bloat one run too late.
+    let text = donsetch::mcp::tools::instructions();
+
+    // chars/4 — the estimator the rest of the codebase uses.
+    let tokens = text.len() / 4;
+    assert!(
+        tokens <= 150,
+        "instructions cost ~{tokens} tokens (>150) — resident in every session"
+    );
+}
+
+#[test]
 fn links_on_renders_real_links() {
     // Wikipedia article body: hundreds of interwiki links. With
     // links=true the pipeline must render them as markdown links


### PR DESCRIPTION
_Note:_ not rebased on master. Master's Windows leg is red on `ghost::sandbox_tests::playwright_discovers_chrome_linux64_layout` (from e670254, issue #84) — the test builds a `chrome-linux64/chrome` fixture, but `playwright_entry_suffixes()` returns only the `chrome-win64/chrome.exe` paths on Windows, so it can only pass on Linux.

As a result this branch conflicts with master in `CHANGELOG.md` only (both sides appended to `[Unreleased]`), which is why GitHub is holding the checks. Left for the hand-merge — say the word and I'll rebase instead. Worth noting a rebase wouldn't make CI green either: `pull_request` builds the merge with master, so that ghost test runs regardless.

**Edit:** Blocked by merge of #89 

## Summary

MCP `instructions` reach the agent's context unconditionally, alongside the system prompt. On harnesses with deferred tool loading — only tool names up front, schemas fetched on demand — this is the only thing that tells an agent these tools exist. Generated from the spec table, so a new tool announces itself with no prose edit.

Kept to ~100 tokens: it is resident in every session whether or not the server is ever used. A new invariant caps it at 150 — the first gate in token_invariants.rs on what we send at handshake time rather than on what a response costs. A golden fixture pins the whole initialize result, holding the package version as a sentinel so a release bump never re-blesses it.

**Fix:**
Both focus descriptions also claimed "hybrid keyword + semantic matching" flatly. On fetch the cross-encoder pass runs only on pages of <=80 blocks and only when the rerank model is already cached from prior search use — plain BM25 otherwise, never a download mid-fetch. On crawl there is no semantic pass at all: frontier candidates score by token overlap on link text and URL path, and a link sharing no token with the query is never enqueued — a hard gate that decides what the crawl reaches and went unmentioned. An agent phrasing a semantic-style query for a BM25 matcher gets worse results, so this is a contract defect rather than wording.

## Type

- [x] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — deps, CI, tooling
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only

## Checks

- [x] `cargo test --features ocr,rerank` passes (719 lib + 5 integration tests)
- [x] `cargo clippy --all-targets --features ocr,rerank -- -Dwarnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes
- [ ] CI is green on all 3 platforms (Linux, macOS, Windows)

## Breaking changes

None at the protocol level — `instructions` is an optional field in the initialize result, and no existing field changed.

Behavior change worth knowing: every session now carries ~100 extra tokens of context whether or not the server is used, and clients that surface `instructions` will display the blurb. On the upside, global/system-prompt nudges that told agents to prefer donsetch can now be dropped — the server announces itself.

## Test plan

Verify performance under real agents.
