### PR TITLE
fix(search): extract Yahoo result headings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   page could appear as distinct candidates. Deduplication now drops a
   conservative set of known tracking keys while preserving meaningful query
   parameters, ordering, and encoding. (changelog: document tracking-parameter deduplication)
+- **Yahoo result titles included breadcrumb and URL text (PR #100):**
+  result cards can wrap their breadcrumb and heading in one outer link, so
+  reading the whole anchor produced noisy titles. Yahoo parsing now extracts
+  the dedicated heading first and keeps the outer text as a fallback.
 
 
 ## [3.5.0] - 2026-09-01

--- a/src/search/engines.rs
+++ b/src/search/engines.rs
@@ -545,12 +545,12 @@ fn parse_yahoo(doc: &Html) -> Vec<Hit> {
         if !url.starts_with("http") {
             continue;
         }
-        let title = text(a);
-        let title = if title.is_empty() {
-            item.select(&h3).next().map(text).unwrap_or_default()
-        } else {
-            title
-        };
+        // Yahoo nests the breadcrumb and the h3 inside the same outer link.
+        // `text(a)` therefore concatenates site name + URL + real title. Use
+        // the dedicated heading first and retain the outer text only as a
+        // fallback for older layouts without an h3.
+        let heading = item.select(&h3).next().map(text).unwrap_or_default();
+        let title = if heading.is_empty() { text(a) } else { heading };
         let snippet = item.select(&cap).next().map(text).unwrap_or_default();
         if !title.is_empty() {
             hits.push(Hit {
@@ -692,7 +692,24 @@ mod tests {
         let hits = parse("bing", html);
         assert_eq!(hits.len(), 1);
         assert_eq!(hits[0].title, "The Rust Programming Language");
-        assert_eq!(hits[0].url, "https://doc.rust-lang.org/book/");
-        assert!(!hits[0].title.contains("https://"));
+        assert_eq!(hits[0].url, "https://doc.rust-lang.org/book/");        assert!(!hits[0].title.contains("https://"));
+    }
+
+    #[test]
+    fn yahoo_extracts_heading_instead_of_outer_link_breadcrumb() {
+        let html = r#"
+        <html><body>
+          <div class="compTitle options-toggle">
+            <a data-matarget="algo" href="https://example.com/ownership">
+              <div><span>Example</span>https://example.com › ownership</div>
+              <h3 class="title"><span>Understanding Ownership</span></h3>
+            </a>
+            <div class="compText"><p>A focused explanation.</p></div>
+          </div>
+        </body></html>
+        "#;
+        let hits = parse("yahoo", html);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].title, "Understanding Ownership");        assert!(!hits[0].title.contains("https://"));
     }
 }


### PR DESCRIPTION
### Summary

Yahoo can wrap its breadcrumb, displayed URL, and nested `h3` in one outer
anchor. Reading the full anchor text contaminates the title passed into ranking.

I now use the dedicated heading when present and keep the outer anchor text as a
fallback. URL decoding, snippets, ranks, and legacy layouts are unchanged.

### Verification

- Added the nested outer-anchor layout that reproduces the contamination.
- Asserted the exact heading and that displayed URL text does not leak.
- Verified the standalone one-commit branch and the combined integration tree.

### Alternatives considered

Generic title cleanup after parsing was rejected because it would guess at
presentation text across every provider. The nested `h3` is the provider's
explicit result-title boundary and is therefore the narrowest reliable fix.
