### PR TITLE
fix(extract): preserve requested table-of-contents projections

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   grouped selectors followed document order and could choose the breadcrumb
   anchor before the actual heading. Bing parsing now prefers the `h2` result
   link while retaining the existing fallback selectors.
+- **Requested table-of-contents output could be replaced by page text
+  (PR #101):** content-rescue paths treated a compact outline as a failed
+  extraction on long pages. A completed TOC projection now returns directly
+  instead of falling through to body-oriented rescue.
 
 
 ## [3.5.0] - 2026-09-01

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -511,6 +511,13 @@ pub fn extract(
         max_chars,
     )?;
 
+    // A TOC is a complete projection, not a failed short extraction. Once
+    // downstream has built the outline, content-oriented rescue paths must
+    // not replace it with the page body.
+    if opts.toc {
+        return Ok(extracted);
+    }
+
     // JSON-in-script rescue: SPAs (Next.js/React/YouTube) embed
     // their content as a JS-assigned JSON blob. DonSift sees an
     // empty shell, but the data is sitting in the HTML. When

--- a/src/extract/tests.rs
+++ b/src/extract/tests.rs
@@ -931,6 +931,25 @@ fn toc_mode_flat_page() {
     assert!(r.markdown.contains("no headings"));
 }
 
+#[test]
+fn toc_mode_is_not_replaced_by_raw_text_fallback() {
+    let body = "This paragraph belongs to the page body, not to its requested outline. ".repeat(20);
+    let html = format!(
+        r#"<html><head><title>Small guide</title></head><body><article>
+<h1>Small guide</h1><p>{body}</p>
+</article></body></html>"#
+    );
+    let r = extract_html_opts(
+        &html,
+        &ExtractOptions {
+            toc: true,
+            ..Default::default()
+        },
+    );
+    assert!(r.markdown.contains("[s1] Small guide"), "{}", r.markdown);
+    assert!(!r.markdown.contains("This paragraph belongs"));
+}
+
 // ════════════════════════════════════════════════════════════
 // 9. SECTION MODE
 // ════════════════════════════════════════════════════════════


### PR DESCRIPTION
### Summary

An explicitly requested table of contents is intentionally short. On a page
with a long visible body, the raw-text rescue path could misinterpret that
compact projection as a failed extraction and replace it with the full page.

I treat a successfully rendered TOC as a completed projection before entering
content-oriented rescue paths. Full-page extraction and its fallbacks retain
their existing behavior.

### Verification

- Added a long-body fixture with a short one-heading TOC.
- The regression fails on the parent because the body replaces the outline.
- The fixed path retains the stable section identifier and excludes body text.
- The complete required test/Clippy/fmt gates pass.

### Alternatives considered

Lowering the global extraction threshold was rejected because it would weaken
rescue behavior for genuinely failed full-page extraction. Special-casing by
output length was also rejected; the request mode itself is the correct
semantic boundary.
