### PR TITLE
fix(ghost): macOS build broken by an unbound collect(), plus an un-gated Windows test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **macOS build broken by the Playwright-discovery change above:**
+  `known_chrome_paths()` on macOS referenced an undefined `paths`
+  variable (`E0425`) — the hardcoded-app-bundle list's `.collect()`
+  was never bound to a `let`, so the build failed on every macOS
+  target. Also un-broke `playwright_discovers_chrome_linux64_layout`,
+  which wasn't OS-gated and failed on Windows/macOS CI runners since
+  it asserts against the Linux-only `chrome-linux64` layout.
 - **Xvfb install hint printed on macOS/Windows every session
   (issue #81):** the "install xvfb" advice belongs to Linux-family
   systems only; headful off-screen Chrome is the native mode on

--- a/src/ghost/mod.rs
+++ b/src/ghost/mod.rs
@@ -302,7 +302,7 @@ fn playwright_candidates_for_root(root: &std::path::Path) -> Vec<PathBuf> {
 
 #[cfg(target_os = "macos")]
 fn known_chrome_paths() -> Vec<PathBuf> {
-    [
+    let mut paths: Vec<PathBuf> = [
         "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
         "/Applications/Chromium.app/Contents/MacOS/Chromium",
         "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
@@ -1510,6 +1510,11 @@ mod sandbox_tests {
         );
     }
 
+    // Exercises the chrome-linux64/chrome-linux suffixes returned by
+    // playwright_entry_suffixes() on this cfg — see that function's
+    // own gate. Fails on macOS/Windows if run there since those
+    // platforms probe a different suffix set entirely.
+    #[cfg(not(any(target_os = "macos", windows)))]
     #[test]
     fn playwright_discovers_chrome_linux64_layout() {
         // Regression for issue #84: Playwright moved Chromium into
@@ -1546,6 +1551,26 @@ mod sandbox_tests {
             "headless shell, firefox and webkit must never be discovered as Chrome"
         );
         std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[cfg(target_os = "macos")]
+    #[test]
+    fn known_chrome_paths_includes_hardcoded_app_bundles() {
+        // Regression: known_chrome_paths() failed to compile on
+        // macOS (E0425: cannot find value `paths`) after the
+        // Playwright-discovery addition dropped the `let mut paths
+        // =` binding on the hardcoded-paths collect().
+        let paths = known_chrome_paths();
+        for expected in [
+            "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+            "/Applications/Chromium.app/Contents/MacOS/Chromium",
+            "/Applications/Google Chrome Canary.app/Contents/MacOS/Google Chrome Canary",
+        ] {
+            assert!(
+                paths.iter().any(|p| p == std::path::Path::new(expected)),
+                "missing hardcoded path {expected}, got: {paths:?}"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Found while opening an unrelated PR (#88): CI on `master` is currently broken on every non-Linux platform.

1. **macOS fails to compile** (`E0425: cannot find value 'paths' in this scope`, `src/ghost/mod.rs:316-317`). The `#[cfg(target_os = "macos")]` variant of `known_chrome_paths()` collects the hardcoded app-bundle list with a bare `.collect();` — never bound via `let` — then references the nonexistent `paths` to extend it with Playwright candidates. The sibling `windows`/`linux_like` variants both correctly use `let mut paths = ...`; this one didn't. Introduced by `e6702549` (today's Playwright-discovery commit, issue #84).
2. **Windows fails a test**: `playwright_discovers_chrome_linux64_layout` isn't OS-gated, but it hardcodes a `chrome-linux64` directory layout that only the Linux branch of `playwright_entry_suffixes()` looks for — Windows (and macOS) probe a different suffix set, so the assertion legitimately fails there.

Both bugs come from the same commit and block CI for anyone opening a PR right now, regardless of what the PR touches — confirmed via the actual failing job logs on #88's `build-test (macos-arm64)`, `build-test (macos-x86_64)`, and `build-test (windows-x86_64)` legs.

## Type

- [x] `fix` — bug fix

## Checks

- [x] `cargo test --lib` passes (709/709 on Linux; the new macOS-only regression test is correctly compiled out here and will run on the macOS CI legs)
- [x] `cargo clippy --lib -- -Dwarnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes
- [ ] `cargo test --features ocr,rerank` — not run locally (same environment limitation as #82/#88)
- [x] CI on all 3 platforms — this is exactly what this PR should turn green; watching after opening.

## Breaking changes

None.

## Test plan

- Added a `#[cfg(target_os = "macos")]` regression test asserting `known_chrome_paths()` returns the three hardcoded app-bundle paths — it can only run on the macOS CI legs (no macOS machine available to me), but its presence proves the fix at least type-checks there once CI runs.
- Gated `playwright_discovers_chrome_linux64_layout` to `#[cfg(not(any(target_os = "macos", windows)))]` — the exact same condition `playwright_entry_suffixes()` itself uses for the Linux branch — so it only runs where its hardcoded layout is actually valid.
- Read through every other branch of `known_chrome_paths()`, `playwright_entry_suffixes()`, `playwright_registry_roots()`, and `playwright_candidates_for_root()` looking for the same mistake class (unbound collect, OS-gating mismatch) — found nothing else.
- I don't have access to a macOS machine; cross-compiling to `aarch64-apple-darwin` from this Linux box fails much earlier at the `zstd-sys`/`boring-sys` native-toolchain stage, before reaching this file, so I could not get an actual macOS compile locally. The fix is a single local-variable binding with no macOS-specific API surface, matching the already-working `windows`/`linux_like` siblings' pattern exactly — CI is the real verification here.

## Contributor note

Not part of the original plan — stumbled onto this while another PR's CI ran. Filing it separately since it's an independent, unrelated fix from #88's actual content.