### PR TITLE
feat(search): add Brave Search API as a BYOK search provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,8 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   alongside the existing Serper.dev provider. Routes by intent like
   the other providers: `google_scholar` engine for paper queries,
   `tbm=nws` for news.
-- **Brave Search API BYOK provider:** `donsetch keys add bravesearch
-  <key>` wires up the official, keyed
+- **Brave Search API BYOK provider:** `donsetch keys add bravesearch <key>`
+  wires up the official, keyed
   [Brave Search API](https://api.search.brave.com) — distinct from
   the existing keyless `brave` SERP scraper. Uses a dedicated news
   endpoint for news-intent queries.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   alongside the existing Serper.dev provider. Routes by intent like
   the other providers: `google_scholar` engine for paper queries,
   `tbm=nws` for news.
+- **Brave Search API BYOK provider:** `donsetch keys add bravesearch
+  <key>` wires up the official, keyed
+  [Brave Search API](https://api.search.brave.com) — distinct from
+  the existing keyless `brave` SERP scraper. Uses a dedicated news
+  endpoint for news-intent queries.
 - **Playwright-managed Chromium discovery (issue #84):** the browser
   probe now finds every Playwright layout (chrome-linux64,
   chrome-win64, chrome-mac-arm64 plus the legacy dirs), honors

--- a/README.md
+++ b/README.md
@@ -412,6 +412,7 @@ donsetch keys add tavily tvly-...       # Tavily
 donsetch keys add exa sk-exa-...        # Exa (stackable)
 donsetch keys add serper ...            # Serper.dev
 donsetch keys add serpapi ...           # SerpApi
+donsetch keys add bravesearch ...       # Brave Search API
 donsetch keys add tinyfish sk-...       # TinyFish (free tier)
 donsetch keys add parallel nKil3...     # Parallel AI (fast mode)
 donsetch keys add bd 576d013c...        # Bright Data SERP

--- a/src/cli/keys.rs
+++ b/src/cli/keys.rs
@@ -9,7 +9,7 @@
 //!   donsetch keys import <path>            Import keys from a file
 //!   donsetch keys clear                     Remove all keys
 //!
-//! Providers: tavily, exa, serper, serpapi, tinyfish, parallel, brightdata, unlocker
+//! Providers: tavily, exa, serper, serpapi, bravesearch, tinyfish, parallel, brightdata, unlocker
 
 use super::{bold, dim, green, red};
 
@@ -466,6 +466,7 @@ fn print_help() {
     println!("    exa        Exa AI Search (api.exa.ai)");
     println!("    serper     Serper.dev Google SERP (google.serper.dev)");
     println!("    serpapi    SerpApi Google SERP (serpapi.com)");
+    println!("    bravesearch Brave Search API (api.search.brave.com)");
     println!("    tinyfish   TinyFish Search (api.search.tinyfish.ai)");
     println!("    parallel   Parallel AI Search (api.parallel.ai) — fast mode");
     println!("    brightdata Bright Data SERP API (api.brightdata.com)");

--- a/src/search/byok/bravesearch.rs
+++ b/src/search/byok/bravesearch.rs
@@ -1,0 +1,194 @@
+//! Brave Search API (official, keyed) adapter.
+//!
+//! Distinct from the keyless `brave` SERP scraper in
+//! `src/search/engines.rs` (which scrapes search.brave.com's HTML,
+//! no key required) — this hits Brave's own REST API and needs a
+//! subscription token. Named `bravesearch` here to keep the two
+//! unambiguous in the provider list.
+//!
+//! GET https://api.search.brave.com/res/v1/web/search
+//! Auth: X-Subscription-Token: <key>  (+ Accept: application/json)
+//! Params: q, count (max 20)
+//! Response: { web: { results: [{ title, url, description }] } }
+//!
+//! News intent uses a separate endpoint:
+//! GET https://api.search.brave.com/res/v1/news/search
+//! Response: { results: [{ title, url, description }] }
+//!
+//! Brave doesn't return a per-result position/rank field, so the
+//! score is derived from array order.
+
+use std::time::Instant;
+
+use serde_json::Value;
+
+use super::{KeyError, ProviderResult, SearchHit};
+
+const WEB_BASE: &str = "https://api.search.brave.com/res/v1/web/search";
+const NEWS_BASE: &str = "https://api.search.brave.com/res/v1/news/search";
+const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Extract hits from an array of `{ title, url, description }`
+/// objects (the shape both the `web.results` and top-level
+/// `results` arrays share). Pure function so it's testable without
+/// a live API call.
+fn parse_results(arr: &[Value]) -> Vec<SearchHit> {
+    arr.iter()
+        .enumerate()
+        .filter_map(|(i, r)| {
+            let title = r
+                .get("title")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            let url = r
+                .get("url")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            if url.is_empty() {
+                return None;
+            }
+            let snippet = r
+                .get("description")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_string();
+            // No position field from Brave — derive from array
+            // order (0 → ~1.0, 9 → ~0.1).
+            let score = 1.0 / (i as f32 + 1.0);
+            Some(SearchHit {
+                title,
+                url,
+                snippet,
+                score,
+            })
+        })
+        .collect()
+}
+
+pub async fn search(
+    client: &reqwest::Client,
+    key: &str,
+    query: &str,
+    max: usize,
+    intent: &crate::search::intent::Intent,
+) -> ProviderResult {
+    let started = Instant::now();
+
+    let is_news = matches!(intent, crate::search::intent::Intent::News);
+    let endpoint = if is_news { NEWS_BASE } else { WEB_BASE };
+    let count = max.clamp(1, 20).to_string();
+
+    let resp = client
+        .get(endpoint)
+        .header("X-Subscription-Token", key)
+        .header("Accept", "application/json")
+        .query(&[("q", query), ("count", &count)])
+        .timeout(TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| {
+            if e.is_timeout() {
+                KeyError::NetworkError
+            } else {
+                KeyError::UnknownError(format!("network: {e}"))
+            }
+        })?;
+
+    let status = resp.status().as_u16();
+    let text = resp.text().await.unwrap_or_default();
+
+    if status == 401 || status == 403 {
+        return Err(KeyError::InvalidKey);
+    }
+    if status == 429 {
+        let lower = text.to_lowercase();
+        if lower.contains("quota") || lower.contains("exceeded") || lower.contains("plan") {
+            return Err(KeyError::CreditDepleted);
+        }
+        return Err(KeyError::RateLimited);
+    }
+    if status >= 500 {
+        return Err(KeyError::ServerError(format!("HTTP {status}")));
+    }
+    if status >= 400 {
+        let lower = text.to_lowercase();
+        if lower.contains("invalid") && (lower.contains("key") || lower.contains("token")) {
+            return Err(KeyError::InvalidKey);
+        }
+        if lower.contains("quota") || lower.contains("exceeded") || lower.contains("plan") {
+            return Err(KeyError::CreditDepleted);
+        }
+        return Err(KeyError::UnknownError(format!("HTTP {status}: {text}")));
+    }
+
+    let json: Value = serde_json::from_str(&text)
+        .map_err(|e| KeyError::UnknownError(format!("parse error: {e}")))?;
+
+    let results = if is_news {
+        json.get("results")
+            .and_then(Value::as_array)
+            .map(|arr| parse_results(arr))
+            .unwrap_or_default()
+    } else {
+        json.get("web")
+            .and_then(|w| w.get("results"))
+            .and_then(Value::as_array)
+            .map(|arr| parse_results(arr))
+            .unwrap_or_default()
+    };
+
+    let ms = started.elapsed().as_millis() as u64;
+    Ok((results, ms))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_results_basic() {
+        let arr = json!([
+            { "title": "Rust", "url": "https://rust-lang.org", "description": "a systems language" },
+            { "title": "Rust book", "url": "https://doc.rust-lang.org/book", "description": "the book" },
+        ]);
+        let hits = parse_results(arr.as_array().unwrap());
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].title, "Rust");
+        assert_eq!(hits[0].url, "https://rust-lang.org");
+        assert_eq!(hits[0].snippet, "a systems language");
+        assert!(
+            hits[0].score > hits[1].score,
+            "earlier array position scores higher"
+        );
+    }
+
+    #[test]
+    fn parse_results_drops_entries_without_url() {
+        let arr = json!([
+            { "title": "No URL" },
+            { "title": "Has URL", "url": "https://example.com" },
+        ]);
+        let hits = parse_results(arr.as_array().unwrap());
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].title, "Has URL");
+    }
+
+    #[test]
+    fn parse_results_empty_array() {
+        let arr = json!([]);
+        assert!(parse_results(arr.as_array().unwrap()).is_empty());
+    }
+
+    #[test]
+    fn parse_results_missing_description_defaults_empty() {
+        let arr = json!([
+            { "title": "No description", "url": "https://example.com" },
+        ]);
+        let hits = parse_results(arr.as_array().unwrap());
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].snippet, "");
+    }
+}

