### PR TITLE
fix(cpu): gate x86-only path imports

### DIFF
--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -11,6 +11,7 @@
 //! start. With `load-dynamic`, ONNX is dlopen'd at runtime, but only
 //! after this check confirms AVX support.
 
+#[cfg(target_arch = "x86_64")]
 use std::path::PathBuf;
 #[cfg(target_arch = "x86_64")]
 use std::sync::OnceLock;


### PR DESCRIPTION
### Summary

`PathBuf` is used only by the x86_64 AVX cache path. Importing it
unconditionally leaves a warning on ARM, which becomes a build failure under
the project's required `-Dwarnings` Clippy gate.

I apply the same target gate already used by every consumer. This changes no
runtime behavior on x86 or non-x86 targets.

### Verification

- Rebuilt exact upstream v3.5.0 on macOS ARM and reproduced the unused-import
  warning before the commit.
- The final integration passes all-target Clippy with warnings denied.
- Existing CPU feature tests remain green.

### Alternatives considered

Suppressing the warning globally was rejected because it hides future unused
imports. Importing inside one function was possible but less consistent than
the module's existing target gates.
