### PR TITLE
fix(ghost): Windows profile winlock can be stolen from a still-live daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   DevTools line. A create_new profile lockfile now mirrors the
   unix flock: the loser diverges to a temp profile, and a stale
   lock left by a dead daemon recovers by age (10 min).
+- **Windows profile lockfile could be stolen out from under a live
+  daemon:** the lockfile's mtime was never refreshed after
+  creation, so a continuously-busy Ghost (which only freezes after
+  20s idle and only reaps after 10min *frozen* — it can run far
+  longer than that without ever hitting either) could hold the
+  lock well past the 10-minute staleness window. A second daemon
+  starting mid-way would see the un-refreshed mtime, mistake the
+  still-live holder for abandoned, and steal the profile — the
+  exact collision the lock exists to prevent. The lockfile's mtime
+  now gets refreshed every 2 minutes for as long as a Ghost holds
+  it.
 - **Browser fingerprint noise:** the ghost no longer runs Chrome
   default apps or extensions, killing the surprise-component
   detection class (enumerable extensions, default-app traffic)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -56,15 +56,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lock left by a dead daemon recovers by age (10 min).
 - **Windows profile lockfile could be stolen out from under a live
   daemon:** the lockfile's mtime was never refreshed after
-  creation, so a continuously-busy Ghost (which only freezes after
-  20s idle and only reaps after 10min *frozen* — it can run far
-  longer than that without ever hitting either) could hold the
-  lock well past the 10-minute staleness window. A second daemon
-  starting mid-way would see the un-refreshed mtime, mistake the
-  still-live holder for abandoned, and steal the profile — the
-  exact collision the lock exists to prevent. The lockfile's mtime
-  now gets refreshed every 2 minutes for as long as a Ghost holds
-  it.
+  creation. Windows kills the Ghost on every guard drop (unlike
+  Linux/Xvfb's warm-freeze path), so the lock is normally held for
+  one call's duration — but a single long `actions` script (up to
+  16 steps, each wait capped at 60s) can legitimately outlast the
+  10-minute staleness window while the Ghost is nowhere near dead.
+  A second daemon starting mid-call would see the un-refreshed
+  mtime, mistake the still-live holder for abandoned, and steal the
+  profile — the exact collision the lock exists to prevent. The
+  lockfile's mtime now gets refreshed every 2 minutes for as long
+  as a Ghost holds it, opened with FILE_SHARE_DELETE so the
+  refresh can never block cleanup on exit.
 - **Browser fingerprint noise:** the ghost no longer runs Chrome
   default apps or extensions, killing the surprise-component
   detection class (enumerable extensions, default-app traffic)

--- a/src/ghost/mod.rs
+++ b/src/ghost/mod.rs
@@ -41,6 +41,24 @@ pub const FREEZE_AFTER: std::time::Duration = std::time::Duration::from_secs(20)
 /// Frozen this long → reap entirely.
 pub const REAP_AFTER: std::time::Duration = std::time::Duration::from_secs(600);
 
