### PR TITLE
fix(transport): scope h2 RST_STREAM to its own stream, fix PUSH_PROMISE refusal payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -74,6 +74,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   outline/bookmark title picked up two invisible trailing NULs. Both call
   sites now convert bytes to units first, matching the sibling
   `field_string` helper in `forms.rs`, which already did this correctly.
+- **A stray HTTP/2 RST_STREAM could abort the wrong request on a
+  reused connection:** every other per-stream frame type (HEADERS,
+  CONTINUATION, DATA) in the h2 read loop is scoped to the current
+  stream id, but RST_STREAM matched any stream id. On a pooled,
+  reused connection, a late RST_STREAM for an already-finished prior
+  stream would abort a completely unrelated new request in flight.
+  Also: the RST_STREAM sent to refuse a PUSH_PROMISE (a spec
+  violation, since we advertise `ENABLE_PUSH=0`) carried the wrong
+  payload — the current request's own stream id instead of a 4-byte
+  HTTP/2 error code (RFC 7540 §6.4); it now sends `REFUSED_STREAM`.
 
 
 ## [3.5.0] - 2026-09-01

--- a/src/transport/h2/conn.rs
+++ b/src/transport/h2/conn.rs
@@ -236,19 +236,32 @@ impl H2Conn {
                         break;
                     }
                 }
-                RST_STREAM => {
+                // Scoped like HEADERS/CONTINUATION/DATA above: on a
+                // pooled, reused connection, a late RST_STREAM for a
+                // PRIOR (already-finished) stream must not abort the
+                // new request currently in flight. Unmatched
+                // RST_STREAM falls through to the `_` arm below and
+                // is correctly ignored.
+                RST_STREAM if hdr.stream_id == stream_id => {
                     return Err(FetchError::Http(format!("h2 rst_stream on {stream_id}")));
                 }
                 GOAWAY => {
                     return Err(FetchError::Http("h2 goaway".into()));
                 }
                 PUSH_PROMISE => {
+                    // RFC 7540 §6.4: RST_STREAM's payload is a 4-byte
+                    // error code, not a stream id — this used to send
+                    // `stream_id`'s own bytes. We advertise
+                    // ENABLE_PUSH=0 in SETTINGS, so a conforming
+                    // server never pushes; REFUSED_STREAM tells a
+                    // non-conforming one plainly why this is refused.
+                    const REFUSED_STREAM: u32 = 0x7;
                     write_frame(
                         &mut self.stream,
                         RST_STREAM,
                         0,
                         hdr.stream_id,
-                        &stream_id.to_be_bytes(),
+                        &REFUSED_STREAM.to_be_bytes(),
                     )
                     .await
                     .ok();


### PR DESCRIPTION
## Summary

Found during a security-focused read-through of the custom TLS/HTTP2 stack (no memory-safety issue found there overall — these are protocol-correctness bugs).

1. **Every other per-stream frame in `H2Conn::get`'s read loop (HEADERS, CONTINUATION, DATA) is guarded with `if hdr.stream_id == stream_id`, but `RST_STREAM` matched unconditionally.** Since h2 connections are pooled and reused across sequential requests, a late/stray `RST_STREAM` for an already-finished prior stream, arriving while a new unrelated request is in flight on the same connection, would incorrectly abort that new request. Scoped it like its siblings — an unmatched `RST_STREAM` now falls through to the existing `_ => {}` arm and is correctly ignored, same as unmatched `HEADERS`/`DATA` already are.

2. **The `RST_STREAM` sent to refuse a `PUSH_PROMISE` carried the wrong payload**: `stream_id.to_be_bytes()` (the current request's own stream id) instead of a 4-byte HTTP/2 error code, as RFC 7540 §6.4 requires. Now sends `REFUSED_STREAM` (0x7). Low practical impact since `SETTINGS` advertises `ENABLE_PUSH=0`, so a conforming server never pushes in the first place — this only matters against a non-conforming one.

## Type

- [x] `fix` — bug fix

## Checks

- [x] `cargo test --lib transport::h2::` passes (2/2 existing parity tests, unaffected)
- [x] `cargo test --lib` — 740/740 with `--test-threads=1` (default parallelism intermittently fails 2-3 unrelated, known-flaky tests in `fetch::guards`/`ghost::xvfb` due to this sandbox's resource contention — confirmed unrelated to `src/transport/`)
- [x] `cargo clippy --lib -- -Dwarnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes
- [ ] `cargo test --features ocr,rerank` — not run locally (same environment limitation as my previous PRs)
- [ ] CI on all 3 platforms — pending.

## Breaking changes

None.

## Test plan

No new test added: `H2Conn`'s `stream` field is concretely typed `SslStream<TcpStream>` (not generic over `AsyncRead + AsyncWrite`), so synthetically injecting a crafted RST_STREAM frame to drive this exact code path would need either a real local TLS server or a broader generic-stream refactor of `H2Conn` — judged disproportionate for this fix. Both changes mirror an already-established, already-untested pattern in the same match block (the `HEADERS`/`CONTINUATION`/`DATA` stream-id guards), so this isn't introducing a new untested category, just extending an existing one consistently.

## Contributor note

An independent review of this PR turned up two more, **pre-existing** (not introduced by this diff) issues in the same `PUSH_PROMISE` arm, worth a follow-up:
- The RST_STREAM the arm sends targets `hdr.stream_id` — but per RFC 7540 §6.6, that's the frame's *associated* stream (the already-open request stream), not the *Promised Stream ID*, which lives in the frame's payload and is never parsed here. So even after this fix's payload correction, the reset is arguably aimed at the wrong stream.
- Per RFC 7540 §6.5.2, once `ENABLE_PUSH=0` is set and acknowledged, receiving a `PUSH_PROMISE` at all should be treated as a connection error (`GOAWAY` with `PROTOCOL_ERROR`), not handled with a per-stream `RST_STREAM` while continuing to use the connection.

Both stay low-impact in practice (only reachable against a non-conforming server, since a conforming one never pushes once `ENABLE_PUSH=0` is acked) and are unchanged by this diff, so I left them out of scope here rather than bundling a larger PUSH_PROMISE-handling rewrite into this fix — happy to file a follow-up issue if that's useful.