### PR TITLE
fix(mcp): refuse to start the HTTP transport with CORS on but auth off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for everything else. (README BYOK plugins section documents the
   contract.)
 
+### Fixed
+
+- **`DONSETCH_HTTP_CORS` without `DONSETCH_HTTP_TOKEN` was a silent
+  drive-by footgun:** CORS and bearer auth on the opt-in HTTP MCP
+  transport are independently optional env vars, so enabling
+  permissive CORS (any origin) without also setting a token left
+  the server wide open — any webpage in a local browser could POST
+  arbitrary MCP tool calls (fetch/crawl/search, including the
+  `actions` browser-automation surface) with no authentication, the
+  classic "localhost server + permissive CORS" drive-by pattern.
+  The HTTP transport now refuses to start with that combination
+  instead of silently accepting it, with an error pointing at
+  `DONSETCH_HTTP_TOKEN`.
+
 ## [3.5.1] - 2026-09-03
 
 ### Added

--- a/src/mcp/http.rs
+++ b/src/mcp/http.rs
@@ -206,7 +206,8 @@ fn validate_http_config(cors_enabled: bool, auth_enabled: bool) -> Result<(), St
             "DONSETCH_HTTP_CORS is enabled without DONSETCH_HTTP_TOKEN: any \
              webpage open in a local browser could drive this MCP server \
              with no authentication. Set DONSETCH_HTTP_TOKEN to a random \
-             secret before enabling CORS."
+             secret before enabling CORS, or leave DONSETCH_HTTP_CORS unset \
+             if you don't need browser-based clients."
                 .into(),
         );
     }

--- a/src/mcp/http.rs
+++ b/src/mcp/http.rs
@@ -105,14 +105,6 @@ pub async fn run(host: String, port: u16) -> Result<(), Box<dyn std::error::Erro
             .and_then(|v| v.parse().ok())
             .unwrap_or(DEFAULT_TIMEOUT_SECS),
     );
-    let state = HttpState {
-        daemon: Arc::clone(&daemon),
-        sessions: Arc::new(SessionTable {
-            sessions: Mutex::new(HashMap::new()),
-        }),
-        auth_token,
-        timeout,
-    };
 
     // CORS is off by default: MCP clients are processes, not browsers,
     // and a permissive layer would let any webpage open in a local
@@ -122,6 +114,16 @@ pub async fn run(host: String, port: u16) -> Result<(), Box<dyn std::error::Erro
         std::env::var("DONSETCH_HTTP_CORS").as_deref(),
         Ok("1" | "true" | "on")
     );
+    validate_http_config(cors_enabled, auth_enabled)?;
+
+    let state = HttpState {
+        daemon: Arc::clone(&daemon),
+        sessions: Arc::new(SessionTable {
+            sessions: Mutex::new(HashMap::new()),
+        }),
+        auth_token,
+        timeout,
+    };
 
     let app = Router::new()
         .route("/health", get(health_handler))
@@ -186,6 +188,29 @@ async fn shutdown_signal() {
 /// Liveness probe for orchestrators and load balancers.
 async fn health_handler() -> impl IntoResponse {
     Json(json!({ "status": "ok", "transport": "http" }))
+}
+
+/// Refuse the classic "localhost server + permissive CORS = drive-by"
+/// footgun: `DONSETCH_HTTP_CORS` and `DONSETCH_HTTP_TOKEN` are
+/// independently optional, so nothing stopped a user from enabling
+/// permissive CORS (any origin) while leaving auth off. With that
+/// combination, any webpage open in the same local browser could
+/// POST arbitrary MCP tool calls — fetch/crawl/search, including the
+/// `actions` browser-automation surface — to this server with no
+/// authentication. Fail closed instead of just warning: a startup
+/// error is impossible to miss, unlike an eprintln! in a background
+/// daemon's log.
+fn validate_http_config(cors_enabled: bool, auth_enabled: bool) -> Result<(), String> {
+    if cors_enabled && !auth_enabled {
+        return Err(
+            "DONSETCH_HTTP_CORS is enabled without DONSETCH_HTTP_TOKEN: any \
+             webpage open in a local browser could drive this MCP server \
+             with no authentication. Set DONSETCH_HTTP_TOKEN to a random \
+             secret before enabling CORS."
+                .into(),
+        );
+    }
+    Ok(())
 }
 
 /// Bearer-auth check shared by every /mcp method (health stays open).
@@ -533,6 +558,22 @@ mod tests {
             );
         }
         h