+/// Windows profile lockfile: age past which an unheld lockfile is
+/// treated as orphaned by a dead daemon and recovered.
+#[cfg(windows)]
+pub const WINLOCK_STALE_AFTER: std::time::Duration = std::time::Duration::from_secs(600);
+/// Windows profile lockfile: how often a held lockfile's mtime is
+/// refreshed. Must stay comfortably below WINLOCK_STALE_AFTER — a
+/// Ghost only freezes after FREEZE_AFTER idle and only reaps after
+/// REAP_AFTER *frozen*, so a continuously-busy Ghost (never idle
+/// long enough to freeze) can hold the lock far longer than
+/// WINLOCK_STALE_AFTER without ever being reaped. Without a
+/// heartbeat, a second daemon starting mid-way would see the
+/// lockfile's un-refreshed creation-time mtime, mistake the
+/// still-live holder for an abandoned one, and steal the profile
+/// out from under it — exactly the collision this lock exists to
+/// prevent.
+#[cfg(windows)]
+pub const WINLOCK_HEARTBEAT: std::time::Duration = std::time::Duration::from_secs(120);
+
 pub struct Ghost {
     child: Child,
     proc: proc::Proc,
@@ -71,6 +89,12 @@ pub struct Ghost {
     /// shared profile.
     #[cfg(windows)]
     winlock: Option<std::path::PathBuf>,
+    /// Refreshes `winlock`'s mtime on an interval so a live,
+    /// continuously-busy Ghost never looks abandoned to another
+    /// daemon's staleness check (see WINLOCK_HEARTBEAT). Aborted
+    /// in Drop, same as fetch_guard.
+    #[cfg(windows)]
+    winlock_heartbeat: Option<tokio::task::JoinHandle<()>>,
 }
 
 /// Persistent profile dir: aged state passes challenges
@@ -494,7 +518,7 @@ impl Ghost {
                                     .and_then(|m| m.modified())
                                     .ok()
                                     .and_then(|t| t.elapsed().ok())
-                                    .is_some_and(|e| e.as_secs() > 600);
+                                    .is_some_and(|e| e > WINLOCK_STALE_AFTER);
                                 if stale {
                                     let _ = std::fs::remove_file(&lock_path);
                                     if take_lock(&lock_path).is_ok() {
@@ -530,6 +554,20 @@ impl Ghost {
         };
         #[cfg(windows)]
         let winlock: Option<std::path::PathBuf> = _winlock_opt;
+        // Keep the winlock's mtime fresh for as long as this Ghost
+        // holds it — see WINLOCK_HEARTBEAT's doc comment for why
+        // this can't just rely on WINLOCK_STALE_AFTER alone.
+        #[cfg(windows)]
+        let winlock_heartbeat = winlock.clone().map(|p| {
+            tokio::spawn(async move {
+                loop {
+                    tokio::time::sleep(WINLOCK_HEARTBEAT).await;
+                    if let Ok(f) = std::fs::OpenOptions::new().write(true).open(&p) {
+                        let _ = f.set_modified(std::time::SystemTime::now());
+                    }
+                }
+            })
+        });
 
         std::fs::create_dir_all(&dir)
             .map_err(|e| FetchError::ghost(format!("profile dir: {e}")))?;
@@ -840,6 +878,8 @@ impl Ghost {
             fetch_guard: Some(fetch_guard),
             #[cfg(windows)]
             winlock,
+            #[cfg(windows)]
+            winlock_heartbeat,
         })
     }
 
@@ -1568,6 +1608,12 @@ impl Drop for Ghost {
         // Child was dropped without killing Chrome.
         self.proc.kill_group();
         sweep_crashpad();
+        // Stop refreshing the winlock's mtime before removing it —
+        // same abort-then-cleanup order as fetch_guard above.
+        #[cfg(windows)]
+        if let Some(handle) = self.winlock_heartbeat.take() {
+            handle.abort();
+        }
         // Release the Windows profile-exclusion lockfile (unix
         // flock releases itself when this handle closes).
         #[cfg(windows)]
@@ -1820,6 +1866,22 @@ mod sandbox_tests {
                 "missing hardcoded path {expected}, got: {paths:?}"
             );
         }
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn winlock_heartbeat_has_safety_margin_under_stale_threshold() {
+        // A continuously-busy Ghost only freezes after FREEZE_AFTER
+        // idle and only reaps after REAP_AFTER *frozen* — so it can
+        // hold the winlock file far longer than WINLOCK_STALE_AFTER
+        // without ever being reaped. Without a heartbeat comfortably
+        // faster than the staleness window, a second daemon starting
+        // mid-way would mistake the still-live holder for an
+        // abandoned one and steal the profile out from under it.
+        assert!(
+            WINLOCK_HEARTBEAT.as_secs() * 3 < WINLOCK_STALE_AFTER.as_secs(),
+            "heartbeat interval must stay comfortably below the staleness window"
+        );
     }
 
     #[test]

--- a/src/ghost/mod.rs
+++ b/src/ghost/mod.rs
@@ -46,16 +46,21 @@ pub const REAP_AFTER: std::time::Duration = std::time::Duration::from_secs(600);
 #[cfg(windows)]
 pub const WINLOCK_STALE_AFTER: std::time::Duration = std::time::Duration::from_secs(600);
 /// Windows profile lockfile: how often a held lockfile's mtime is
-/// refreshed. Must stay comfortably below WINLOCK_STALE_AFTER — a
-/// Ghost only freezes after FREEZE_AFTER idle and only reaps after
-/// REAP_AFTER *frozen*, so a continuously-busy Ghost (never idle
-/// long enough to freeze) can hold the lock far longer than
-/// WINLOCK_STALE_AFTER without ever being reaped. Without a
-/// heartbeat, a second daemon starting mid-way would see the
-/// lockfile's un-refreshed creation-time mtime, mistake the
-/// still-live holder for an abandoned one, and steal the profile
-/// out from under it — exactly the collision this lock exists to
-/// prevent.
+/// refreshed. Must stay comfortably below WINLOCK_STALE_AFTER.
+///
+/// FREEZE_AFTER/REAP_AFTER don't apply here: GhostGuard::drop kills
+/// the Ghost outright on every guard drop on Windows (see
+/// manager.rs), so the lock is normally held only for a single
+/// call's duration. The real trigger is one long-running call: an
+/// `actions` script allows up to MAX_STEPS steps with individual
+/// wait_selector/wait_text polls capped at 60s each (see
+/// actions.rs), so a single guarded call can legitimately run well
+/// past WINLOCK_STALE_AFTER without the Ghost being anywhere near
+/// dead. Without a heartbeat, a second daemon starting mid-call
+/// would see the lockfile's un-refreshed creation-time mtime,
+/// mistake the still-live holder for an abandoned one, and steal
+/// the profile out from under it — exactly the collision this lock
+/// exists to prevent.
 #[cfg(windows)]
 pub const WINLOCK_HEARTBEAT: std::time::Duration = std::time::Duration::from_secs(120);
 
@@ -89,10 +94,10 @@ pub struct Ghost {
     /// shared profile.
     #[cfg(windows)]
     winlock: Option<std::path::PathBuf>,
-    /// Refreshes `winlock`'s mtime on an interval so a live,
-    /// continuously-busy Ghost never looks abandoned to another
-    /// daemon's staleness check (see WINLOCK_HEARTBEAT). Aborted
-    /// in Drop, same as fetch_guard.
+    /// Refreshes `winlock`'s mtime on an interval so a Ghost held
+    /// through one long-running call never looks abandoned to
+    /// another daemon's staleness check (see WINLOCK_HEARTBEAT).
+    /// Aborted in Drop, same as fetch_guard.
     #[cfg(windows)]
     winlock_heartbeat: Option<tokio::task::JoinHandle<()>>,
 }
@@ -505,15 +510,29 @@ impl Ghost {
                         // age: >10min old is taken as orphaned.
                         let _ = f;
                         let lock_path = crate::paths::cache_dir().join("ghost-profile.winlock");
+                        // FILE_SHARE_DELETE (0x4, alongside the usual
+                        // READ|WRITE) explicitly, not relied on as a
+                        // default: without it, Drop's remove_file could
+                        // hit a sharing violation if it races the
+                        // heartbeat's own brief open() on another
+                        // thread, leaving the lockfile behind after a
+                        // clean exit.
                         let take_lock = |p: &std::path::Path| {
+                            use std::os::windows::fs::OpenOptionsExt;
                             std::fs::OpenOptions::new()
                                 .write(true)
                                 .create_new(true)
+                                .share_mode(0x1 | 0x2 | 0x4)
                                 .open(p)
                         };
                         match take_lock(&lock_path) {
                             Ok(_f) => (profile_dir(), None, Some(lock_path)),
                             Err(_) => {
+                                // Sub-second precision (a full Duration
+                                // compare, not `.as_secs() > 600` as
+                                // before) — the boundary shifts by
+                                // under a second either way, moot at a
+                                // 10-minute threshold.
                                 let stale = std::fs::metadata(&lock_path)
                                     .and_then(|m| m.modified())
                                     .ok()
@@ -560,9 +579,16 @@ impl Ghost {
         #[cfg(windows)]
         let winlock_heartbeat = winlock.clone().map(|p| {
             tokio::spawn(async move {
+                use std::os::windows::fs::OpenOptionsExt;
                 loop {
                     tokio::time::sleep(WINLOCK_HEARTBEAT).await;
-                    if let Ok(f) = std::fs::OpenOptions::new().write(true).open(&p) {
+                    // FILE_SHARE_DELETE so this brief handle never
+                    // blocks Drop's remove_file on another thread.
+                    if let Ok(f) = std::fs::OpenOptions::new()
+                        .write(true)
+                        .share_mode(0x1 | 0x2 | 0x4)
+                        .open(&p)
+                    {
                         let _ = f.set_modified(std::time::SystemTime::now());
                     }
                 }
@@ -1871,12 +1897,12 @@ mod sandbox_tests {
     #[cfg(windows)]
     #[test]
     fn winlock_heartbeat_has_safety_margin_under_stale_threshold() {
-        // A continuously-busy Ghost only freezes after FREEZE_AFTER
-        // idle and only reaps after REAP_AFTER *frozen* — so it can
-        // hold the winlock file far longer than WINLOCK_STALE_AFTER
-        // without ever being reaped. Without a heartbeat comfortably
+        // A single long-running actions call (up to MAX_STEPS steps,
+        // each wait_selector/wait_text capped at 60s) can hold the
+        // winlock file far longer than WINLOCK_STALE_AFTER while the
+        // Ghost is nowhere near dead. Without a heartbeat comfortably
         // faster than the staleness window, a second daemon starting
-        // mid-way would mistake the still-live holder for an
+        // mid-call would mistake the still-live holder for an
         // abandoned one and steal the profile out from under it.
         assert!(
             WINLOCK_HEARTBEAT.as_secs() * 3 < WINLOCK_STALE_AFTER.as_secs(),


### PR DESCRIPTION
## Summary

Found by reading through the Windows profile-lockfile logic added in a recent commit (the flock-equivalent for two daemons sharing the same Chromium profile dir).

**The bug**: the lockfile's mtime is set once at creation and never touched again. Staleness is judged purely by that mtime being >10 minutes old (`WINLOCK_STALE_AFTER`). But `GhostGuard::drop` kills the Ghost unconditionally on every guard drop on Windows (`manager.rs`) — so the lock is normally held for exactly one call's duration. The exception: a single `actions` call can legitimately run past 10 minutes in one unbroken hold (up to `MAX_STEPS=16` steps, each `wait_selector`/`wait_text` capped at 60s — `actions.rs`). If a second daemon starts up during that window, it sees the un-refreshed creation-time mtime, concludes the still-live holder is dead, deletes its lockfile, and steals the shared profile — the exact two-daemon collision this lock exists to prevent.

**The fix**: a background task refreshes the lockfile's mtime every 2 minutes (`WINLOCK_HEARTBEAT`) for as long as a Ghost holds it, comfortably below the 10-minute staleness window, aborted in `Drop` alongside the existing `fetch_guard` task (same pattern). Both the initial lock and the heartbeat's periodic reopen now request `FILE_SHARE_DELETE` explicitly, so a heartbeat tick can never block `Drop`'s cleanup on exit.

## Type

- [x] `fix` — bug fix

## Checks

- [x] `cargo test --lib` — 727/729 (2 unrelated, pre-existing failures in `fetch::guards::tests::{ensure_url_safe_blocks_literal,ensure_url_safe_fail_closed_on_dns_error}` — these do live DNS/loopback checks and fail in my sandboxed dev environment's network setup; unrelated file, not touched by this diff, confirmed via `git show --stat`)
- [x] `cargo test --lib ghost::` — 52/52 (the new Windows-gated test correctly compiles out on Linux and doesn't run here)
- [x] `cargo clippy --lib -- -Dwarnings` — zero warnings
- [x] `cargo fmt --all -- --check` — clean
- [ ] `cargo test --features ocr,rerank` — not run locally (same environment limitation as my previous PRs)
- [ ] CI on all 3 platforms — pending, especially interested in the Windows leg here.

## Breaking changes

None.

## Test plan — and an important caveat

I do not have access to a Windows machine, and a full cross-compile from this Linux box fails early at BoringSSL's native-assembly build stage (same limitation as my earlier `known_chrome_paths` macOS fix), so **I could not execute or reproduce the actual race on real Windows.** This fix rests on static reasoning about `FREEZE_AFTER`/`REAP_AFTER`/`GhostGuard::drop`'s interaction (traced through `manager.rs` and `actions.rs` by hand) plus a from-scratch independent code review pass, not a live repro.

What I *could* verify:
- A new `#[cfg(windows)]` regression test pins the safety-margin invariant between `WINLOCK_HEARTBEAT` and `WINLOCK_STALE_AFTER` (3x margin) — it will compile-check and run on the Windows CI leg, but obviously can't simulate the actual two-process race.
- Traced every `Ghost`-dropping code path (`acquire`'s relaunch, the reaper, shutdown) to confirm none of them leak a `Ghost` without running `Drop` (no `mem::forget`/`Box::leak`/detached-Arc patterns anywhere in the codebase for this type).
- Confirmed `tokio::spawn` is valid at this call site (the pre-existing `fetch_guard` task is spawned the same way, a few lines earlier in the same constructor).

What CI's Windows leg will **not** catch, and where I'd specifically want a human with real Windows access to look before merging:
- The actual two-daemon race end-to-end (one daemon busy past 10 minutes via a long `actions` script, a second daemon starting mid-way, confirming it backs off instead of stealing the profile).
- Whether `File::set_modified()` reliably and promptly updates the visible mtime under real-world conditions (AV/EDR software transiently locking the file, non-NTFS volumes, etc.) — heartbeat write failures are currently silent (swallowed via `if let Ok(...)`), so a systemic failure would only surface as an eventual, hard-to-diagnose collision with no diagnostic trail. Happy to add `DONGHOST_DEBUG` logging on heartbeat failures in a follow-up if that'd help.

## Contributor note

This went through an unusually adversarial self-review round given the "can't test on Windows" risk — the first draft's doc comments incorrectly blamed a "continuously-busy Ghost" (a framing that doesn't actually apply on Windows, since the Ghost dies after every single guard use there) instead of the real trigger (one long `actions` call), and the review also caught a plausible Drop-vs-heartbeat file-sharing race that the `FILE_SHARE_DELETE` addition closes. Both are fixed in the second commit on this branch. I'd rather have this land after a human with Windows access has poked at it than assume it's correct — genuinely open to "hold this until someone can verify on real hardware" if that's the right call.