### PR TITLE
fix(pi-extension): gate startup banner behind DONSETCH_DEBUG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **pi-extension: startup banner corrupted the viewport:** the
+  `[donsetch] N tools registered: ...` line printed on every
+  `session_start` via a raw `process.stderr.write`, which bypasses
+  pi's TUI paint cycle. Under parallel background agents each
+  process's banner interleaved with the others on the same screen,
+  producing garbled repeated lines above the status bar. Now gated
+  behind `DONSETCH_DEBUG`/`DEBUG`, matching the existing gate on the
+  daemon's forwarded stderr diagnostics (issue #95) so a normal
+  session prints nothing.
+
 - **Secure cookies could replay over plain HTTP (security):** the
   tier-1 jar dropped the `Secure` attribute at both ingresses:
   bare `Secure` tokens from `Set-Cookie` never matched the

--- a/npm/pi-extension.ts
+++ b/npm/pi-extension.ts
@@ -31,6 +31,12 @@ const INIT_TIMEOUT_MS = 10_000;
 const CALL_TIMEOUT_MS = 120_000;
 const SHUTDOWN_GRACE_MS = 2_000;
 
+// A raw process.stderr.write bypasses pi's TUI paint cycle and
+// corrupts the viewport (worse across parallel agents). Gate it here.
+const DEBUG_MODE =
+  (process.env.DONSETCH_DEBUG ?? "").length > 0 ||
+  (process.env.DEBUG ?? "").length > 0;
+
 // ── TUI rendering note ──
 // Pi's TUI wraps tool calls in its own green (success) / red (failure)
 // highlight. We output PLAIN TEXT only : no ANSI codes at all.
@@ -165,13 +171,10 @@ function startServer(): Promise<void> {
     // - DONSETCH_DEBUG / DEBUG set: forward everything (dev mode)
     // - otherwise only crash/fatal lines survive; the rest is
     //   tool-level information the caller already has
-    const debugMode =
-      (process.env.DONSETCH_DEBUG ?? "").length > 0 ||
-      (process.env.DEBUG ?? "").length > 0;
     const FATAL_RE = /fatal|panic|crash|SIGSEGV|abort|OOM|out of memory/i;
     let stderrTail = "";
     proc.stderr?.on("data", (chunk: Buffer) => {
-      if (debugMode) {
+      if (DEBUG_MODE) {
         process.stderr.write(chunk);
         return;
       }
@@ -602,7 +605,11 @@ export default function (pi: ExtensionAPI) {
       });
     }
 
-    process.stderr.write(`[donsetch] ${mcpTools.length} tools registered: ${toolNames.join(", ")}\n`);
+    // Fires every session_start (unlike the failure paths above), so
+    // this one corrupted the viewport on every normal run.
+    if (DEBUG_MODE) {
+      process.stderr.write(`[donsetch] ${mcpTools.length} tools registered: ${toolNames.join(", ")}\n`);
+    }
   });
 
   pi.on("session_shutdown", () => {


### PR DESCRIPTION
The `[donsetch] N tools registered` banner in `npm/pi-extension.ts` printed unconditionally on every `session_start` via a raw `process.stderr.write`, which bypasses pi's TUI paint cycle. That corrupted the terminal viewport on every normal run, and got worse under parallel background agents, where each process's banner interleaved with the others on the same screen (garbled repeated lines above the status bar).

Gates it behind `DONSETCH_DEBUG`/`DEBUG`, matching the existing gate already applied to the daemon's forwarded stderr diagnostics (issue #95). A normal session now prints nothing from this path; debug mode still shows it.

CHANGELOG entry included.