+    }
+
+    #[test]
+    fn cors_without_auth_is_refused() {
+        assert!(validate_http_config(true, false).is_err());
+    }
+
+    #[test]
+    fn cors_with_auth_is_allowed() {
+        assert!(validate_http_config(true, true).is_ok());
+    }
+
+    #[test]
+    fn no_cors_is_always_allowed_regardless_of_auth() {
+        assert!(validate_http_config(false, false).is_ok());
+        assert!(validate_http_config(false, true).is_ok());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Found during a security-focused read-through of the MCP daemon layer.

`DONSETCH_HTTP_CORS` and `DONSETCH_HTTP_TOKEN` are independently optional env vars on the opt-in HTTP transport (behind the `http` cargo feature, off by default), with nothing tying them together. A user enabling permissive CORS (e.g. for a legitimate browser-based client) without also setting an auth token gets a server that any webpage open in the same local browser can freely POST arbitrary MCP tool calls to — fetch/crawl/search, including the `actions` browser-automation surface — with zero authentication. The classic "localhost server + permissive CORS = drive-by" pattern, and it directly contradicts this file's own doc comment explaining why CORS is off by default (browsers, not trusted processes, being exactly the threat that comment already names).

Fix: `run()` now validates the combination right after computing both flags and fails closed — refuses to start, with a clear error — instead of silently accepting it. A startup error is impossible to miss, unlike an `eprintln!` buried in a background daemon's log.

## Type

- [x] `fix` — bug fix

## Checks

- [x] `cargo test --lib --features http mcp::http::` passes (11/11, including 3 new unit tests)
- [x] `cargo test --lib --features http` passes (819/819)
- [x] `cargo clippy --lib --features http -- -Dwarnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo build --lib` (default, no `--features http`) confirmed unaffected — the touched code lives entirely inside the `#[cfg(feature = "http")]`-gated module
- [ ] `cargo test --features ocr,rerank` — not run locally (same environment limitation as my previous PRs; note `--features http` was needed here specifically, since `mcp::http` doesn't compile at all under default features — first test run showed "running 0 tests" until I found this)
- [ ] CI on all 3 platforms — pending.

## Breaking changes

None for the default (no-`http`-feature) build. For anyone already running `--http` with `DONSETCH_HTTP_CORS` set and no token: the server will now refuse to start until either a token is set or CORS is unset. This is the intended fix — that combination was never safe to run.

## Test plan

- 3 new unit tests on the extracted pure decision function (`validate_http_config`), following this file's existing convention (see `token_ok`'s "pure form... so tests don't need server state" comment): CORS+no-auth is refused, CORS+auth is allowed, no-CORS is always allowed regardless of auth. Together they cover the full 2×2 truth table.
- Confirmed by reading the full `run()` function that the check executes before `HttpState` is built, before the `Router`/`CorsLayer` are constructed, and before `TcpListener::bind` — a misconfigured server never binds a socket or attaches the CORS layer.
- Verified `tower-http`'s `CorsLayer` here never sets `allow_credentials(true)`, so this isn't a cookie-theft scenario — the actual exposure is unauthenticated read/write MCP access from any local webpage, which is already the severity this fix addresses.

## Contributor note

The error message also mentions unsetting `DONSETCH_HTTP_CORS` as the alternative fix (not just "add a token"), in case CORS was enabled without really needing it.