### PR TITLE
fix(search): ignore tracking parameters during URL deduplication

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   downstream shell heuristics could mark valid, compact PDF output as thin
   and suggest browser rendering. Documents already identified through PDF
   page metadata now bypass HTML-only shell classification.
+- **Tracking parameters split identical search results during URL
+  deduplication (PR #103):** normalized URL keys retained analytics
+  identifiers such as `utm_*`, `gclid`, `fbclid`, and `msclkid`, so the same
+  page could appear as distinct candidates. Deduplication now drops a
+  conservative set of known tracking keys while preserving meaningful query
+  parameters, ordering, and encoding. (changelog: document tracking-parameter deduplication)
 
 
 ## [3.5.0] - 2026-09-01

--- a/src/search/rank.rs
+++ b/src/search/rank.rs
@@ -54,8 +54,44 @@ pub fn norm_key(raw: &str) -> String {
         .trim_end_matches("/index.html")
         .trim_end_matches("/index.htm")
         .to_lowercase();
-    let query = u.query().map(|q| format!("?{q}")).unwrap_or_default();
+    let query = u
+        .query()
+        .map(|query| {
+            let kept = query
+                .split('&')
+                .filter(|pair| {
+                    url::form_urlencoded::parse(pair.as_bytes())
+                        .next()
+                        .is_none_or(|(key, _)| !is_tracking_query_key(&key))
+                })
+                .collect::<Vec<_>>();
+            if kept.is_empty() {
+                String::new()
+            } else {
+                format!("?{}", kept.join("&"))
+            }
+        })
+        .unwrap_or_default();
     format!("{host}{path}{query}")
+}
+
+fn is_tracking_query_key(key: &str) -> bool {
+    let key = key.to_ascii_lowercase();
+    key.starts_with("utm_")
+        || matches!(
+            key.as_str(),
+            "fbclid"
+                | "gclid"
+                | "dclid"
+                | "msclkid"
+                | "msockid"
+                | "mc_cid"
+                | "mc_eid"
+                | "igshid"
+                | "ref_src"
+                | "_ga"
+                | "_gl"
+        )
 }
 
 pub fn host_of(raw: &str) -> String {
@@ -488,6 +524,40 @@ mod tests {
         let a = norm_key("https://www.docs.rs/ratatui/index.html");
         let b = norm_key("http://docs.rs/ratatui/");
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn norm_key_drops_tracking_but_preserves_meaningful_query_parameters() {
+        let tracked = norm_key(
+            "https://example.com/search?topic=rust&utm_source=newsletter&page=2&gclid=abc",
+        );
+        let clean = norm_key("https://example.com/search?topic=rust&page=2");
+        let different_page = norm_key("https://example.com/search?topic=rust&page=3");
+
+        assert_eq!(tracked, clean);
+        assert_ne!(clean, different_page);
+    }
+
+    #[test]
+    fn norm_key_preserves_meaningful_query_order_and_encoding() {
+        assert_ne!(
+            norm_key("https://example.com/workflow?step=one&step=two"),
+            norm_key("https://example.com/workflow?step=two&step=one")
+        );
+        assert_ne!(
+            norm_key("https://example.com/search?q%3Da=b"),
+            norm_key("https://example.com/search?q=a%3Db")
+        );
+    }
+
+    #[test]
+    fn norm_key_detects_encoded_and_case_insensitive_tracking_keys() {
+        let clean = norm_key("https://example.com/page?id=7");
+        assert_eq!(
+            norm_key("https://example.com/page?%75tm_source=x&id=7&FBCLID=y"),
+            clean
+        );
+        assert_ne!(norm_key("https://example.com/page?ref=docs&id=7"), clean);
     }
 
     #[test]


### PR DESCRIPTION
### Summary

Search consensus treated one page as multiple results when providers attached
analytics parameters. I remove only known tracking keys from the internal
deduplication key while preserving meaningful query bytes, ordering, repeated
parameters, and encoded delimiters.

This improves duplicate collapse and cross-provider agreement without claiming
that arbitrary query strings are interchangeable.

### Verification

- Covered ordinary, case-insensitive, and percent-encoded tracking keys.
- Preserved an unclassified `ref` parameter and meaningful page values.
- Proved repeated-key order and encoded delimiters cannot collide.
- Full v3.5.0 validation is green.

### Alternatives considered

Sorting or decoding the full query was rejected because query order and encoded
syntax can be application semantics. A large generic ignore list was rejected
because false equivalence is worse than failing open on an unknown tracker.
