### PR TITLE
fix(pdf): bookmark titles get 2 trailing NULs from a byte/unit mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   result cards can wrap their breadcrumb and heading in one outer link, so
   reading the whole anchor produced noisy titles. Yahoo parsing now extracts
   the dedicated heading first and keeps the outer text as a fallback.
+- **PDF bookmark titles carried two trailing NUL characters:**
+  `FPDF_GetMetaText`/`FPDFBookmark_GetTitle` report their length in bytes
+  (including the UTF-16 NUL terminator), but the decode call was treating
+  that count as UTF-16 units — a mismatch that read past the real string
+  into the buffer's zero-initialized slack. `get_meta`'s output was
+  unaffected (it already strips all `'\0'` chars), but every extracted
+  outline/bookmark title picked up two invisible trailing NULs. Both call
+  sites now convert bytes to units first, matching the sibling
+  `field_string` helper in `forms.rs`, which already did this correctly.
 
 
 ## [3.5.0] - 2026-09-01

--- a/src/pdf/engine.rs
+++ b/src/pdf/engine.rs
@@ -399,6 +399,19 @@ fn decode_utf16(buf: &[u16], len_units: usize) -> String {
     String::from_utf16_lossy(&buf[..end])
 }
 
+/// Decode a UTF-16LE buffer using a PDFium-reported BYTE count, as
+/// returned by `FPDF_GetMetaText`/`FPDFBookmark_GetTitle` (both
+/// count bytes, including the NUL terminator — see their headers in
+/// fpdf_doc.h). `decode_utf16` above takes a UNIT count instead;
+/// passing a byte count straight through reads past the real string
+/// into the buffer's zero-initialized tail, appending trailing NULs
+/// (the buffers here are always over-allocated by a few units past
+/// what the byte count implies, matching the sibling `field_string`
+/// helper in forms.rs, which does this division correctly).
+fn decode_utf16_from_byte_count(buf: &[u16], byte_count: usize) -> String {
+    decode_utf16(buf, (byte_count / 2).min(buf.len()))
+}
+
 /// Fonts whose glyphs are pictures, not text (checkboxes, seals,
 /// logo art). Detected once at intern time.
 pub fn is_dingbat_family(name: &str) -> bool {
@@ -457,7 +470,7 @@ fn get_meta(doc: FpdfDocument, tag: &str, buf: &mut Vec<u16>) -> Option<String> 
                 return None;
             }
         }
-        let s = decode_utf16(buf, n.min(buf.len()));
+        let s = decode_utf16_from_byte_count(buf, n);
         let cleaned: String = s.chars().filter(|&c| c != '\0').collect();
         let s = cleaned.trim();
         if s.is_empty() {
@@ -480,7 +493,7 @@ fn bookmark_title(bm: FpdfBookmark) -> String {
             buf.as_mut_ptr() as *mut c_void,
             (buf.len() * 2) as c_ulong,
         ) as usize;
-        decode_utf16(&buf, n2.min(buf.len()))
+        decode_utf16_from_byte_count(&buf, n2)
     }
 }
 
@@ -905,5 +918,56 @@ where
 
         drop(guard);
         Ok((raw, pages_out))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_utf16_from_byte_count_strips_terminator_and_padding() {
+        // Mimics the real buffer shape at both call sites: "Hi" (2
+        // UTF-16 units) + a NUL terminator (1 unit) written by
+        // PDFium, followed by the caller's over-allocated slack
+        // (the `n/2 + 2` sizing convention), left zero-initialized.
+        let buf: Vec<u16> = vec![
+            'H' as u16, 'i' as u16, 0x0000, // title + NUL terminator
+            0x0000, 0x0000, // caller's slack padding
+        ];
+        // PDFium reports byte counts, not unit counts: a 2-char
+        // title + its NUL terminator is (2 + 1) * 2 = 6 bytes.
+        assert_eq!(decode_utf16_from_byte_count(&buf, 6), "Hi");
+    }
+
+    #[test]
+    fn decode_utf16_from_byte_count_handles_empty_title() {
+        let buf: Vec<u16> = vec![0x0000, 0x0000];
+        // byte_count for just the NUL terminator: 1 unit * 2 = 2.
+        assert_eq!(decode_utf16_from_byte_count(&buf, 2), "");
+    }
+
+    #[test]
+    fn decode_utf16_from_byte_count_never_reads_past_the_buffer() {
+        // A byte_count larger than the actual buffer must never
+        // panic — defensive against a hostile/corrupt PDF causing
+        // PDFium to report an implausible size.
+        let buf: Vec<u16> = vec!['x' as u16, 0x0000];
+        assert_eq!(decode_utf16_from_byte_count(&buf, 1_000_000), "x");
+    }
+
+    #[test]
+    fn decode_utf16_from_byte_count_matches_unit_count_form() {
+        // Regression for the actual bug: the byte-count form must
+        // agree with calling decode_utf16 directly with the correct
+        // UNIT count, not the byte count itself passed straight
+        // through (which is what both call sites used to do).
+        let buf: Vec<u16> = vec!['h' as u16, 'i' as u16, 0x0000, 0x0000];
+        let byte_count = 6; // (2 chars + NUL) * 2
+        let unit_count = 3; // 2 chars + NUL
+        assert_eq!(
+            decode_utf16_from_byte_count(&buf, byte_count),
+            decode_utf16(&buf, unit_count)
+        );
     }
 }


