### PR TITLE
fix(security): redact secrets from Proxy and KeyEntry's Debug output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-Nothing yet.
+### Fixed
+
+- **`Proxy` and BYOK `KeyEntry` derived a plaintext `Debug`:** neither
+  type has a live call site that formats it with `{:?}` today, but
+  nothing in the type system stopped one from being added later and
+  silently leaking a proxy password or a BYOK API key into a log or
+  error message. Both now redact the secret field behind a hand-
+  written `Debug` impl; `ProviderConfig`/`ByokConfig`'s derived
+  `Debug` picks up the redaction automatically through the nested
+  `KeyEntry`.
 
 ## [3.5.2] - 2026-09-03
 

--- a/src/search/byok/store.rs
+++ b/src/search/byok/store.rs
@@ -64,7 +64,7 @@ impl KeyState {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct KeyEntry {
     pub key: String,
     pub state: KeyState,
@@ -72,6 +72,23 @@ pub struct KeyEntry {
     /// Used for rate-limit cooldown calculation.
     #[serde(default)]
     pub ts: u64,
+}
+
+/// Redacts `key` — a derived Debug would print the plaintext BYOK
+/// API key into any log/error output that formats a `KeyEntry` (or
+/// a `ProviderConfig`/`ByokConfig` containing one) with `{:?}`. The
+/// existing debug logging in `byok::mod` is careful to print only
+/// `key.chars().take(8)`, but that's a manual convention, not
+/// something the type system enforces — this closes the gap so a
+/// future `{cfg:?}`-style dump can't defeat it by accident.
+impl std::fmt::Debug for KeyEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("KeyEntry")
+            .field("key", &"***")
+            .field("state", &self.state)
+            .field("ts", &self.ts)
+            .finish()
+    }
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -629,6 +646,29 @@ fn mask_key(key: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn debug_redacts_key_and_propagates_through_containers() {
+        let mut cfg = ByokConfig::empty();
+        cfg.add_key("tavily", "tvly-s3cret-actual-key");
+
+        let entry_out = format!("{:?}", cfg.providers[0].keys[0]);
+        assert!(
+            !entry_out.contains("tvly-s3cret-actual-key"),
+            "leaked key: {entry_out}"
+        );
+        assert!(entry_out.contains("***"));
+
+        // The derived Debug on the containing structs calls
+        // KeyEntry's own (redacted) fmt for each element — the leak
+        // must not resurface just by formatting the outer config.
+        let cfg_out = format!("{cfg:?}");
+        assert!(
+            !cfg_out.contains("tvly-s3cret-actual-key"),
+            "leaked key via container Debug: {cfg_out}"
+        );
+        assert!(cfg_out.contains("***"));
+    }
 
     #[test]
     fn add_key_creates_provider_and_sets_default() {

--- a/src/transport/proxy.rs
+++ b/src/transport/proxy.rs
@@ -48,13 +48,29 @@ pub enum ProxyScheme {
     Socks5,
 }
 
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Proxy {
     pub host: String,
     pub port: u16,
     pub user: String,
     pub pass: String,
     pub scheme: ProxyScheme,
+}
+
+/// Redacts `pass` — a derived Debug would print the plaintext proxy
+/// password into any log/error output that formats a `Proxy` with
+/// `{:?}`. No such call site exists today, but nothing stops one
+/// being added later without anyone noticing the leak.
+impl std::fmt::Debug for Proxy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Proxy")
+            .field("host", &self.host)
+            .field("port", &self.port)
+            .field("user", &self.user)
+            .field("pass", &"***")
+            .field("scheme", &self.scheme)
+            .finish()
+    }
 }
 
 impl Proxy {
@@ -560,6 +576,22 @@ pub(crate) fn base64(input: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn debug_redacts_password() {
+        let p = Proxy {
+            host: "proxy.example.com".into(),
+            port: 8080,
+            user: "alice".into(),
+            pass: "s3cret-password".into(),
+            scheme: ProxyScheme::Http,
+        };
+        let out = format!("{p:?}");
+        assert!(!out.contains("s3cret-password"), "leaked password: {out}");
+        assert!(out.contains("proxy.example.com"));
+        assert!(out.contains("alice"));
+        assert!(out.contains("***"));
+    }
 
     #[test]
     fn base64_rfc4648_vectors() {


### PR DESCRIPTION
## Summary

Found during a security-focused sweep of the search/egress and BYOK-storage layers (last one from that sweep — the other findings landed as #98, #108, #110, #112, plus a private advisory for the one genuinely live vulnerability).

`Proxy` (`src/transport/proxy.rs`) carries a plaintext `pass` field and `KeyEntry` (`src/search/byok/store.rs`) carries a plaintext `key` field (a user's configured BYOK provider API key); both derived `Debug` with no redaction. I found **no live call site today** that actually formats either with `{:?}` — this is a latent gap, not an active leak — but nothing in the type system stops a future `eprintln!("{proxy:?}")`, a stray `dbg!()`, or a new debug-log line from printing the secret verbatim. The existing BYOK debug logging elsewhere (`byok::mod`, untouched by this PR) is already careful to print only `key.chars().take(8)...`, but that's a manual convention, not something the compiler enforces.

Fix: hand-written `Debug` impls for both types that redact the secret field to `"***"`, leaving everything else (host/port/user for `Proxy`; state/ts for `KeyEntry`) visible for debuggability — matching this project's own established sensitivity bar (partial-reveal for keys elsewhere, not blanket redaction of everything adjacent to a secret).

## Type

- [x] `fix` — bug fix (hardening)

## Checks

- [x] `cargo test --lib transport::proxy::` passes (26/26, including 1 new test)
- [x] `cargo test --lib byok::store::` passes (30/30, including 1 new test)
- [x] `cargo test --lib --features http` passes (819/821 — 2 pre-existing, unrelated sandbox-DNS flakes in `fetch::guards`, confirmed via `--test-threads=1`: 29/29 clean)
- [x] `cargo clippy --lib --features http -- -Dwarnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes
- [x] `cargo build --lib` (default features) confirmed unaffected
- [ ] `cargo test --features ocr,rerank` — not run locally (same environment limitation as my previous PRs)
- [ ] CI on all 3 platforms — pending.

## Breaking changes

None. `Serialize`/`Deserialize` (used for the on-disk BYOK key file and export/import) are untouched — only `Debug` formatting changes.

## Test plan

- New test on `Proxy`: builds one with a known password, asserts the password string is absent from `{:?}` output while host/user/etc. are still present.
- New test on `KeyEntry`/`ByokConfig`: adds a key with a known secret value via the real `add_key()` path, asserts the secret is absent both from formatting the `KeyEntry` directly AND from formatting the containing `ByokConfig` — confirming the redaction actually propagates through `ProviderConfig`/`ByokConfig`'s derived `Debug` (which still call `KeyEntry`'s own, now-redacted, `fmt` per field — Rust's derive only requires the field type implement the `Debug` trait, not that the impl itself be derived).
- Swept the codebase for other structs nesting `Proxy` (found `Egress` in `search/egress.rs`, still derives `Debug` unmodified, confirmed it still compiles) and for other plaintext-secret-shaped fields (`password`/`secret`/`token`/`api_key`/etc.) on any type deriving `Debug` — found no other live gap (`HttpState.auth_token` in `mcp/http.rs` doesn't derive `Debug` today).

## Contributor note

Lowest-severity item from the sweep — closing it mainly because it's cheap, correct, and the type-level enforcement is strictly better than relying on every future call site remembering a manual convention.