### PR TITLE
fix(extract): exclude PDFs from HTML shell detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (PR #101):** content-rescue paths treated a compact outline as a failed
   extraction on long pages. A completed TOC projection now returns directly
   instead of falling through to body-oriented rescue.
+- **Short PDFs could be mislabeled as HTML application shells (PR #102):**
+  downstream shell heuristics could mark valid, compact PDF output as thin
+  and suggest browser rendering. Documents already identified through PDF
+  page metadata now bypass HTML-only shell classification.
 
 
 ## [3.5.0] - 2026-09-01

--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -981,7 +981,12 @@ fn downstream(
         1.0
     };
     let is_shell = raw_len > 20_000 && density < 0.05 && full.len() < 3_000;
-    let thin = !section_hit
+    // A PDF can legitimately contain only a few words. It is already parsed
+    // from a complete binary document, so HTML shell heuristics must never
+    // label a short PDF as a JS-rendered page.
+    let is_pdf = pdf_pages.is_some();
+    let thin = !is_pdf
+        && !section_hit
         && ((full.len() < 800 && (thin_flag || raw_len > 5_000 || blocks_total == 0))
             || (thin_flag && has_skeletons && full.len() < 4000)
             || is_shell);

--- a/src/extract/tests.rs
+++ b/src/extract/tests.rs
@@ -1164,6 +1164,43 @@ fn content_density_large_page_many_chars_not_thin() {
     );
 }
 
+#[test]
+fn short_pdf_is_not_classified_as_an_html_shell() {
+    let doc = Html::parse_document("<html lang=\"en\"><title>Receipt</title></html>");
+    let meta = metadata::metadata(&doc);
+    let blocks = vec![blocks::Block::Para {
+        md: "Total due: EUR 12".to_string(),
+        link_density: 0.0,
+        path: Vec::new(),
+    }];
+    let pages = vec![crate::pdf::PageMeta {
+        page: 0,
+        chars: 17,
+        ocr: false,
+        confidence: 1.0,
+    }];
+    let lang = language::detect(&doc);
+
+    let out = downstream(
+        &meta,
+        blocks,
+        25_000,
+        false,
+        false,
+        Vec::new(),
+        lang,
+        Some(pages),
+        "https://example.com/receipt.pdf",
+        &ExtractOptions::default(),
+        16_000,
+    )
+    .unwrap();
+
+    assert!(!out.thin);
+    assert!(!out.markdown.contains("JS-rendered"));
+    assert_eq!(out.pdf_pages.as_ref().map(Vec::len), Some(1));
+}
+
 // ════════════════════════════════════════════════════════════
 // 12. CROSS-BLOCK DEDUP
 // ════════════════════════════════════════════════════════════


### PR DESCRIPTION
### Summary

DonSheet has already parsed PDF bytes when shared downstream extraction sees
per-page metadata. Applying HTML density and JavaScript-shell heuristics to a
short parsed document can incorrectly set `thin=true` and inject an SPA warning.

I use the existing PDF metadata boundary to bypass only HTML shell detection.
PDF parsing, HTML thresholds, and normal thin-content behavior are unchanged.

### Verification

- Added a corpus-free regression using the same compact block/per-page shape
  produced by DonSheet.
- On the parent, the fixture is marked thin; with the fix it remains complete,
  keeps PDF metadata, and has no JS-rendered warning.
- Full feature tests, Clippy, and formatting pass on v3.5.0.

### Alternatives considered

Relaxing HTML density thresholds was rejected because it changes real SPA
detection. Adding PDF-specific content padding was rejected because it would
modify evidence merely to satisfy an unrelated heuristic.