### PR DESCRIPTION
## Summary

Found during a broader security-focused read-through of the PDF/PDFium FFI layer (nothing memory-unsafe found there overall — this is a text-correctness bug, not a security issue).

`FPDF_GetMetaText`/`FPDFBookmark_GetTitle` report their length in **bytes** (including the UTF-16LE NUL terminator — see `fpdf_doc.h`), but both `get_meta()` and `bookmark_title()` in `src/pdf/engine.rs` passed that byte count straight into `decode_utf16(buf, len_units)`, which expects a UTF-16 **unit** count. The mismatch reads past the real decoded string into the buffer's zero-initialized slack (both call sites deliberately over-allocate to `n/2 + 2` units for a safe refetch — that slack is exactly what leaks through).

Practical impact differs between the two call sites:
- `get_meta()`'s output is unaffected — its caller already does `s.chars().filter(|&c| c != '\0').collect()` before returning, silently stripping the garbage tail.
- `bookmark_title()`'s result flows straight into `OutlineItem.title` with nothing downstream to filter it: **every extracted PDF bookmark/outline title carries exactly 2 trailing NUL characters.**

Fix: added `decode_utf16_from_byte_count()`, the correct bytes→units conversion, mirroring the sibling `field_string()` helper in `src/pdf/forms.rs` (used for AcroForm field values), which already divides by 2 correctly. Switched both call sites to it.

## Type

- [x] `fix` — bug fix

## Checks

- [x] `cargo test --lib pdf::engine::` passes (4/4 new unit tests)
- [x] `cargo test --lib` passes (744/744)
- [x] `cargo clippy --lib -- -Dwarnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes
- [ ] `cargo test --features ocr,rerank` — not run locally (same environment limitation as my previous PRs)
- [ ] CI on all 3 platforms — pending.

## Breaking changes

None.

## Test plan

- 4 new unit tests directly exercise `decode_utf16_from_byte_count()`'s byte→unit math: strips the terminator and padding correctly, handles an empty title, never reads past the buffer even with a wildly-wrong byte count (defensive against a hostile/corrupt PDF), and agrees with calling `decode_utf16()` directly using the hand-computed correct unit count.
- Honest caveat: these test the new helper directly, not the old buggy call sites end-to-end (`bookmark_title`/`get_meta` need a real PDFium document/bookmark handle, and there's no existing fixture-driven outline-extraction test in the codebase to hook into for this fix's scope). The byte/unit math is the actual bug and is what's pinned.
- Grepped for other `decode_utf16` call sites — these are the only two, and they're now both fixed; `field_string` in `forms.rs` (a structurally similar helper) already did the division correctly, confirming the bug was isolated to these two spots.

## Contributor note

Not the primary target of the security sweep this came out of — this is the one non-security (text-correctness) finding from that pass. Happy to also look at filing a follow-up for `get_meta`'s post-resize decode always using the first call's byte count (`n`) rather than the refetch's (`n2`) — almost certainly benign since PDFium's contract should make them equal once the buffer is sized correctly, but noting it in case it's worth a defensive tweak; didn't want to bundle an unrelated speculative change into this fix.