### PR TITLE
feat(byok): add SerpBase (Google SERP) as a BYOK provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -472,6 +472,7 @@ donsetch keys add tavily tvly-...       # Tavily
 donsetch keys add exa sk-exa-...        # Exa (stackable)
 donsetch keys add serper ...            # Serper.dev
 donsetch keys add serpapi ...           # SerpApi
+donsetch keys add serpbase sb-...       # SerpBase Google SERP (100 free searches)
 donsetch keys add bravesearch ...       # Brave Search API
 donsetch keys add tinyfish sk-...       # TinyFish (free tier)
 donsetch keys add parallel nKil3...     # Parallel AI (fast mode)

--- a/src/cli/keys.rs
+++ b/src/cli/keys.rs
@@ -9,7 +9,7 @@
 //!   donsetch keys import <path>            Import keys from a file
 //!   donsetch keys clear                     Remove all keys
 //!
-//! Providers: tavily, exa, serper, serpapi, bravesearch, tinyfish, parallel, brightdata, unlocker
+//! Providers: tavily, exa, serper, serpapi, serpbase, bravesearch, tinyfish, parallel, brightdata, unlocker
 
 use super::{bold, dim, green, red};
 
@@ -466,6 +466,7 @@ fn print_help() {
     println!("    exa        Exa AI Search (api.exa.ai)");
     println!("    serper     Serper.dev Google SERP (google.serper.dev)");
     println!("    serpapi    SerpApi Google SERP (serpapi.com)");
+    println!("    serpbase   SerpBase Google SERP (serpbase.dev)");
     println!("    bravesearch Brave Search API (api.search.brave.com)");
     println!("    tinyfish   TinyFish Search (api.search.tinyfish.ai)");
     println!("    parallel   Parallel AI Search (api.parallel.ai) : fast mode");

--- a/src/search/byok/mod.rs
+++ b/src/search/byok/mod.rs
@@ -19,6 +19,7 @@ mod brightdata;
 mod exa;
 mod parallel;
 mod serpapi;
+mod serpbase;
 mod serper;
 pub mod store;
 mod tavily;
@@ -258,6 +259,7 @@ async fn dispatch(
         "exa" => exa::search(client, key, query, max, intent).await,
         "serper" => serper::search(client, key, query, max, intent).await,
         "serpapi" => serpapi::search(client, key, query, max, intent).await,
+        "serpbase" => serpbase::search(client, key, query, max, intent).await,
         "bravesearch" => bravesearch::search(client, key, query, max, intent).await,
         "tinyfish" => tinyfish::search(client, key, query, max, intent).await,
         "parallel" => parallel::search(client, key, query, max, intent).await,

--- a/src/search/byok/serpbase.rs
+++ b/src/search/byok/serpbase.rs
@@ -1,0 +1,209 @@
+//! SerpBase (serpbase.dev) Google SERP provider adapter.
+//!
+//! POST https://api.serpbase.dev/google/search
+//! Auth: X-API-Key <key> (header)
+//! Body: { q, num, hl, gl }
+//! Response: { status, organic: [{ position, title, link, snippet }], ... }
+//!
+//! `status` is a business-level code: 0 = success, non-zero = error
+//! (e.g. 1001 unauthorized). Errors may come back as HTTP 200 with a
+//! non-zero `status` envelope, so the status field must be checked
+//! even on 2xx responses.
+//!
+//! Correctness note: this adapter follows the *current* SerpBase API
+//! contract (POST + JSON body + `X-API-Key` header, results under
+//! `organic`). Earlier public examples used `GET /google/search?api_key=`
+//! and an `organic_results` field; that contract is outdated and will
+//! return HTTP 200 with a non-zero `status` error envelope.
+
+use std::time::Instant;
+
+use serde_json::{Value, json};
+
+use super::{KeyError, ProviderResult, SearchHit};
+
+const BASE: &str = "https://api.serpbase.dev/google/search";
+const TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+
+/// Extract hits from the `organic` array. Pure function so it's
+/// testable without a live API call. Mirrors the serpapi/serper
+/// adapters: entries without a URL are dropped, and a relevance
+/// score is derived from position (1 → ~1.0, 10 → ~0.1).
+fn parse_results(json: &Value) -> Vec<SearchHit> {
+    json.get("organic")
+        .and_then(Value::as_array)
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|r| {
+                    let title = r
+                        .get("title")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string();
+                    let url = r
+                        .get("link")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string();
+                    if url.is_empty() {
+                        return None;
+                    }
+                    let snippet = r
+                        .get("snippet")
+                        .and_then(Value::as_str)
+                        .unwrap_or("")
+                        .to_string();
+                    let position = r.get("position").and_then(Value::as_u64).unwrap_or(1) as f32;
+                    let score = 1.0 / position.max(1.0);
+                    Some(SearchHit {
+                        title,
+                        url,
+                        snippet,
+                        score,
+                    })
+                })
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+pub async fn search(
+    client: &reqwest::Client,
+    key: &str,
+    query: &str,
+    max: usize,
+    _intent: &crate::search::intent::Intent,
+) -> ProviderResult {
+    let started = Instant::now();
+
+    let body = json!({
+        "q": query,
+        "num": max.min(10),
+    });
+
+    let resp = client
+        .post(BASE)
+        .header("X-API-Key", key)
+        .json(&body)
+        .timeout(TIMEOUT)
+        .send()
+        .await
+        .map_err(|e| {
+            if e.is_timeout() {
+                KeyError::NetworkError
+            } else {
+                KeyError::UnknownError(format!("network: {e}"))
+            }
+        })?;
+
+    let status = resp.status().as_u16();
+    let text = resp.text().await.unwrap_or_default();
+
+    if status == 401 || status == 403 {
+        return Err(KeyError::InvalidKey);
+    }
+    if status == 402 {
+        return Err(KeyError::CreditDepleted);
+    }
+    if status == 429 {
+        return Err(KeyError::RateLimited);
+    }
+    if status >= 500 {
+        return Err(KeyError::ServerError(format!("HTTP {status}")));
+    }
+    if status >= 400 {
+        let lower = text.to_lowercase();
+        if lower.contains("invalid") && lower.contains("key") {
+            return Err(KeyError::InvalidKey);
+        }
+        if lower.contains("credit") || lower.contains("quota") || lower.contains("billing") {
+            return Err(KeyError::CreditDepleted);
+        }
+        return Err(KeyError::UnknownError(format!("HTTP {status}: {text}")));
+    }
+
+    let json: Value = serde_json::from_str(&text)
+        .map_err(|e| KeyError::UnknownError(format!("parse error: {e}")))?;
+
+    // Business-level error envelope: HTTP 200 with status != 0.
+    // 1001 = unauthorized (bad/revoked key), others are query-level
+    // errors. Map 1001 to InvalidKey so the key is marked dead and
+    // rotation moves to the next key; everything else is unknown.
+    if let Some(code) = json.get("status").and_then(Value::as_u64) {
+        if code == 1001 {
+            return Err(KeyError::InvalidKey);
+        }
+        if code != 0 {
+            let msg = json
+                .get("error")
+                .and_then(Value::as_str)
+                .unwrap_or("unknown")
+                .to_string();
+            return Err(KeyError::UnknownError(format!(
+                "serpbase status {code}: {msg}"
+            )));
+        }
+    }
+
+    let results = parse_results(&json);
+
+    let ms = started.elapsed().as_millis() as u64;
+    Ok((results, ms))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn parse_results_organic() {
+        let body = json!({
+            "status": 0,
+            "organic": [
+                { "position": 1, "title": "Rust", "link": "https://rust-lang.org", "snippet": "a systems language" },
+                { "position": 2, "title": "Rust book", "link": "https://doc.rust-lang.org/book", "snippet": "the book" },
+            ]
+        });
+        let hits = parse_results(&body);
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].title, "Rust");
+        assert_eq!(hits[0].url, "https://rust-lang.org");
+        assert_eq!(hits[0].snippet, "a systems language");
+        assert!(
+            hits[0].score > hits[1].score,
+            "earlier position scores higher"
+        );
+    }
+
+    #[test]
+    fn parse_results_drops_entries_without_link() {
+        let body = json!({
+            "organic": [
+                { "position": 1, "title": "No URL" },
+                { "position": 2, "title": "Has URL", "link": "https://example.com" },
+            ]
+        });
+        let hits = parse_results(&body);
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].title, "Has URL");
+    }
+
+    #[test]
+    fn parse_results_missing_key_returns_empty() {
+        let body = json!({ "status": 0 });
+        assert!(parse_results(&body).is_empty());
+    }
+
+    #[test]
+    fn parse_results_defaults_missing_position_to_one() {
+        let body = json!({
+            "organic": [
+                { "title": "No position field", "link": "https://example.com" },
+            ]
+        });
+        let hits = parse_results(&body);
+        assert_eq!(hits.len(), 1);
+        assert!((hits[0].score - 1.0).abs() < 0.001);
+    }
+}

