### PR TITLE
fix(crawl): focus_match compound-term check crosses word boundaries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to DonSeTch are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`focus_match` compound-term check crossed word boundaries:** the
+  crawl frontier's hard focus gate matched a compound query term
+  (e.g. `auto-complete`) against any URL/anchor text containing it
+  as a raw substring, so `auto-completed` (a different word once
+  stemming strips `-ed`) falsely counted as a match. The full-form
+  check is now a contiguous token-subsequence match instead of a
+  string `contains`, closing the same word-boundary gap the
+  existing fragment-based check (issue #86 follow-up) already
+  guarded against.
+
 ## [3.4.4] - 2026-08-31
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stemming strips `-ed`) falsely counted as a match. The full-form
   check is now a contiguous token-subsequence match instead of a
   string `contains`, closing the same word-boundary gap the
-  existing fragment-based check (issue #86 follow-up) already
-  guarded against.
+  existing fragment-based check (added in v2.3.1) already guarded
+  against.
 
 ## [3.4.4] - 2026-08-31
 

--- a/src/crawl/score.rs
+++ b/src/crawl/score.rs
@@ -162,10 +162,15 @@ fn depth_prior(path: &str) -> f64 {
 /// Compound token handling: query terms containing `_` or `-`
 /// (e.g. `spawn_blocking`, `async-await`) are treated as compound
 /// identifiers. A compound term matches if:
-///   (a) the full compound form appears as a substring in the
-///       path or anchor (e.g. `spawn_blocking` in the path), OR
-///   (b) ALL its fragments appear in the path/anchor tokens.
-/// This prevents the stemmed fragment `block` (from splitting
+///   (a) its fragments appear as a contiguous, in-order run in the
+///       path or anchor tokens (e.g. `spawn_blocking` right next to
+///       each other in the path), OR
+///   (b) ALL its fragments appear in the path/anchor tokens, in any
+///       order.
+/// (a) is token-boundary-safe by construction: a raw string
+/// `contains` would match `auto-complete` inside `auto-completed`,
+/// a different word once stemming strips the `-ed`.
+/// (b) prevents the stemmed fragment `block` (from splitting
 /// `spawn_blocking` → `spawn` + `block`) from matching unrelated
 /// paths like `/ant-libp2p-allow-block-list/` where only `block`
 /// appears without `spawn`.
@@ -180,22 +185,28 @@ pub fn focus_match(anchor: &str, path: &str, focus: &str) -> bool {
     let path_toks = focus::tokenize(&path_text, &qlang);
     let all_toks: Vec<&String> = anchor_toks.iter().chain(path_toks.iter()).collect();
 
-    let lower_path = path.to_lowercase();
-    let lower_anchor = anchor.to_lowercase();
-
     // Split query into whitespace-separated terms.
     for term in focus.split_whitespace() {
         let lower_term = term.to_lowercase();
 
-        // Compound term (contains _ or -): check full form as
-        // substring, or ALL fragments as token matches.
+        // Compound term (contains _ or -): check full form as a
+        // contiguous token run, or ALL fragments as token matches
+        // (any order).
         if lower_term.contains('_') || lower_term.contains('-') {
-            // (a) Full compound form as substring.
-            if lower_path.contains(&lower_term) || lower_anchor.contains(&lower_term) {
+            let fragments = focus::tokenize(&lower_term, &qlang);
+            // (a) Full compound form: fragments appear contiguous
+            // and in order in the path or anchor tokens. A raw
+            // string `contains` here would cross word boundaries
+            // (e.g. "auto-complete" is a substring of
+            // "auto-completed", a different word once "-ed" is
+            // stripped) — token-subsequence matching can't.
+            if !fragments.is_empty()
+                && (contains_subsequence(&path_toks, &fragments)
+                    || contains_subsequence(&anchor_toks, &fragments))
+            {
                 return true;
             }
-            // (b) ALL fragments must match as tokens.
-            let fragments = focus::tokenize(&lower_term, &qlang);
+            // (b) ALL fragments must match as tokens, any order.
             if !fragments.is_empty() && fragments.iter().all(|ft| all_toks.contains(&ft)) {
                 return true;
             }
@@ -209,6 +220,19 @@ pub fn focus_match(anchor: &str, path: &str, focus: &str) -> bool {
     }
 
     false
+}
+
+/// True if `needle` appears as a contiguous, in-order run inside
+/// `haystack`. Used for compound-term matching: token-boundary-safe
+/// alternative to a raw string `contains`, which can match across
+/// word boundaries.
+fn contains_subsequence(haystack: &[String], needle: &[String]) -> bool {
+    if needle.is_empty() || needle.len() > haystack.len() {
+        return false;
+    }
+    haystack
+        .windows(needle.len())
+        .any(|window| window == needle)
 }
 
 #[cfg(test)]
@@ -358,6 +382,36 @@ mod tests {
             "spawn_blocking vs spawn"
         ));
         assert!(!focus_match("", "/asm_block", "spawn_blocking vs spawn"));
+    }
+
+    #[test]
+    fn focus_match_compound_substring_respects_word_boundaries() {
+        // The compound-term "full form as substring" check (case a)
+        // must not cross word boundaries: "auto-complete" is a raw
+        // substring of "auto-completed" (auto-complete[d]), but the
+        // page is about the past tense of a DIFFERENT stem
+        // ("complet", once "-ed" is stripped), not the "complete"
+        // feature.
+        assert!(
+            !focus_match("", "/features/auto-completed-suggestions", "auto-complete"),
+            "auto-complete must not match auto-completed across a word boundary"
+        );
+        // Same shape with anchor text instead of path.
+        assert!(
+            !focus_match(
+                "the field was auto-completed already",
+                "/x",
+                "auto-complete"
+            ),
+            "auto-complete must not match \"auto-completed\" in anchor text either"
+        );
+        // A real match must still work: the compound term appears
+        // as its own word, not glued to surrounding letters.
+        assert!(focus_match(
+            "",
+            "/docs/auto-complete-guide",
+            "auto-complete"
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Found while reading through the fresh real-IDF scoring code from #86 (`src/crawl/score.rs`). `focus_match()` — the crawl frontier's hard focus gate — has two ways to match a compound query term (one containing `_` or `-`, e.g. `spawn_blocking`): (a) the full compound form as a substring, or (b) all its fragments as tokens, any order.

Check (a) was a raw `String::contains` against the lowercased but otherwise unmodified path/anchor text. That crosses word boundaries: `auto-complete` is a literal substring of `auto-completed`, even though this codebase's own stemmer (`stem_en`'s `-ed` rule) turns `"completed"` into `"complet"` — a different token from `"complete"` everywhere else matching happens (check (b), `score_candidate`, etc). So `focus_match("", "/features/auto-completed-suggestions", "auto-complete")` returned `true`, letting the crawler enqueue an off-topic page purely because of an accidental substring collision.

Replaces the raw substring check with `contains_subsequence()`: does the compound term's tokenized fragments appear as a contiguous, in-order run within the already-tokenized `path_toks`/`anchor_toks`? Since those went through the same tokenizer/stemmer as everything else, this is boundary-safe and stemming-consistent by construction.

## Type

- [x] `fix` — bug fix

## Checks

- [x] `cargo test --lib` passes (719/719, including a new regression test)
- [x] `cargo clippy --lib -- -Dwarnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes
- [ ] `cargo test --features ocr,rerank` — not run locally (same environment limitation as my previous PRs)
- [ ] CI on all 3 platforms — pending.

## Breaking changes

None. This only tightens an over-permissive match into a correct one; every case that still matches under the new logic matched under the old logic too (verified: the only paths where old/new logic differ are exactly the word-boundary-crossing false positives being fixed — case (b), which is untouched, keeps working for the "all fragments, any order" path).

## Test plan

- New regression test `focus_match_compound_substring_respects_word_boundaries`: covers the false positive via path text, the same false positive via anchor text, and a true-positive control (`/docs/auto-complete-guide`, where the term appears as its own contiguous tokens) to prove the fix isn't just "always stricter."
- Traced through `focus_match_compound_in_path` and `focus_match_compound_no_false_positive` (existing tests) by hand to confirm they still pass for the right reason under the new subsequence-based logic.
- Reasoned through whether the old substring behavior could ever have caught a legitimate match the new logic now misses — every case where they'd differ is, by construction, a word-boundary-crossing artifact (the bug itself), not a real distinct match worth preserving.

## Contributor note

Not something I went looking for — found it by reading the surrounding code while getting familiar with the new focus-scoring machinery from #86.