--- a/src/search/byok/bravesearch.rs
+++ b/src/search/byok/bravesearch.rs
@@ -102,6 +102,12 @@ pub async fn search(
     if status == 401 || status == 403 {
         return Err(KeyError::InvalidKey);
     }
+    // No 402 branch: unlike Tavily/SerpApi/Serper/Brightdata's
+    // underlying services, Brave's API doesn't document a 402.
+    // Its rate-limit policy expresses both per-second throttling
+    // and monthly-quota exhaustion under the same 429 status (see
+    // the X-RateLimit-Policy header's 1s/30-day windows), so quota
+    // exhaustion is inferred here via message-sniffing only.
     if status == 429 {
         let lower = text.to_lowercase();
         if lower.contains("quota") || lower.contains("exceeded") || lower.contains("plan") {

--- a/src/search/byok/mod.rs
+++ b/src/search/byok/mod.rs
@@ -1,7 +1,8 @@
 //! Bring Your Own Keys (BYOK) — provider search with key rotation.
 //!
 //! When the user configures API keys for external search providers
-//! (Tavily, Exa, Serper.dev, SerpApi, TinyFish, Parallel AI, Bright Data), the entire local 5-engine
+//! (Tavily, Exa, Serper.dev, SerpApi, Brave Search API, TinyFish,
+//! Parallel AI, Bright Data), the entire local 5-engine
 //! search system is bypassed. The provider handles everything:
 //! search, IP, rate limiting. DonSeTch just sends the query and
 //! normalizes the results.
@@ -13,6 +14,7 @@
 //! after 60s cooldown. Credit-depleted/invalid keys stay dead
 //! until the user resets them.
 
+mod bravesearch;
 mod brightdata;
 mod exa;
 mod parallel;
@@ -256,6 +258,7 @@ async fn dispatch(
         "exa" => exa::search(client, key, query, max, intent).await,
         "serper" => serper::search(client, key, query, max, intent).await,
         "serpapi" => serpapi::search(client, key, query, max, intent).await,
+        "bravesearch" => bravesearch::search(client, key, query, max, intent).await,
         "tinyfish" => tinyfish::search(client, key, query, max, intent).await,
         "parallel" => parallel::search(client, key, query, max, intent).await,
         "brightdata" => brightdata::search(client, key, query, max, intent).await,

--- a/src/search/byok/store.rs
+++ b/src/search/byok/store.rs
@@ -27,6 +27,7 @@ pub const PROVIDERS: &[&str] = &[
     "exa",
     "serper",
     "serpapi",
+    "bravesearch",
     "tinyfish",
     "parallel",
     "brightdata",


### PR DESCRIPTION
## Summary

Adds the official, keyed [Brave Search API](https://api.search.brave.com) as a second BYOK search provider (`donsetch keys add bravesearch <key>`), following the same shape as #82 (SerpApi). Named `bravesearch` — deliberately distinct from the existing keyless `brave` SERP scraper in `src/search/engines.rs`, so there's no ambiguity between the two.

Two differences from `serpapi.rs`/`serper.rs` worth calling out:
- Auth is `X-Subscription-Token: <key>` (a header, like Serper — not a query param like SerpApi).
- Brave doesn't return a per-result `position` field, so relevance score is derived from array order instead.
- Web-search results live at `web.results[]`; news-intent queries hit a separate `/res/v1/news/search` endpoint with a top-level `results[]`.

## Type

- [x] `feat` — new feature

## Checks

- [x] `cargo test --lib` passes (713/713, including 4 new unit tests for `bravesearch.rs`'s JSON-parsing logic)
- [x] `cargo clippy --lib -- -Dwarnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes
- [ ] `cargo test --features ocr,rerank` / `cargo clippy --all-targets --features ocr,rerank -- -Dwarnings` — not run locally (same as #82, heavy native/ML deps not set up here); this change only touches `src/search/byok/` and `src/cli/keys.rs`.
- [ ] CI on all 3 platforms — pending.

## Breaking changes

None. Purely additive.

## Test plan

- `parse_results()` factored out as a pure, testable function (same convention as `serpapi.rs`/`brightdata.rs`), covered by 4 unit tests: basic ordering/scoring, entries missing `url` (dropped), empty array, and a missing `description` (defaults to empty snippet).
- Verified the `SearchHit` output is compatible with `to_merged()` in `mod.rs` — no changes needed there.
- Cross-checked the endpoint paths, header name, response field names, and `count` max (20) against Brave's public API docs.
- **Caveat**, same as #82: I don't have a live Brave Search API subscription, so the exact wording Brave uses in 429 error bodies (for the message-sniffing that distinguishes rate-limit vs. quota-exhaustion) is inferred from docs, not a real account. Brave's rate-limit docs do confirm there's no 402 status in their API (documented in a comment in the diff), unlike Tavily/SerpApi/Serper/Brightdata.

## Contributor note

Follow-up to #82 (SerpApi), same BYOK-provider pattern. Happy to adjust the error-classification wording once someone can test against a live key.