### PR TITLE
fix(ghost): safe_member rejects Windows rooted-without-drive archive paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -102,6 +102,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lockfile's mtime now gets refreshed every 2 minutes for as long
   as a Ghost holds it, opened with FILE_SHARE_DELETE so the
   refresh can never block cleanup on exit.
+- **CloakBrowser archive extraction didn't reject rooted paths on
+  Windows:** `safe_member()`'s traversal guard used `is_absolute()`,
+  which requires a drive prefix on Windows — a path like
+  `/tmp/chrome` has a root but no prefix, so `is_absolute()` is
+  false there even though joining it onto the extraction dir still
+  escapes it (Windows path-join semantics replace everything past
+  the prefix for any rooted push). Practical impact is narrow: the
+  archive comes from a single pinned repository and is SHA256-
+  verified against a checksum baked into this binary before
+  extraction ever starts, so exploiting this needs a compromise of
+  that supply chain, not just an untrusted archive. Switched the
+  guard to `has_root()`, which `is_absolute()` is itself defined as
+  on Unix (no behavior change there) and is the correct, broader
+  check on Windows.
 - **Browser fingerprint noise:** the ghost no longer runs Chrome
   default apps or extensions, killing the surprise-component
   detection class (enumerable extensions, default-app traffic)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,10 +109,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   false there even though joining it onto the extraction dir still
   escapes it (Windows path-join semantics replace everything past
   the prefix for any rooted push). Practical impact is narrow: the
-  archive comes from a single pinned repository and is SHA256-
-  verified against a checksum baked into this binary before
-  extraction ever starts, so exploiting this needs a compromise of
-  that supply chain, not just an untrusted archive. Switched the
+  archive's hash is checked against a manifest that is itself
+  Ed25519-signed and verified against a public key pinned in this
+  binary, before extraction ever starts — exploiting this needs a
+  compromise of that signing key or release process, not just an
+  untrusted archive. Switched the
   guard to `has_root()`, which `is_absolute()` is itself defined as
   on Unix (no behavior change there) and is the correct, broader
   check on Windows.

--- a/src/ghost/cloak.rs
+++ b/src/ghost/cloak.rs
@@ -470,7 +470,15 @@ fn extract_archive(archive_path: &Path, root: &Path) -> Result<(), String> {
 }
 
 fn safe_member(path: &Path) -> Result<(), String> {
-    if path.is_absolute() || path.components().any(|c| matches!(c, Component::ParentDir)) {
+    // has_root(), not is_absolute(): on Windows a path can have a
+    // root without a drive prefix (`\tmp\chrome`, or `/tmp/chrome`
+    // once the archive's forward slashes are turned into
+    // components) and is_absolute() returns false for those —
+    // joining one onto the extraction dir still replaces
+    // everything past the prefix, escaping it just the same. Unix
+    // defines is_absolute() as has_root(), so this is a no-op
+    // there.
+    if path.has_root() || path.components().any(|c| matches!(c, Component::ParentDir)) {
         Err(format!(
             "archive path escapes extraction root: {}",
             path.display()


### PR DESCRIPTION
## Summary

Found via a genuinely unrelated CI failure on #97 (already merged): `ghost::cloak::tests::archive_paths_reject_traversal` — an unconditional test that runs on every platform — has apparently always failed specifically on the Windows CI leg.

`safe_member()` guards every entry inside a downloaded CloakBrowser archive before it's joined onto the extraction directory and written to disk (a zip-slip / path-traversal guard). It checked `path.is_absolute()`, but on Windows that requires *both* a root *and* a drive prefix — a path like `/tmp/chrome` (root, no prefix) is not "absolute" there, even though joining it onto the extraction dir still escapes it: Windows' `PathBuf::push`/`.join()` replaces everything past the prefix when the pushed component has a root, regardless of whether it's "absolute" by that stricter definition.

Fix: use `has_root()` instead. On Unix, `is_absolute()` is *defined* as `has_root()` (verified against std's documented semantics), so this is a no-op there — it only changes (correctly broadens) behavior on Windows. No new test needed: the existing `archive_paths_reject_traversal` already asserts exactly the `/tmp/chrome` case and should now pass on Windows instead of failing.

## Type

- [x] `fix` — bug fix

## Checks

- [x] `cargo test --lib ghost::cloak::` passes (7/7)
- [x] `cargo test --lib` — 732/733 (1 unrelated, pre-existing sandbox-network flake in `fetch::guards::tests::ensure_url_safe_blocks_literal`, a live-DNS/loopback check that misbehaves under this dev environment's network sandboxing — unrelated file, not touched by this diff)
- [x] `cargo clippy --lib -- -Dwarnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes
- [ ] `cargo test --features ocr,rerank` — not run locally (same environment limitation as my previous PRs)
- [ ] CI on all 3 platforms — pending, obviously most interested in the Windows leg.

## Breaking changes

None.

## A note on severity / why this is a normal PR and not a private security advisory

I checked `SECURITY.md`'s disclosure policy before opening this publicly, since it's a path-traversal fix in archive extraction. Read through the full download → verify → extract pipeline in `cloak.rs`: the archive's hash is checked against a manifest that is itself Ed25519-signed and verified against a public key (`CLOAK_SIGNING_KEY`) pinned in this binary, and a mismatch is a hard `Result::Err` — there's no fallback or warning-only path, `extract_tar`/`extract_zip` are unreachable on a bad archive. `CLOAKBROWSER_VERSION` only selects a release tag (validated against injection, see `version_pin_rejects_url_injection`) under the single hardcoded `CLOAK_REPOSITORY`; `CLOAKBROWSER_BINARY_PATH` is a fully separate code path that skips the entire download/verify/extract pipeline and never reaches `safe_member` at all. So exploiting the traversal gap this fixes would need a compromise of the signing key or release process itself — at which point an attacker has a much more direct path to arbitrary code (ship a malicious binary through the same trusted channel) than a path-traversal write during extraction. Judged this as defense-in-depth hardening on a secondary layer, not a standalone exploitable vulnerability in DonSeTch's own trust boundary, and appropriate for a normal public fix.

## Test plan

- `has_root()` vs `is_absolute()` semantics verified against Rust's documented platform-specific behavior, not just local testing (can't reproduce the Windows-specific difference on this Linux dev machine — `is_absolute() == has_root()` always on Unix, so there's no input where they'd disagree here).
- Swept the rest of the file (and the wider codebase) for the same mistake class — no other `is_absolute()`-based path-safety checks besides one in `src/paths.rs` (`resolve_screenshot_path`), which is *not* currently exploitable because an independent, unconditional canonicalize-under-root check afterward would catch and reject the same escape regardless. Not part of this PR's scope; happy to open a small follow-up for consistency if wanted.

## Contributor note

Another one that fell out of investigating an unrelated CI failure rather than deliberate searching — happy to also file the `src/paths.rs` follow-up separately if useful, or leave it since it's not currently reachable.