### PR TITLE
fix(search): prefer Bing result heading links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   down.
 - **PathBuf import now gated by x86_64 flag (PR #104):** this import
   was used only on x86_64 and caused clippy errors on other architectures.
+- **Bing result cards could expose attribution links as results (PR #99):**
+  grouped selectors followed document order and could choose the breadcrumb
+  anchor before the actual heading. Bing parsing now prefers the `h2` result
+  link while retaining the existing fallback selectors.
 
 
 ## [3.5.0] - 2026-09-01

--- a/src/search/engines.rs
+++ b/src/search/engines.rs
@@ -355,16 +355,22 @@ fn parse_brave(doc: &Html) -> Vec<Hit> {
 
 fn parse_bing(doc: &Html) -> Vec<Hit> {
     let items = sel("li.b_algo");
-    // Primary: h2 a; fallback: h2 > a, a.tilk, a[data-h]
-    let link = sel("h2 a, h2 > a, a.tilk, a[data-h]");
+    // Keep the title link and the attribution link separate. A grouped
+    // selector returns matches in document order, not selector-preference
+    // order; Bing places `a.tilk` (site + breadcrumb) before `h2 a`, so the
+    // old grouped selector silently used the breadcrumb as both URL and
+    // title on every result.
+    let title_link = sel("h2 a");
+    let fallback_link = sel("a.tilk, a[data-h]");
     // Primary: .b_caption p; fallback: .b_lineclamp*, [data-text]
     let cap = sel(".b_caption p, .b_lineclamp2, .b_lineclamp3, .b_lineclamp4, p[data-text]");
     let h2 = sel("h2");
     let mut hits = Vec::new();
     for (rank, li) in doc.select(&items).enumerate() {
         let Some(a) = li
-            .select(&link)
+            .select(&title_link)
             .next()
+            .or_else(|| li.select(&fallback_link).next())
             .or_else(|| li.select(&sel("a[href]")).next())
         else {
             continue;
@@ -666,5 +672,27 @@ mod tests {
         assert_eq!(hits.len(), 1, "SERP URL should be filtered, got {hits:?}");
         assert_eq!(hits[0].url, "https://doc.rust-lang.org/book");
         assert_eq!(hits[0].title, "The Rust Book");
+    }
+
+    #[test]
+    fn bing_prefers_result_heading_over_earlier_attribution_link() {
+        let html = r#"
+        <html><body><ol>
+          <li class="b_algo">
+            <div class="b_tpcn">
+              <a class="tilk" href="https://www.bing.com/site-attribution">
+                <span>rust-lang.org</span><cite>https://doc.rust-lang.org › book</cite>
+              </a>
+            </div>
+            <h2><a href="https://doc.rust-lang.org/book/">The Rust Programming Language</a></h2>
+            <div class="b_caption"><p>Learn Rust ownership and borrowing.</p></div>
+          </li>
+        </ol></body></html>
+        "#;
+        let hits = parse("bing", html);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].title, "The Rust Programming Language");
+        assert_eq!(hits[0].url, "https://doc.rust-lang.org/book/");
+        assert!(!hits[0].title.contains("https://"));
     }
 }


### PR DESCRIPTION
### Summary

I found that Bing can place its attribution/breadcrumb anchor before the real
`h2` result link. A grouped selector follows document order rather than selector
preference, so the parser could use the breadcrumb as both title and target.

I now prefer the heading anchor and retain the existing attribution and generic
fallbacks for older layouts. This is deliberately a parser correction, not a
ranking heuristic.

### Verification

- Added a fixture where attribution and heading point to different URLs.
- Asserted the exact clean title, correct target URL, and absence of displayed
  URL text in the title.
- Ran the complete `ocr,rerank` suite, Clippy with warnings denied, and rustfmt
  on the integrated v3.5.0 tree.

### Alternatives considered

Post-processing breadcrumb-looking titles in the ranker was rejected because
the parser already has an unambiguous structural signal. Removing fallback
selectors was also rejected because older Bing layouts may still need them.