--- a/src/search/byok/store.rs
+++ b/src/search/byok/store.rs
@@ -27,6 +27,7 @@ pub const PROVIDERS: &[&str] = &[
     "exa",
     "serper",
     "serpapi",
+    "serpbase",
     "bravesearch",
     "tinyfish",
     "parallel",
@@ -489,7 +490,7 @@ pub fn render_list(cfg: &ByokConfig) {
         );
         println!(
             "  Providers:       {}",
-            cli::dim("tavily, exa, serper, tinyfish, parallel, brightdata")
+            cli::dim("tavily, exa, serper, serpbase, tinyfish, parallel, brightdata")
         );
         return;
     }


### PR DESCRIPTION
## Summary
Adds SerpBase (https://serpbase.dev) as another BYOK Google SERP provider, per the discussion on #94. It mirrors the existing `serpapi`/`serper` adapters exactly — one adapter file plus registry/help/README lines.

## Changes
- **New**: `src/search/byok/serpbase.rs` — `search()` adapter + pure `parse_results()` (4 unit tests)
- **Updated**: `src/search/byok/mod.rs` — module + dispatch arm
- **Updated**: `src/search/byok/store.rs` — provider registry + list help
- **Updated**: `src/cli/keys.rs` — `keys add` help line
- **Updated**: `README.md` — `keys add serpbase` example

## API contract notes (verified against serpbase.dev docs)
- `POST https://api.serpbase.dev/google/search`, JSON body `{q, num, hl, gl}`, auth via `X-API-Key` header
- Business errors can come back as HTTP 200 with a non-zero `status` envelope (`1001` = unauthorized → mapped to `KeyError::InvalidKey` so rotation marks the key dead; others → `UnknownError`)
- HTTP 401/403 → `InvalidKey`, 402 → `CreditDepleted`, 429 → `RateLimited`, 5xx → `ServerError`
- Results under `organic[]` (`position`/`title`/`link`/`snippet`) → mapped to `SearchHit` with position-derived relevance score, same as serpapi/serper
- `num` capped at 10 to match the other providers
- No new dependencies, no behavior change when the key is absent

## Testing
- 4 new unit tests on `parse_results` (organic mapping, drops entries without link, empty on missing key, position default)
- Full suite: 733 passed, 0 failed
- `cargo fmt --check` and `cargo clippy --lib` clean

Closes #94 (feature request).
