### PR TITLE
feat(mcp)!: compact model-facing tool contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Compact MCP contracts:** model-facing tool schemas now keep lifecycle
+  guidance on the tool and field-specific rules on each parameter, while
+  preserving the full CLI help. Search, fetch, crawl, and batch responses
+  render evidence once, retain actionable routing and recovery state, and
+  move bounded diagnostics to client-only `_meta`. The three existing tools,
+  acquisition, ranking, explicit query grouping, and fallback behavior are
+  unchanged.
+  Credit: adaaaaaaaaaaaaaaaaaaaaa (#120). CLI stats footer updated in the
+  same change set to read moved telemetry from `_meta`.
+
 ### Fixed
 
 - **`chrome_h2_probe` non-Linux CI:** gate the Linux-only imports,
   ALPN callback, and frame-decoding helpers together with the probe entry
   point, so `cargo clippy --all-targets -- -Dwarnings` does not compile them
   as unused code on Windows or macOS.
-
+  Credit: adaaaaaaaaaaaaaaaaaaaaa (#121).
 
 ## [3.6.0] - 2026-09-04
 

--- a/src/cli/tool.rs
+++ b/src/cli/tool.rs
@@ -227,23 +227,47 @@ fn render_result(result: &Value, json_mode: bool, quiet: bool, cmd: &str) -> u8 
         print!("{content}");
     }
 
-    if !quiet
-        && !is_error
-        && let Some(sc) = result.get("structuredContent")
-    {
-        eprintln!("{}", stats_line(cmd, sc, content.len()));
+    if !quiet && !is_error {
+        eprintln!("{}", stats_line(cmd, result, content.len()));
     }
 
     exit
 }
 
+/// Read a field from model state first, then from the client-only
+/// debug payload. Compact MCP contracts move transport telemetry to
+/// `_meta`; the CLI still surfaces it.
+fn pick<'a>(sc: &'a Value, dbg: &'a Value, name: &str) -> Option<&'a Value> {
+    sc.get(name).or_else(|| dbg.get(name))
+}
+
 /// Build the compact one-line stats string for stderr.
-fn stats_line(cmd: &str, sc: &Value, content_len: usize) -> String {
+fn stats_line(cmd: &str, result: &Value, content_len: usize) -> String {
+    let sc = result.get("structuredContent").cloned().unwrap_or_default();
+    let dbg = result
+        .pointer("/_meta")
+        .cloned()
+        .map(|meta| {
+            let ns = match cmd {
+                "fetch" => "com.donsetch/fetch-debug",
+                "search" => "com.donsetch/search-debug",
+                "crawl" => "com.donsetch/crawl-debug",
+                _ => "",
+            };
+            meta.get(ns).cloned().unwrap_or_default()
+        })
+        .unwrap_or_default();
     match cmd {
         "fetch" => {
-            let tokens_est = sc.get("tokens_est").and_then(|v| v.as_u64()).unwrap_or(0);
-            let tier = sc.get("tier").and_then(|v| v.as_str()).unwrap_or("?");
-            let verdict = sc.get("verdict").and_then(|v| v.as_str()).unwrap_or("?");
+            let tokens_est = pick(&sc, &dbg, "tokens_est")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let tier = pick(&sc, &dbg, "tier")
+                .and_then(|v| v.as_str())
+                .unwrap_or("?");
+            let verdict = pick(&sc, &dbg, "verdict")
+                .and_then(|v| v.as_str())
+                .unwrap_or("?");
             let mut parts = vec![
                 format!("{content_len} chars"),
                 format!("~{tokens_est} tokens"),
@@ -266,9 +290,10 @@ fn stats_line(cmd: &str, sc: &Value, content_len: usize) -> String {
                 .and_then(|r| r.as_array())
                 .map(|a| a.len())
                 .unwrap_or(0);
-            let ms = sc.get("elapsed_ms").and_then(|v| v.as_u64()).unwrap_or(0);
-            let provider = sc
-                .get("provider")
+            let ms = pick(&sc, &dbg, "elapsed_ms")
+                .and_then(|v| v.as_u64())
+                .unwrap_or(0);
+            let provider = pick(&sc, &dbg, "provider")
                 .and_then(|v| v.as_str())
                 .unwrap_or("local");
             let mut parts = vec![
@@ -281,7 +306,7 @@ fn stats_line(cmd: &str, sc: &Value, content_len: usize) -> String {
             }
             // Surface degraded engine health in plain mode so agents
             // can tell coverage dropped without parsing --json.
-            if let Some(engines) = sc.get("engines").and_then(|e| e.as_array()) {
+            if let Some(engines) = pick(&sc, &dbg, "engines").and_then(|e| e.as_array()) {
                 let degraded: Vec<String> = engines
                     .iter()
                     .filter_map(|e| {
@@ -311,7 +336,7 @@ fn stats_line(cmd: &str, sc: &Value, content_len: usize) -> String {
                 .and_then(|r| r.as_array())
                 .map(|a| a.len())
                 .unwrap_or(0);
-            let total: u64 = sc
+            let total: u64 = dbg
                 .get("pages")
                 .and_then(|r| r.as_array())
                 .map(|a| {
@@ -320,8 +345,12 @@ fn stats_line(cmd: &str, sc: &Value, content_len: usize) -> String {
                         .sum()
                 })
                 .unwrap_or(0);
-            let elapsed = sc.get("elapsed_s").and_then(|v| v.as_f64()).unwrap_or(0.0);
-            let stop = sc.get("stop").and_then(|v| v.as_str()).unwrap_or("?");
+            let elapsed = pick(&sc, &dbg, "elapsed_s")
+                .and_then(|v| v.as_f64())
+                .unwrap_or(0.0);
+            let stop = pick(&sc, &dbg, "stop")
+                .and_then(|v| v.as_str())
+                .unwrap_or("?");
             let mut parts = vec![
                 format!("{n} pages"),
                 format!("{total} chars"),
@@ -512,48 +541,70 @@ mod tests {
 
     #[test]
     fn stats_line_fetch() {
-        let sc = json!({
-            "total_chars": 15853,
-            "tokens_est": 4000,
-            "tier": "1",
-            "verdict": "ContentOk",
-            "next_offset": 15923,
-            "thin": false
+        let v = json!({
+            "structuredContent": {
+                "total_chars": 15853,
+                "next_offset": 15923,
+                "thin": false
+            },
+            "_meta": {
+                "com.donsetch/fetch-debug": {
+                    "tokens_est": 4000,
+                    "tier": "1",
+                    "verdict": "ContentOk"
+                }
+            }
         });
-        let s = stats_line("fetch", &sc, 15853);
+        let s = stats_line("fetch", &v, 15853);
         assert!(s.contains("15853 chars"));
+        assert!(s.contains("~4000 tokens"));
         assert!(s.contains("tier 1"));
         assert!(s.contains("ContentOk"));
         assert!(s.contains("next_offset 15923"));
     }
 
     #[test]
-    fn stats_line_search() {
-        let sc = json!({
-            "results": [{"title": "a"}, {"title": "b"}],
-            "elapsed_ms": 2100,
-            "provider": null,
-            "weak": true
+    fn stats_line_fetch_prefers_model_state() {
+        // Field present in both surfaces: model state wins over debug.
+        let v = json!({
+            "structuredContent": { "tier": "2(ghost)", "verdict": "ContentOk" },
+            "_meta": { "com.donsetch/fetch-debug": { "tier": "1", "verdict": "Blocked" } }
         });
-        let s = stats_line("search", &sc, 0);
+        let s = stats_line("fetch", &v, 0);
+        assert!(s.contains("tier 2(ghost)"));
+        assert!(s.contains("ContentOk"));
+    }
+
+    #[test]
+    fn stats_line_search() {
+        let v = json!({
+            "structuredContent": {"results": [{"rank": 1}, {"rank": 2}], "weak": true},
+            "_meta": {
+                "com.donsetch/search-debug": {"elapsed_ms": 2100, "provider": null}
+            }
+        });
+        let s = stats_line("search", &v, 0);
         assert!(s.contains("2 results"));
         assert!(s.contains("weak consensus"));
     }
 
     #[test]
     fn stats_line_search_degraded_engines() {
-        let sc = json!({
-            "results": [{"title": "a"}],
-            "elapsed_ms": 5000,
-            "provider": null,
-            "weak": false,
-            "engines": [
-                {"engine": "bing", "status": "ok", "hits": 5, "ms": 800},
-                {"engine": "mojeek", "status": "blocked:429", "hits": 0, "ms": 100},
-                {"engine": "brave", "status": "timeout", "hits": 0, "ms": 5000}
-            ]
+        let v = json!({
+            "structuredContent": {"results": [{"rank": 1}], "weak": false},
+            "_meta": {
+                "com.donsetch/search-debug": {
+                    "elapsed_ms": 5000,
+                    "provider": null,
+                    "engines": [
+                        {"engine": "bing", "status": "ok", "hits": 5, "ms": 800},
+                        {"engine": "mojeek", "status": "blocked:429", "hits": 0, "ms": 100},
+                        {"engine": "brave", "status": "timeout", "hits": 0, "ms": 5000}
+                    ]
+                }
+            }
         });
-        let s = stats_line("search", &sc, 0);
+        let s = stats_line("search", &v, 0);
         assert!(s.contains("degraded"));
         assert!(s.contains("mojeek blocked"));
         assert!(s.contains("brave timeout"));
@@ -578,13 +629,20 @@ mod tests {
 
     #[test]
     fn stats_line_crawl() {
-        let sc = json!({
-            "pages": [{"chars": 5000}, {"chars": 3000}],
-            "elapsed_s": 12.3,
-            "stop": "MaxPages",
-            "resume": "abc123"
+        let v = json!({
+            "structuredContent": {
+                "pages": [{"url": "https://e.com/1"}, {"url": "https://e.com/2"}],
+                "stop": "MaxPages",
+                "resume": "abc123"
+            },
+            "_meta": {
+                "com.donsetch/crawl-debug": {
+                    "pages": [{"chars": 5000}, {"chars": 3000}],
+                    "elapsed_s": 12.3
+                }
+            }
         });
-        let s = stats_line("crawl", &sc, 0);
+        let s = stats_line("crawl", &v, 0);
         assert!(s.contains("2 pages"));
         assert!(s.contains("8000 chars"));
         assert!(s.contains("stop MaxPages"));

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -591,6 +591,7 @@ async fn crawl_tool(daemon: &Arc<Daemon>, args: &Value, ctx: Option<ToolCtx>) ->
         }
     }
 
+    let requested_mode = opts.mode;
     let crawl_t0 = std::time::Instant::now();
     let result = match daemon.crawler.crawl(&url, opts, resume.as_deref()).await {
         Ok(r) => {
@@ -637,104 +638,105 @@ async fn crawl_tool(daemon: &Arc<Daemon>, args: &Value, ctx: Option<ToolCtx>) ->
         }
     };
 
-    // Content text: the map (if any) + pages. Keep the lead-in
-    // small; the pages are the payload.
+    render_crawl_result(&result, requested_mode)
+}
+
+fn render_crawl_result(result: &crate::crawl::CrawlResult, requested_mode: CrawlMode) -> Value {
+    // One linear evidence document: page identity and body appear exactly once.
     let mut text = String::new();
-    text.push_str(&format!(
-        "# crawl: {} ({} pages, stop={:?}, {:.1}s)\n\n",
-        result.seed,
-        result.pages.len(),
-        result.stop,
-        result.elapsed.as_secs_f64()
-    ));
-    // A crawl-delay-pace crawl looks hung without this note :
-    // the site demanded the pace, we honored it, say so.
-    if let Some(cd) = result.crawl_delay
-        && cd > 2.0
-    {
-        text.push_str(&format!(
-            "*robots crawl-delay: {cd:.0}s between requests (site-declared; pass respect_robots=false to override)*\n\n"
-        ));
-    }
-    if !result.map.is_empty() {
-        text.push_str("## map\n");
+    text.push_str(&format!("# Crawl\n{}\n\n", result.seed));
+    if requested_mode == CrawlMode::Map {
+        text.push_str("## Discovered URLs\n");
         for u in &result.map {
             text.push_str(&format!("- {u}\n"));
         }
         text.push('\n');
     }
-    for p in &result.pages {
-        if p.duplicate {
-            continue;
+    if requested_mode != CrawlMode::Map {
+        for (index, page) in result
+            .pages
+            .iter()
+            .filter(|page| !page.duplicate)
+            .enumerate()
+        {
+            text.push_str(&format!("## [{}]", index + 1));
+            if !page.title.is_empty() {
+                text.push_str(&format!(" {}", page.title));
+            }
+            text.push('\n');
+            text.push_str(&page.url);
+            let body = strip_source_frontmatter(
+                &page.markdown,
+                &page.url,
+                (!page.title.is_empty()).then_some(page.title.as_str()),
+            );
+            if !body.is_empty() {
+                text.push_str("\n\n");
+                text.push_str(&body);
+            }
+            text.push_str("\n\n---\n\n");
         }
-        text.push_str(&format!("## [{}] {}\n", p.title, p.url));
-        text.push_str(&format!(
-            "kind={:?} quality={:.2} {} chars\n\n",
-            p.kind, p.quality, p.chars
-        ));
-        text.push_str(&p.markdown);
-        text.push_str("\n\n---\n\n");
-    }
-    if !result.skipped.is_empty() {
-        text.push_str("## skipped\n");
-        for (u, why) in &result.skipped {
-            text.push_str(&format!("- {u}: {why}\n"));
+        if requested_mode == CrawlMode::Full {
+            let rendered = result
+                .pages
+                .iter()
+                .filter(|page| !page.duplicate)
+                .map(|page| page.url.as_str())
+                .collect::<std::collections::HashSet<_>>();
+            let remaining = result
+                .map
+                .iter()
+                .filter(|url| !rendered.contains(url.as_str()))
+                .collect::<Vec<_>>();
+            if !remaining.is_empty() {
+                text.push_str("## Discovered URLs not fetched\n");
+                for url in remaining {
+                    text.push_str(&format!("- {url}\n"));
+                }
+            }
         }
-    }
-    if let Some(tok) = &result.resume {
-        text.push_str(&format!(
-            "\nresume: call crawl again with resume={tok} to continue.\n"
-        ));
     }
 
-    // Agent guidance: next_action tells the agent what to try
-    // next when results are poor or empty. Computed from the
-    // stop reason, skip reasons, and page count.
-    let next_action = compute_crawl_next_action(&result);
-    if !next_action.is_empty() {
-        text.push_str(&format!("\n💡 {next_action}\n"));
-    }
-
-    let structured = json!({
+    let next_action = compute_crawl_next_action(result);
+    let mut structured = json!({
         "seed": result.seed,
+        "complete": matches!(result.stop, crate::crawl::StopReason::FrontierEmpty),
         "pages": result.pages.iter().filter(|p| !p.duplicate).map(|p| json!({
+            "url": p.url,
+            "lastmod": p.lastmod,
+        })).collect::<Vec<_>>(),
+        "stop": format!("{:?}", result.stop),
+    });
+    if let Some(resume) = &result.resume {
+        structured["resume"] = json!(resume);
+    }
+    if !next_action.is_empty() {
+        structured["next_action"] = json!(next_action);
+    }
+    let debug = json!({
+        "mode": format!("{:?}", requested_mode),
+        "map": result.map,
+        "queued": result.queued,
+        "filtered_out": result.filtered_out,
+        "skipped": result.skipped.iter().map(|(u, w)| json!({"url": u, "reason": w})).collect::<Vec<_>>(),
+        "pages": result.pages.iter().map(|p| json!({
             "url": p.url,
             "title": p.title,
             "kind": format!("{:?}", p.kind),
             "chars": p.chars,
             "quality": p.quality,
+            "duplicate": p.duplicate,
             "parent": p.parent,
             "score": (p.score * 100.0).round() / 100.0,
             "lastmod": p.lastmod,
         })).collect::<Vec<_>>(),
-        "map": result.map,
-        "queued": result.queued,
-        "filtered_out": result.filtered_out,
-        "skipped": result.skipped.iter().map(|(u, w)| json!({"url": u, "reason": w})).collect::<Vec<_>>(),
-        "stop": format!("{:?}", result.stop),
         "crawl_delay": result.crawl_delay,
         "elapsed_s": result.elapsed.as_secs_f64(),
-        "resume": result.resume,
-        "next_action": next_action,
     });
-    let mut meta = json!({
-        "seed": result.seed,
-        "pages": result.pages.iter().filter(|p| !p.duplicate).count(),
-        "stop": format!("{:?}", result.stop),
-        "elapsed_s": (result.elapsed.as_secs_f64() * 10.0).round() / 10.0,
-    });
-    if let Some(tok) = &result.resume {
-        meta["resume"] = json!(tok);
-    }
-    if !next_action.is_empty() {
-        meta["next_action"] = json!(next_action);
-    }
     json!({
-        "content": [
-            {"type": "text", "text": format!("[meta] {}", compact_json(&meta))},
-            {"type": "text", "text": text},
-        ],
-        "structuredContent": structured
+        "content": [{"type": "text", "text": text.trim_end()}],
+        "structuredContent": structured,
+        "_meta": {"com.donsetch/crawl-debug": debug},
     })
 }
 
@@ -2926,14 +2928,6 @@ async fn fetch_with_actions(
     res
 }
 
-/// Compact JSON string (no whitespace) for embedding in text
-/// content blocks. Used for [meta] blocks that give clients
-/// (Claude Code, VSCode) essential fields they'd otherwise
-/// only get from structuredContent.
-fn compact_json(v: &Value) -> String {
-    serde_json::to_string(v).unwrap_or_default()
-}
-
 /// v3 image OCR: fetch + OCR the page's content images (up to 4,
 /// 5MB each, SSRF-guarded) and append an `## image text` section
 /// to the result. On-demand only : OCR models are heavy and most
@@ -4440,6 +4434,59 @@ mod batch_output_contract_tests {
         assert_eq!(flagged_state["next_offset"], 16000);
         assert_eq!(flagged_state["cloak_suspected"], true);
         assert_eq!(flagged_state["archived"]["age_days"], 3);
+    }
+}
+
+#[cfg(test)]
+mod crawl_output_contract_tests {
+    use super::render_crawl_result;
+    use crate::crawl::{CrawlMode, CrawlPage, CrawlResult, StopReason};
+    use crate::extract::ContentKind;
+    use serde_json::json;
+    use std::time::Duration;
+
+    #[test]
+    fn crawl_renders_page_identity_once_and_keeps_resume_as_state() {
+        let page = CrawlPage {
+            url: "https://example.com/docs/page".into(),
+            title: "Evidence page".into(),
+            kind: ContentKind::Article,
+            markdown: "# Evidence page\nhttps://example.com/docs/page\n\nUseful evidence.".into(),
+            chars: 16,
+            quality: 0.93,
+            duplicate: false,
+            parent: Some("https://example.com/docs/".into()),
+            score: 0.88,
+            lastmod: Some("2026-09-04".into()),
+        };
+        let result = CrawlResult {
+            seed: "https://example.com/docs/".into(),
+            pages: vec![page],
+            queued: vec![],
+            filtered_out: 0,
+            skipped: vec![],
+            stop: StopReason::MaxPages,
+            elapsed: Duration::from_millis(42),
+            map: vec![],
+            crawl_delay: None,
+            resume: Some("opaque-resume".into()),
+        };
+        let output = render_crawl_result(&result, CrawlMode::Full);
+        let text = output["content"][0]["text"].as_str().unwrap();
+        assert_eq!(text.matches("Evidence page").count(), 1);
+        assert_eq!(text.matches("https://example.com/docs/page").count(), 1);
+        assert!(!text.contains("quality="));
+        assert!(!text.contains("opaque-resume"));
+        assert_eq!(output["structuredContent"]["resume"], "opaque-resume");
+        assert!(
+            output["structuredContent"]["pages"][0]
+                .get("quality")
+                .is_none()
+        );
+        assert_eq!(
+            output["_meta"]["com.donsetch/crawl-debug"]["pages"][0]["quality"],
+            json!(0.93_f32)
+        );
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1844,9 +1844,10 @@ async fn fetch_single_inner(daemon: &Arc<Daemon>, args: &Value, url: &str) -> Va
                     &trace,
                     t0.elapsed().as_millis(),
                 );
-                res["_meta"] = json!({ "ttlMs": 300_000, "cacheScope": "session" });
-                if prewarmed && let Some(sc) = res.pointer_mut("/structuredContent") {
-                    sc["prewarmed_by_search"] = json!(true);
+                res["_meta"]["ttlMs"] = json!(300_000);
+                res["_meta"]["cacheScope"] = json!("session");
+                if prewarmed {
+                    res["_meta"]["com.donsetch/fetch-debug"]["prewarmed_by_search"] = json!(true);
                 }
                 apply_link_handles(daemon, &mut res).await;
                 return res;
@@ -2038,8 +2039,8 @@ async fn fetch_single_inner(daemon: &Arc<Daemon>, args: &Value, url: &str) -> Va
         &trace,
         t0.elapsed().as_millis(),
     );
-    if prewarmed && let Some(sc) = res.pointer_mut("/structuredContent") {
-        sc["prewarmed_by_search"] = json!(true);
+    if prewarmed {
+        res["_meta"]["com.donsetch/fetch-debug"]["prewarmed_by_search"] = json!(true);
     }
     if stitched_parts > 1
         && let Some(sc) = res.pointer_mut("/structuredContent")
@@ -2060,7 +2061,7 @@ async fn fetch_single_inner(daemon: &Arc<Daemon>, args: &Value, url: &str) -> Va
         cloak_warning = Some(note);
     }
     if let Some(note) = &cloak_warning {
-        if let Some(cell) = res.pointer_mut("/content/1/text")
+        if let Some(cell) = res.pointer_mut("/content/0/text")
             && let Some(md) = cell.as_str().map(String::from)
         {
             *cell = json!(format!("*[cloak_suspected: {note}]*\n\n{md}"));
@@ -2184,13 +2185,11 @@ async fn try_bypass(
         trace,
         t0.elapsed().as_millis(),
     );
-    if let Some(sc) = res.pointer_mut("/structuredContent") {
-        sc["bypass"] = json!({
-            "provider": "brightdata",
-            "tier": if outcome.cached { "cache" } else { "unlocker" },
-            "cache": outcome.cached,
-        });
-    }
+    res["_meta"]["com.donsetch/fetch-debug"]["bypass"] = json!({
+        "provider": "brightdata",
+        "tier": if outcome.cached { "cache" } else { "unlocker" },
+        "cache": outcome.cached,
+    });
     apply_link_handles(daemon, &mut res).await;
     Some(res)
 }
@@ -2961,7 +2960,7 @@ async fn apply_image_ocr(daemon: &Arc<Daemon>, res: &mut Value, images: &[(Strin
                 }
             }
         }
-        if let Some(cell) = res.pointer_mut("/content/1/text")
+        if let Some(cell) = res.pointer_mut("/content/0/text")
             && let Some(md) = cell.as_str().map(String::from)
         {
             *cell = json!(md + &section);
@@ -3122,35 +3121,26 @@ async fn try_resurrect(daemon: &Arc<Daemon>, url: &str, live_error: &Value) -> O
     let mut trace = Trace::default();
     trace.step("archive", "wayback", &format!("snapshot {ts}"), 0);
     let structured = json!({
+        "content_ok": !ex.thin,
+        "url": url,
+        "snapshot_url": snap_url,
+        "archived": { "snapshot": ts, "date": date, "age_days": age_days },
+    });
+    let debug = json!({
         "status": snap.status,
         "tier": "1(wayback)",
         "verdict": "Archived",
-        "content_ok": !ex.thin,
         "thin": ex.thin,
         "title": ex.title,
         "total_chars": ex.total_chars,
         "tokens_est": tokens,
-        "url": url,
-        "snapshot_url": snap_url,
-        "archived": { "snapshot": ts, "date": date, "age_days": age_days },
         "live_error": live_reason,
         "escalation": trace.value(),
     });
-    let meta = json!({
-        "url": url,
-        "tier": "1(wayback)",
-        "verdict": "Archived",
-        "archived": date,
-        "age_days": age_days,
-        "tokens_est": tokens,
-        "title": ex.title,
-    });
     Some(json!({
-        "content": [
-            {"type": "text", "text": format!("[meta] {}", compact_json(&meta))},
-            {"type": "text", "text": ex.markdown},
-        ],
+        "content": [{"type": "text", "text": format_fetch_markdown(&ex, &snap_url, url)}],
         "structuredContent": structured,
+        "_meta": {"com.donsetch/fetch-debug": debug},
     }))
 }
 
@@ -3256,9 +3246,9 @@ fn apply_page_history(
     if since_last {
         let title_line = ex_title.map(|t| format!("# {t}\n")).unwrap_or_default();
         let body = match (changed.as_str(), &delta) {
-            ("unchanged", _) => format!(
-                "{title_line}{url}\n\n*unchanged since last fetch ({ago}s ago) : fingerprint {fp}*\n"
-            ),
+            ("unchanged", _) => {
+                format!("{title_line}{url}\n\n*unchanged since last fetch ({ago}s ago)*\n")
+            }
             (_, Some(d)) => format!(
                 "{title_line}{url}\n\n*changed since last fetch ({changed}, {ago}s ago):*\n\n- {d}\n\n*(full content: refetch without since_last)*\n"
             ),
@@ -3266,17 +3256,14 @@ fn apply_page_history(
                 "{title_line}{url}\n\n*{changed} since last fetch ({ago}s ago) : refetch without since_last for full content*\n"
             ),
         };
-        if let Some(cell) = res.pointer_mut("/content/1/text") {
+        if let Some(cell) = res.pointer_mut("/content/0/text") {
             *cell = json!(body);
-        }
-        if let Some(sc) = res.pointer_mut("/structuredContent") {
-            sc["tokens_est"] = json!(body.len() / 4);
         }
     } else if changed != "new" {
         // Note in the content on change (first contact with the
         // delta is valuable; unchanged stays silent).
         if let Some(d) = &delta
-            && let Some(cell) = res.pointer_mut("/content/1/text")
+            && let Some(cell) = res.pointer_mut("/content/0/text")
             && let Some(md) = cell.as_str().map(String::from)
         {
             *cell = json!(format!(
@@ -3286,31 +3273,17 @@ fn apply_page_history(
         }
     }
 
-    // Stamp meta + structuredContent.
-    let mut meta_patch = json!({ "fp": fp, "changed": changed });
-    if ago > 0 {
-        meta_patch["age_s"] = json!(ago);
-    }
-    if let Some(d) = &delta {
-        meta_patch["changed_sections"] = json!(d);
-    }
-    if let Some(cell) = res.pointer_mut("/content/0/text")
-        && let Some(t) = cell.as_str().map(String::from)
-        && t.ends_with('}')
-    {
-        let mut obj: serde_json::Map<String, Value> =
-            serde_json::from_str(&t.replace("[meta] ", "")).unwrap_or_default();
-        for (k, v) in meta_patch.as_object().unwrap() {
-            obj.insert(k.clone(), v.clone());
-        }
-        *cell = json!(format!("[meta] {}", Value::Object(obj)));
-    }
+    // Change state affects the next model decision. Opaque fingerprints and
+    // observation age are client diagnostics.
     if let Some(sc) = res.pointer_mut("/structuredContent") {
-        sc["fingerprint"] = json!(fp);
         sc["changed"] = json!(changed);
         if let Some(d) = &delta {
             sc["changed_sections"] = json!(d);
         }
+    }
+    res["_meta"]["com.donsetch/fetch-debug"]["fingerprint"] = json!(fp);
+    if ago > 0 {
+        res["_meta"]["com.donsetch/fetch-debug"]["history_age_s"] = json!(ago);
     }
 }
 
@@ -3322,7 +3295,7 @@ fn now_unix() -> u64 {
 }
 
 /// v3 reference handles: rewrite markdown links in a fetch result
-/// to `L{n}` handles and stamp the count into the [meta] block.
+/// to `L{n}` handles and expose the count as compact machine state.
 /// Mutates `res` in place; no-op when links aren't in the output.
 async fn apply_link_handles(daemon: &Arc<Daemon>, res: &mut Value) {
     // When handles are disabled, links keep their hrefs.
@@ -3330,7 +3303,7 @@ async fn apply_link_handles(daemon: &Arc<Daemon>, res: &mut Value) {
         return;
     }
     let Some(text) = res
-        .pointer("/content/1/text")
+        .pointer("/content/0/text")
         .and_then(Value::as_str)
         .map(String::from)
     else {
@@ -3342,22 +3315,59 @@ async fn apply_link_handles(daemon: &Arc<Daemon>, res: &mut Value) {
         return;
     }
     ht.flush();
-    if let Some(cell) = res.pointer_mut("/content/1/text") {
+    if let Some(cell) = res.pointer_mut("/content/0/text") {
         *cell = json!(new_md);
-    }
-    // Stamp the handle count into the [meta] line so the agent
-    // knows links are fetchable handles now. The meta text is
-    // "[meta] {compact json}" : splice before the closing brace.
-    if let Some(meta_text) = res.pointer_mut("/content/0/text")
-        && let Some(s) = meta_text.as_str().map(String::from)
-        && s.ends_with('}')
-    {
-        let patched = s.trim_end_matches('}').to_string() + &format!(",\"link_handles\":{n}}}");
-        *meta_text = json!(patched);
     }
     if let Some(sc) = res.pointer_mut("/structuredContent") {
         sc["link_handles"] = json!(n);
     }
+}
+
+/// Remove only frontmatter represented by the wrapper's canonical source
+/// header. Byline, publication date and summaries remain evidence.
+fn strip_source_frontmatter(markdown: &str, url: &str, title: Option<&str>) -> String {
+    const FRONTMATTER_LINES: usize = 8;
+    let mut dropped_title = false;
+    let mut dropped_url = false;
+    let mut lines = Vec::new();
+    for (index, line) in markdown.lines().enumerate() {
+        let is_same_title = title.is_some_and(|title| {
+            line.strip_prefix("# ")
+                .is_some_and(|candidate| candidate.trim() == title.trim())
+        });
+        if index < FRONTMATTER_LINES && !dropped_title && is_same_title {
+            dropped_title = true;
+            continue;
+        }
+        if index < FRONTMATTER_LINES && !dropped_url && same_fetch_url(line.trim(), url) {
+            dropped_url = true;
+            continue;
+        }
+        lines.push(line);
+    }
+    lines.join("\n").trim().to_string()
+}
+
+fn same_fetch_url(candidate: &str, expected: &str) -> bool {
+    match (url::Url::parse(candidate), url::Url::parse(expected)) {
+        (Ok(candidate), Ok(expected)) => candidate == expected,
+        _ => candidate == expected,
+    }
+}
+
+/// Present one canonical title and source URL followed by the evidence body.
+fn format_fetch_markdown(ex: &extract::Extracted, source_url: &str, display_url: &str) -> String {
+    let body = strip_source_frontmatter(&ex.markdown, source_url, ex.title.as_deref());
+    let mut markdown = String::new();
+    if let Some(title) = &ex.title {
+        markdown.push_str(&format!("# {title}\n"));
+    }
+    markdown.push_str(display_url);
+    if !body.is_empty() {
+        markdown.push_str("\n\n");
+        markdown.push_str(&body);
+    }
+    markdown
 }
 
 fn finish_result(
@@ -3390,15 +3400,36 @@ fn finish_result(
             "per_page_capped": pages.len() > 50,
         })
     });
+    // The model-facing object contains only state that can alter its next
+    // action. Evidence itself appears once in the text block below.
     let mut structured = json!({
+        "url": url,
+        "content_ok": !ex.thin && verdict == "ContentOk",
+        "content_kind": format!("{:?}", ex.content_kind),
+    });
+    if ex.thin {
+        structured["thin"] = json!(true);
+    }
+    if !matches!(ex.lang.as_str(), "" | "und" | "unknown") {
+        structured["lang"] = json!(ex.lang);
+    }
+    if let Some(next_offset) = ex.next_offset {
+        structured["next_offset"] = json!(next_offset);
+    }
+    if let Some(pdf) = &pdf {
+        structured["pdf"] = json!({
+            "pages": pdf["pages"],
+            "ocr_pages": pdf["ocr_pages"],
+        });
+    }
+
+    // Transport and extraction telemetry remains available to MCP clients but
+    // no longer competes with source evidence in model context.
+    let debug = json!({
         "status": status,
         "tier": tier,
         "verdict": verdict,
-        "content_ok": !ex.thin && verdict == "ContentOk",
-        "thin": ex.thin,
-        "content_kind": format!("{:?}", ex.content_kind),
         "quality": ex.quality,
-        "lang": ex.lang,
         "title": ex.title,
         "byline": ex.byline,
         "published": ex.published,
@@ -3406,52 +3437,16 @@ fn finish_result(
         "blocks_shown": ex.blocks_shown,
         "blocks_total": ex.blocks_total,
         "total_chars": ex.total_chars,
-        "next_offset": ex.next_offset,
         "tokens_est": ex.tokens_est,
+        "elapsed_ms": elapsed_ms,
         "escalation": trace.value(),
+        "via": ex.via,
         "pdf": pdf,
-        "url": url,
-        "ms": elapsed_ms,
     });
-    // v3: the honest adapter label : the agent sees WHICH
-    // structured source produced this result.
-    if let Some(via) = ex.via {
-        structured["via"] = json!(via);
-    }
-    // Compact metadata text block prepended for clients (Claude Code,
-    // VSCode) that drop text content when structuredContent is present.
-    let mut meta = json!({
-        "url": url,
-        "tier": tier,
-        "verdict": verdict,
-        "content_ok": !ex.thin && verdict == "ContentOk",
-        "thin": ex.thin,
-        "tokens_est": ex.tokens_est,
-        "total_chars": ex.total_chars,
-        "ms": elapsed_ms,
-        "lang": ex.lang,
-    });
-    if let Some(n) = ex.next_offset {
-        meta["next_offset"] = json!(n);
-    }
-    if let Some(via) = ex.via {
-        meta["via"] = json!(via);
-    }
-    if let Some(t) = &ex.title {
-        meta["title"] = json!(t);
-    }
-    if let Some(p) = &pdf {
-        meta["pdf_pages"] = json!(p["pages"]);
-        if p["ocr_pages"].as_u64().unwrap_or(0) > 0 {
-            meta["pdf_ocr"] = json!(p["ocr_pages"]);
-        }
-    }
     json!({
-        "content": [
-            {"type": "text", "text": format!("[meta] {}", compact_json(&meta))},
-            {"type": "text", "text": ex.markdown},
-        ],
+        "content": [{"type": "text", "text": format_fetch_markdown(ex, url, url)}],
         "structuredContent": structured,
+        "_meta": {"com.donsetch/fetch-debug": debug},
     })
 }
 
@@ -4057,10 +4052,8 @@ fn next_action_for(verdict: Option<Verdict>, status: u16, kind: &str) -> String 
 
 /// Escalation trace: the ordered record of what DonSeTch tried :
 /// HTTP → browser → OCR-style fallbacks : with tier, action,
-/// outcome and per-step latency. Surfaced as
-/// structuredContent.escalation on successes AND errors, so the
-/// agent sees exactly why a fetch took its path (and what a
-/// 20s latency was spent on) without re-deriving it.
+/// outcome and per-step latency. Successes expose it through client-only
+/// `_meta`; errors retain actionable state on the model surface.
 #[derive(Default)]
 struct Trace {
     steps: Vec<Value>,
@@ -4226,6 +4219,82 @@ mod error_code_tests {
             "crawl.resume"
         );
         assert_eq!(error_code("fetch: invalid URL", None), "fetch.invalid");
+    }
+}
+
+#[cfg(test)]
+mod fetch_output_contract_tests {
+    use super::{Trace, finish_result, format_fetch_markdown};
+    use crate::extract::{ContentKind, Extracted};
+
+    pub(super) fn extracted(markdown: &str) -> Extracted {
+        Extracted {
+            markdown: markdown.into(),
+            title: Some("Example".into()),
+            byline: Some("A. Author".into()),
+            published: Some("2026-09-04".into()),
+            site: Some("Example Site".into()),
+            total_chars: markdown.len(),
+            next_offset: None,
+            blocks_total: 4,
+            blocks_shown: 3,
+            tokens_est: markdown.len() / 4,
+            thin: false,
+            content_kind: ContentKind::Article,
+            lang: "en".into(),
+            quality: 0.91,
+            pdf_pages: None,
+            images: Vec::new(),
+            fingerprint: Some("opaque".into()),
+            via: None,
+        }
+    }
+
+    #[test]
+    fn fetch_renders_identity_once_and_hides_diagnostics_from_model_state() {
+        let mut trace = Trace::default();
+        trace.step("1", "http-fetch", "ok", 12);
+        let output = finish_result(
+            &extracted("https://example.com/page\n\n# Example\n\nEvidence."),
+            "1",
+            200,
+            "ContentOk",
+            "https://example.com/page",
+            &trace,
+            14,
+        );
+
+        assert_eq!(output["content"].as_array().unwrap().len(), 1);
+        let text = output["content"][0]["text"].as_str().unwrap();
+        assert_eq!(text.matches("# Example").count(), 1);
+        assert_eq!(text.matches("https://example.com/page").count(), 1);
+        assert!(!text.starts_with("[meta]"));
+        let state = output["structuredContent"].as_object().unwrap();
+        for absent in [
+            "title",
+            "tier",
+            "quality",
+            "tokens_est",
+            "escalation",
+            "status",
+        ] {
+            assert!(
+                !state.contains_key(absent),
+                "{absent} leaked to model state"
+            );
+        }
+        assert_eq!(state["url"], "https://example.com/page");
+        assert_eq!(output["_meta"]["com.donsetch/fetch-debug"]["tier"], "1");
+
+        let unrelated = extracted("# Actual first section\n\nEvidence.");
+        assert!(
+            format_fetch_markdown(
+                &unrelated,
+                "https://example.com/page",
+                "https://example.com/page"
+            )
+            .contains("# Actual first section")
+        );
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -3674,31 +3674,64 @@ async fn search_inner(
         Ok(out) => {
             let top = out.results.first().map(|r| r.url.as_str());
             maybe_pre_solve(daemon, top);
-            render_search_outcome(daemon, &out, query).await
+            render_search_outcome(daemon, &out).await
         }
         Err(failure) => search_error(query, &failure.cause, failure.byok_tried),
     }
 }
 
-async fn render_search_outcome(
-    daemon: &Arc<Daemon>,
-    out: &crate::search::SearchOutcome,
-    query: &str,
-) -> Value {
+async fn render_search_outcome(daemon: &Arc<Daemon>, out: &crate::search::SearchOutcome) -> Value {
     let hs = bind_search_handles(daemon, out).await;
     let hints = route_hints(daemon, out).await;
-    let md = search::render_markdown(out, query, Some(&hs), &hints);
-    let meta = search::render_meta(out);
+    let md = search::render_compact_markdown(out, "# Search results", Some(&hs), &hints);
+    let model = search_model_meta(out, &hs);
+    let debug = search_debug_meta(out);
     json!({
         "content": [{ "type": "text", "text": md }],
-        "structuredContent": meta,
+        "structuredContent": model,
+        "_meta": {"com.donsetch/search-debug": debug},
     })
 }
 
-/// Execute explicit query variants concurrently but keep every result set
-/// separate. Cross-query score fusion would create a second, unbenchmarked
-/// ranker; grouped evidence lets the calling model compare formulations while
-/// each query retains DonSeTch's existing ranking semantics.
+/// Machine state needed to route a subsequent fetch. Titles and snippets are
+/// already present on the linear evidence surface; ranking and engine
+/// telemetry remain in client-only metadata.
+fn search_model_meta(out: &crate::search::SearchOutcome, handles: &[String]) -> Value {
+    let results = out
+        .results
+        .iter()
+        .enumerate()
+        .map(|(index, result)| {
+            let mut item = json!({
+                "rank": index + 1,
+                "url": result.url,
+            });
+            if let Some(handle) = handles.get(index) {
+                item["handle"] = json!(handle);
+            }
+            item
+        })
+        .collect::<Vec<_>>();
+    json!({"weak": out.weak, "results": results})
+}
+
+fn search_debug_meta(out: &crate::search::SearchOutcome) -> Value {
+    let mut debug = search::render_meta(out);
+    if let Some(results) = debug.get_mut("results").and_then(Value::as_array_mut) {
+        for result in results {
+            if let Some(fields) = result.as_object_mut() {
+                fields.remove("title");
+                fields.remove("url");
+                fields.remove("snippet");
+            }
+        }
+    }
+    debug
+}
+
+/// Execute explicit query variants concurrently and keep every result set
+/// separate. Grouped evidence lets the calling model compare formulations
+/// while each query retains DonSeTch's established ranking semantics.
 async fn search_batch_inner(
     daemon: &Arc<Daemon>,
     queries: &[String],
@@ -3745,16 +3778,18 @@ async fn search_batch_inner(
         .collect::<Vec<_>>();
     let handles = bind_search_urls(daemon, &urls).await;
     let mut handle_offset = 0usize;
-    let mut markdown = format!(
-        "*{} explicit query formulations searched in parallel; result sets are kept separate.*\n\n",
-        queries.len()
-    );
+    let mut markdown = format!("# Search results : {} formulations", queries.len());
     let mut searches = Vec::with_capacity(queries.len());
+    let mut diagnostics = Vec::with_capacity(queries.len());
 
     for (query, outcome) in queries.iter().zip(outcomes.iter()) {
-        if !markdown.ends_with("\n\n") {
-            markdown.push_str("\n\n");
-        }
+        markdown.push_str("\n\n");
+        let role = if searches.is_empty() {
+            "primary"
+        } else {
+            "variant"
+        };
+        let heading = format!("## q{} {role} : {query}", searches.len());
         match outcome {
             Ok(out) => {
                 let count = out.results.len();
@@ -3765,22 +3800,27 @@ async fn search_batch_inner(
                 };
                 handle_offset += count;
                 let hints = route_hints(daemon, out).await;
-                markdown.push_str(&search::render_markdown(out, query, query_handles, &hints));
-                markdown.push_str("\n---\n");
-                let mut meta = search::render_meta(out);
-                meta["query"] = json!(query);
-                searches.push(meta);
+                markdown.push_str(&search::render_compact_markdown(
+                    out,
+                    &heading,
+                    query_handles,
+                    &hints,
+                ));
+                let mut model = search_model_meta(out, query_handles.unwrap_or(&[]));
+                model["query"] = json!(query);
+                searches.push(model);
+                let mut debug = search_debug_meta(out);
+                debug["query"] = json!(query);
+                diagnostics.push(debug);
             }
             Err(failure) => {
-                markdown.push_str(&format!(
-                    "# Search: {query}\n\n*failed: {}*\n\n---\n",
-                    failure.cause
-                ));
+                markdown.push_str(&format!("{heading}\nFailed : {}", failure.cause));
                 searches.push(json!({
                     "query": query,
                     "error": failure.cause,
                     "results": [],
                 }));
+                diagnostics.push(json!({"query": query, "error": failure.cause}));
             }
         }
     }
@@ -3791,9 +3831,12 @@ async fn search_batch_inner(
             "query_count": queries.len(),
             "ok": ok,
             "errors": queries.len() - ok,
-            "elapsed_ms": started.elapsed().as_millis() as u64,
             "searches": searches,
         },
+        "_meta": {"com.donsetch/search-debug": {
+            "elapsed_ms": started.elapsed().as_millis() as u64,
+            "searches": diagnostics,
+        }},
     })
 }
 
@@ -4348,6 +4391,47 @@ mod fetch_output_contract_tests {
             )
             .contains("# Actual first section")
         );
+    }
+}
+
+#[cfg(test)]
+mod search_output_contract_tests {
+    use super::{search_debug_meta, search_model_meta};
+    use crate::search::SearchOutcome;
+    use crate::search::intent::Intent;
+    use crate::search::rank::Merged;
+    use std::time::Duration;
+
+    #[test]
+    fn search_structure_routes_without_repeating_ranked_evidence() {
+        let output = SearchOutcome {
+            results: vec![Merged {
+                title: "Visible in markdown".into(),
+                url: "https://example.com/answer".into(),
+                snippet: "Evidence belongs to text".into(),
+                sources: vec![("bing".into(), 0)],
+                score: 0.9,
+                published: None,
+            }],
+            weak: false,
+            intent: Intent::Web,
+            report: Vec::new(),
+            cached: false,
+            elapsed: Duration::from_millis(10),
+            provider: None,
+            reranked: true,
+        };
+        let state = search_model_meta(&output, &["S1".into()]);
+        assert_eq!(state["results"][0]["rank"], 1);
+        assert_eq!(state["results"][0]["handle"], "S1");
+        for absent in ["title", "snippet", "score", "engines"] {
+            assert!(state["results"][0].get(absent).is_none());
+        }
+        let debug = search_debug_meta(&output);
+        assert_eq!(debug["results"][0]["score"], 0.9);
+        assert!(debug["results"][0].get("title").is_none());
+        assert!(debug["results"][0].get("url").is_none());
+        assert!(debug["results"][0].get("snippet").is_none());
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1042,29 +1042,11 @@ async fn fetch_multi(
 
     let is_err = |v: &Value| v.get("isError").and_then(Value::as_bool).unwrap_or(false);
     let md_of = |v: &Value| {
-        v.pointer("/content/1/text")
+        v.pointer("/content/0/text")
             .and_then(Value::as_str)
             .unwrap_or("")
             .to_string()
     };
-    let title_of = |v: &Value| {
-        v.pointer("/structuredContent/title")
-            .and_then(Value::as_str)
-            .unwrap_or("")
-            .to_string()
-    };
-    let tokens_of = |v: &Value| {
-        v.pointer("/structuredContent/tokens_est")
-            .and_then(Value::as_u64)
-            .unwrap_or(0) as usize
-    };
-    let tier_of = |v: &Value| {
-        v.pointer("/structuredContent/tier")
-            .and_then(Value::as_str)
-            .unwrap_or("?")
-            .to_string()
-    };
-
     // Budget slicing: proportional to returned size, floor 300
     // chars, only when the sum overflows.
     let mut markdowns: Vec<Option<String>> = results
@@ -1130,7 +1112,31 @@ async fn fetch_multi(
         }
     }
 
-    // Compose.
+    render_fetch_batch(&urls, &results, &markdowns, budget_tokens, &sliced_flags)
+}
+
+/// Compose a batch without repeating page evidence or transport telemetry on
+/// model-visible surfaces. Kept pure so partial and all-failed contracts are
+/// deterministic unit-test inputs.
+fn render_fetch_batch(
+    urls: &[String],
+    results: &[Value],
+    markdowns: &[Option<String>],
+    budget_tokens: Option<usize>,
+    sliced_flags: &[bool],
+) -> Value {
+    debug_assert_eq!(urls.len(), results.len());
+    debug_assert_eq!(urls.len(), markdowns.len());
+    debug_assert_eq!(urls.len(), sliced_flags.len());
+
+    let is_err = |v: &Value| v.get("isError").and_then(Value::as_bool).unwrap_or(false);
+    let title_of = |v: &Value| {
+        v.pointer("/_meta/com.donsetch~1fetch-debug/title")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .to_string()
+    };
+
     let mut text = String::new();
     let ok_count = markdowns.iter().filter(|m| m.is_some()).count();
     let err_count = results.len() - ok_count;
@@ -1142,67 +1148,120 @@ async fn fetch_multi(
             } else {
                 title.as_str()
             };
+            let body = strip_source_frontmatter(
+                md,
+                &urls[i],
+                (!title.is_empty()).then_some(title.as_str()),
+            );
             text.push_str(&format!(
-                "## [{i}] {} : {}\ntier={} tokens≈{}\n\n{}\n\n---\n\n",
+                "## [{}] {}\n{}\n\n{}\n\n---\n\n",
+                i + 1,
                 head,
                 urls[i],
-                tier_of(r),
-                (md.len() / 4).max(1),
-                md
+                body
             ));
         } else {
             let msg = r
                 .pointer("/content/0/text")
                 .and_then(Value::as_str)
                 .unwrap_or("fetch failed");
-            text.push_str(&format!("## [{i}] {} : ERROR\n{}\n\n---\n\n", urls[i], msg));
+            text.push_str(&format!(
+                "## [{}] {} : ERROR\n{}\n\n---\n\n",
+                i + 1,
+                urls[i],
+                msg
+            ));
         }
     }
-    let mut meta = json!({
-        "urls": results.len(),
-        "ok": ok_count,
-        "errors": err_count,
-    });
-    if let Some(b) = budget_tokens {
-        meta["budget_tokens"] = json!(b);
-    }
-    let structured = json!({
-        "urls": urls,
-        "results": results.iter().enumerate().map(|(i, r)| {
+    let structured_results = results
+        .iter()
+        .enumerate()
+        .map(|(i, r)| {
             let mut o = json!({
                 "url": urls[i],
                 "ok": !is_err(r),
-                "tier": tier_of(r),
-                "tokens_est": tokens_of(r),
             });
+            if !is_err(r) {
+                let state = &r["structuredContent"];
+                if state.get("content_ok").and_then(Value::as_bool) == Some(false) {
+                    o["content_ok"] = json!(false);
+                }
+                for field in ["next_offset", "archived"] {
+                    if let Some(value) = state.get(field)
+                        && !value.is_null()
+                    {
+                        o[field] = value.clone();
+                    }
+                }
+                for field in ["thin", "cloak_suspected"] {
+                    if state.get(field).and_then(Value::as_bool).unwrap_or(false) {
+                        o[field] = json!(true);
+                    }
+                }
+                if let Some(changed) = state.get("changed").and_then(Value::as_str)
+                    && changed != "new"
+                {
+                    o["changed"] = json!(changed);
+                }
+            }
             if sliced_flags[i] {
                 o["sliced"] = json!(true);
             }
             if is_err(r) {
-                o["error"] = json!(r.pointer("/content/0/text").and_then(Value::as_str).unwrap_or("fetch failed"));
+                o["code"] = r
+                    .pointer("/structuredContent/code")
+                    .cloned()
+                    .unwrap_or_else(|| json!("content.extract"));
             }
             o
-        }).collect::<Vec<_>>(),
+        })
+        .collect::<Vec<_>>();
+    let mut structured = json!({
+        "ok": ok_count,
+        "errors": err_count,
+        "results": structured_results,
+    });
+    let debug_results = results
+        .iter()
+        .enumerate()
+        .map(|(index, result)| {
+            let fetch_debug = &result["_meta"]["com.donsetch/fetch-debug"];
+            let mut item = json!({"url": urls[index]});
+            for field in ["tier", "tokens_est"] {
+                if let Some(value) = fetch_debug.get(field)
+                    && !value.is_null()
+                {
+                    item[field] = value.clone();
+                }
+            }
+            item
+        })
+        .collect::<Vec<_>>();
+    let debug = json!({
+        "count": results.len(),
         "budget_tokens": budget_tokens,
+        "results": debug_results,
     });
 
     if ok_count == 0 {
-        return tool_error_structured(
-            format!("fetch: all {} urls failed", results.len()),
+        structured["next_action"] =
+            json!("inspect the per-URL errors above; retry only transient failures individually");
+        let mut error = tool_error_structured(
+            format!(
+                "fetch: all {} urls failed\n\n{}",
+                results.len(),
+                text.trim_end()
+            ),
             "transient",
-            Some(json!({
-                "urls": urls,
-                "results": structured["results"].clone(),
-                "next_action": "see per-url errors in structuredContent.results : fetch promising ones individually",
-            })),
+            Some(structured),
         );
+        error["_meta"]["com.donsetch/fetch-batch-debug"] = debug;
+        return error;
     }
     json!({
-        "content": [
-            {"type": "text", "text": format!("[meta] {}", compact_json(&meta))},
-            {"type": "text", "text": text},
-        ],
-        "structuredContent": structured
+        "content": [{"type": "text", "text": text.trim_end()}],
+        "structuredContent": structured,
+        "_meta": {"com.donsetch/fetch-batch-debug": debug},
     })
 }
 
@@ -4295,6 +4354,92 @@ mod fetch_output_contract_tests {
             )
             .contains("# Actual first section")
         );
+    }
+}
+
+#[cfg(test)]
+mod batch_output_contract_tests {
+    use super::fetch_output_contract_tests::extracted;
+    use super::{Trace, finish_result, render_fetch_batch};
+    use serde_json::json;
+
+    #[test]
+    fn batch_keeps_evidence_order_and_per_url_failure_codes() {
+        let urls: Vec<String> = vec![
+            "https://example.com/a".into(),
+            "https://example.com/b".into(),
+        ];
+        let success = finish_result(
+            &extracted("# Example\nhttps://example.com/a\n\nAlpha."),
+            "1",
+            200,
+            "ContentOk",
+            &urls[0],
+            &Trace::default(),
+            1,
+        );
+        let failure = json!({
+            "content": [{"type": "text", "text": "request timed out"}],
+            "structuredContent": {"code": "network.timeout"},
+            "isError": true,
+        });
+        let results = vec![success, failure];
+        let markdowns = vec![
+            Some(
+                results[0]["content"][0]["text"]
+                    .as_str()
+                    .unwrap()
+                    .to_string(),
+            ),
+            None,
+        ];
+        let output = render_fetch_batch(&urls, &results, &markdowns, Some(2_000), &[false, false]);
+        assert_eq!(output["content"].as_array().unwrap().len(), 1);
+        let text = output["content"][0]["text"].as_str().unwrap();
+        assert!(text.find("Alpha.").unwrap() < text.find("request timed out").unwrap());
+        assert_eq!(
+            output["structuredContent"]["results"][1]["code"],
+            "network.timeout"
+        );
+        let first = &output["structuredContent"]["results"][0];
+        assert!(first.get("content_ok").is_none());
+        assert!(first.get("content_kind").is_none());
+        assert!(first.get("thin").is_none());
+        assert!(first.get("changed").is_none());
+        assert!(first.get("tier").is_none());
+        let first_debug = &output["_meta"]["com.donsetch/fetch-batch-debug"]["results"][0];
+        assert_eq!(first_debug["tier"], "1");
+        assert!(first_debug.get("tokens_est").is_some());
+        assert!(first_debug.get("quality").is_none());
+        assert!(first_debug.get("escalation").is_none());
+
+        let flagged = json!({
+            "content": [{"type": "text", "text": "# Thin\nhttps://example.com/a"}],
+            "structuredContent": {
+                "content_ok": false,
+                "content_kind": "Page",
+                "thin": true,
+                "changed": "major",
+                "next_offset": 16000,
+                "cloak_suspected": true,
+                "archived": {"date": "2026-09-01", "age_days": 3}
+            }
+        });
+        let flagged_output = render_fetch_batch(
+            &urls[..1],
+            &[flagged],
+            &[Some("# Thin\nhttps://example.com/a".into())],
+            None,
+            &[false],
+        );
+        let flagged_state = &flagged_output["structuredContent"]["results"][0];
+        assert_eq!(flagged_state["content_ok"], false);
+        assert!(flagged_state.get("content_kind").is_none());
+        assert_eq!(flagged_state["thin"], true);
+        assert_eq!(flagged_state["changed"], "major");
+        assert_eq!(flagged_state["next_offset"], 16000);
+        assert_eq!(flagged_state["cloak_suspected"], true);
+        assert_eq!(flagged_state["archived"]["age_days"], 3);
     }
 }
 

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -1214,6 +1214,66 @@ or add an API-key provider (`donsetch keys add`)*\n",
     md
 }
 
+/// Compact MCP evidence surface. Rank already communicates the ordering
+/// decision, while per-engine scores and timings remain available as client
+/// diagnostics. Keep only evidence and state that can alter the next action.
+pub fn render_compact_markdown(
+    out: &SearchOutcome,
+    heading: &str,
+    handles: Option<&[String]>,
+    hints: &[Option<String>],
+) -> String {
+    let mut markdown = String::new();
+    if !heading.is_empty() {
+        markdown.push_str(heading);
+        markdown.push('\n');
+    }
+
+    for (index, result) in out.results.iter().enumerate() {
+        let reference = handles
+            .and_then(|items| items.get(index))
+            .map(String::as_str)
+            .unwrap_or(&result.url);
+        let host = rank::host_of(&result.url);
+        markdown.push_str(&format!(
+            "{}. {reference} · {} : {host}",
+            index + 1,
+            result.title
+        ));
+        if let Some(hint) = hints.get(index).and_then(|hint| hint.as_deref()) {
+            markdown.push(' ');
+            markdown.push_str(hint);
+        }
+        markdown.push('\n');
+        if !result.snippet.is_empty() {
+            markdown.push_str("   ");
+            markdown.push_str(&clip_snippet(&result.snippet, SNIPPET_CHARS));
+            markdown.push('\n');
+        }
+    }
+
+    if out.results.is_empty() {
+        markdown.push_str("No results. Retry once with a materially different formulation.\n");
+    } else if out.weak {
+        markdown.push_str("Weak results : low cross-source agreement.\n");
+    }
+
+    let unavailable = out
+        .report
+        .iter()
+        .filter(|report| report.status != "ok")
+        .count();
+    if unavailable > 0 {
+        markdown.push_str(&format!(
+            "Degraded retrieval : {}/{} backends available.\n",
+            out.report.len() - unavailable,
+            out.report.len()
+        ));
+    }
+
+    markdown.trim_end().to_string()
+}
+
 /// structuredContent metadata.
 pub fn render_meta(out: &SearchOutcome) -> Value {
     json!({
@@ -1483,6 +1543,59 @@ mod tests {
             md.contains("engines: bing, ddg · score: 0.83"),
             "provenance line missing:\n{md}"
         );
+    }
+
+    #[test]
+    fn compact_markdown_keeps_evidence_and_actionable_state_only() {
+        let mut result = merged("https://tokio.rs/runtime");
+        result.title = "Tokio runtime guide".into();
+        result.snippet = "A focused explanation of the asynchronous runtime.".into();
+        result.sources = vec![("bing".into(), 0), ("ddg".into(), 2)];
+        result.score = 0.8312;
+        let mut search = outcome(vec![result]);
+        search.weak = true;
+        search.report = vec![
+            EngineReport {
+                engine: "bing".into(),
+                status: "ok".into(),
+                hits: 10,
+                ms: 12,
+                egress: "direct".into(),
+            },
+            EngineReport {
+                engine: "ddg".into(),
+                status: "blocked:403".into(),
+                hits: 0,
+                ms: 20,
+                egress: "proxy".into(),
+            },
+        ];
+
+        let markdown = render_compact_markdown(
+            &search,
+            "# Search results",
+            Some(&["S1".into()]),
+            &[Some("· ⚠ needs browser".into())],
+        );
+        assert!(markdown.contains("1. S1 · Tokio runtime guide : tokio.rs · ⚠ needs browser"));
+        assert!(markdown.contains("A focused explanation"));
+        assert!(markdown.contains("Weak results : low cross-source agreement."));
+        assert!(markdown.contains("Degraded retrieval : 1/2 backends available."));
+        for diagnostic in [
+            "engines:",
+            "score:",
+            "results in",
+            "via local",
+            "fetch results by",
+        ] {
+            assert!(!markdown.contains(diagnostic), "{diagnostic}:\n{markdown}");
+        }
+    }
+
+    #[test]
+    fn compact_markdown_gives_zero_result_recovery() {
+        let markdown = render_compact_markdown(&outcome(Vec::new()), "# Search results", None, &[]);
+        assert!(markdown.contains("materially different formulation"));
     }
 
     #[test]

--- a/src/spec.rs
+++ b/src/spec.rs
@@ -44,9 +44,8 @@ pub enum ParamKind {
     /// JSON boolean; CLI flag whose presence sets `false`
     /// (negating flags like --any-host for same_host).
     SetFalse,
-    /// JSON value passed through as-is (array of objects);
-    /// CLI takes a JSON string and parses it.
-    JsonStr,
+    /// Ordered browser action objects; CLI takes one JSON array string.
+    ActionList,
 }
 
 /// How the parameter appears on the CLI.
@@ -72,10 +71,11 @@ pub struct ParamSpec {
     pub kind: ParamKind,
     pub cli: CliKind,
     pub required: bool,
-    /// Description string : used verbatim as the MCP schema
-    /// description AND the clap help text. One string, both
-    /// interfaces.
+    /// Complete human-facing help used by the CLI.
     pub help: &'static str,
+    /// Optional compact model-facing help. `None` means the CLI help is
+    /// already concise enough to serve both audiences.
+    pub mcp_help: Option<&'static str>,
 }
 
 pub struct ToolSpec {
@@ -86,8 +86,11 @@ pub struct ToolSpec {
     /// One-liner : `donsetch --help` listing AND the MCP
     /// `instructions` blurb sent at initialize.
     pub summary: &'static str,
-    /// Full description : MCP tool description AND CLI long help.
+    /// Full human-facing description used by CLI long help.
     pub description: &'static str,
+    /// Compact model-facing contract. Field-specific instructions stay on the
+    /// corresponding parameters instead of being repeated here.
+    pub mcp_description: &'static str,
     pub params: &'static [ParamSpec],
     /// Copy-pasteable CLI examples, shown in `--help` epilog.
     pub examples: &'static [&'static str],
@@ -103,6 +106,9 @@ const FETCH_PARAMS: &[ParamSpec] = &[
         cli: CliKind::PositionalBulk,
         required: true,
         help: "URL to fetch: http(s) URL, a handle (L/S from earlier results), or an array of up to 12 for one parallel batch call.",
+        mcp_help: Some(
+            "One http(s) URL, an S/L handle returned earlier, or an array of up to 12 URLs or handles for one batch read.",
+        ),
     },
     ParamSpec {
         name: "budget_tokens",
@@ -111,6 +117,9 @@ const FETCH_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Batch mode (array url): total output token budget shared across all results (200-500k). DonSeTch allocates it across pages by size : small pages stay whole, big ones get sliced with a resume note. Without it each page uses max_chars independently.",
+        mcp_help: Some(
+            "Shared output-token limit for a URL batch (200-500000). Omit for one URL. Truncated members return continuation information.",
+        ),
     },
     ParamSpec {
         name: "focus",
@@ -119,6 +128,9 @@ const FETCH_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Relevance query : returns ONLY blocks that score against it, cutting tokens 50-80% on long pages. Scoring is BM25 keyword matching; a cross-encoder pass also catches blocks that use different words, but only on pages of 80 blocks or fewer AND only when the rerank model is already cached from prior search use (plain BM25 otherwise, never a download mid-fetch). If nothing matches, returns the full page with a notice. ALWAYS set when you know what you're looking for : #1 token saver.",
+        mcp_help: Some(
+            "Topic or question for returning only relevant passages. Set when the requested evidence is known; omit only when the whole page is needed. A no-match response is labeled and falls back to the full page.",
+        ),
     },
     ParamSpec {
         name: "max_chars",
@@ -127,6 +139,7 @@ const FETCH_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Max markdown chars (default 16000). Truncated pages include next_offset for resumption.",
+        mcp_help: None,
     },
     ParamSpec {
         name: "offset",
@@ -135,6 +148,9 @@ const FETCH_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Resume from a previous response's next_offset to continue a truncated page.",
+        mcp_help: Some(
+            "Continue from a previous next_offset. Reuse the same URL and any focus, section, selector or rendering fields from that fetch.",
+        ),
     },
     ParamSpec {
         name: "section",
@@ -143,6 +159,7 @@ const FETCH_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Heading name (substring, case-insensitive) : return only that section. Use after toc to target a specific part.",
+        mcp_help: None,
     },
     ParamSpec {
         name: "toc",
@@ -151,6 +168,9 @@ const FETCH_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "true = heading outline only, no body text. Read structure first, then target with section or focus.",
+        mcp_help: Some(
+            "Return only the heading outline. Use as a standalone first read, then make a new fetch with section or focus.",
+        ),
     },
     ParamSpec {
         name: "deadline_ms",
@@ -159,6 +179,7 @@ const FETCH_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Hard time budget for this call in ms (500-600000). On expiry: honest deadline error + next_action : never a silent hang. Batch mode: per-URL budget.",
+        mcp_help: None,
     },
     ParamSpec {
         name: "archive",
@@ -167,6 +188,9 @@ const FETCH_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Dead-page recovery via the keyless Wayback Machine. auto (default): on hard failure (404/paywall/unsolvable wall) serve the nearest archived snapshot, clearly labeled with its date. only: skip the live fetch, go straight to the archive. off: never.",
+        mcp_help: Some(
+            "Archived-page policy: auto (default) falls back when the live page is unavailable; only skips the live page; off disables archive recovery.",
+        ),
     },
     ParamSpec {
         name: "since_last",
@@ -175,6 +199,9 @@ const FETCH_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Change check instead of full read: if the page is unchanged since your last fetch, output collapses to a one-line verdict; if changed, you get the section-level delta (added/removed/changed). Refetch without it for full content. Monitoring/re-verification at ~zero tokens.",
+        mcp_help: Some(
+            "Standalone change check for a previously fetched URL. Returns an unchanged verdict or changed sections instead of the full page. Do not combine with reading filters or rendering fields.",
+        ),
     },
     ParamSpec {
         name: "stitch",
@@ -183,6 +210,9 @@ const FETCH_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Multi-page articles: follow rel=next pagination and return the WHOLE article in one call (up to 6 parts / 48k chars) with *(part N)* markers, instead of re-fetching page by page. Same-host only.",
+        mcp_help: Some(
+            "Read all parts of a paginated article in one call (up to 6 parts / 48000 chars). Enable only when the requested source spans article pages.",
+        ),
     },
     ParamSpec {
         name: "image_text",
@@ -191,6 +221,9 @@ const FETCH_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "OCR the page's content images (up to 4) and append an 'image text' section. For infographics/comics/screenshots whose meaning IS the image. Costs extra fetch+compute : only when image content matters.",
+        mcp_help: Some(
+            "Extract words from up to 4 content images. Enable only when requested evidence is inside an infographic, screenshot, comic or other image.",
+        ),
     },
     ParamSpec {
         name: "must_contain",
@@ -199,6 +232,9 @@ const FETCH_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Probe mode: verify the page mentions a string/pattern WITHOUT loading it into context. Output = MATCH/NO-MATCH verdict + up to 3 short context excerpts. Case-insensitive substring, or /regex/ (e.g. \"/CVE-2026-\\d+/\"). Full fetch still happens (tiers, walls, PDFs) : only the output collapses. For verification questions, not reading.",
+        mcp_help: Some(
+            "Case-insensitive string or /regex/ presence check. Returns MATCH/NO-MATCH and up to 3 excerpts instead of the full page; use for verification, not general reading.",
+        ),
     },
     ParamSpec {
         name: "selector",
@@ -207,6 +243,9 @@ const FETCH_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "CSS selector : extract only from matching elements. Narrows scope precisely.",
+        mcp_help: Some(
+            "CSS selector for extracting only matching elements. Set only when the selector is known; focus may filter passages inside that region.",
+        ),
     },
     ParamSpec {
         name: "tier",
@@ -215,6 +254,7 @@ const FETCH_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "auto (default, always use for real work): HTTP first, auto-escalates to headless browser on bot-walls/JS-shells, auto-detects and parses PDFs. \"1\" (testing): HTTP only, no browser : fails on JS sites. \"2\" (testing): browser directly : slower, skips HTTP entirely.",
+        mcp_help: None,
     },
     ParamSpec {
         name: "links",
@@ -223,6 +263,9 @@ const FETCH_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Include [text](url) link URLs. Default false : saves ~30% tokens. Enable only when you need the URLs.",
+        mcp_help: Some(
+            "Include destination URLs found inside page content. The fetched page's own citation URL is always returned separately; enable only when outbound targets are requested evidence.",
+        ),
     },
     ParamSpec {
         name: "media",
@@ -231,14 +274,20 @@ const FETCH_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Include image alt text and sources. Default false.",
+        mcp_help: Some(
+            "Include image alt text and source URLs. Use image_text instead when words inside an image must be read.",
+        ),
     },
     ParamSpec {
         name: "actions",
         flag: "actions",
-        kind: ParamKind::JsonStr,
+        kind: ParamKind::ActionList,
         cli: CliKind::Flag,
         required: false,
         help: "Browser steps to run BEFORE extraction : page control inside fetch: [{\"do\":\"click\",\"selector\":\"#load-more\"},{\"do\":\"type\",\"selector\":\"input[q]\",\"text\":\"query\"},{\"do\":\"press\",\"key\":\"Enter\"},{\"do\":\"wait_text\",\"text\":\"results\"}]. Steps: wait {ms}, wait_selector {selector,timeout_ms}, wait_text {text,timeout_ms}, click {selector OR text}, hover, type {selector?,text}, press {key: Enter|Tab|Escape|Backspace|ArrowDown|...}, scroll {to: top|bottom|down | px}. Max 16 steps. Actions run in the headless browser (tier auto/2, never 1); after them the page is extracted normally : focus/section/toc still apply. First failing step aborts honestly with per-step results in structuredContent.actions; fix that step and re-run.",
+        mcp_help: Some(
+            "Ordered page interactions before reading (1-16 objects). Each object requires do. Required fields: wait uses ms; wait_selector uses selector; wait_text uses text; click/hover uses selector or text; type uses text and optional selector; press uses key; scroll uses to or px. The first failed step stops and is reported.",
+        ),
     },
     ParamSpec {
         name: "shot",
@@ -247,6 +296,7 @@ const FETCH_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "File path : saves a PNG screenshot when blocked by interactive captcha. Only fires on captcha walls; not a general screenshot tool.",
+        mcp_help: None,
     },
 ];
 
@@ -260,6 +310,9 @@ const SEARCH_PARAMS: &[ParamSpec] = &[
         cli: CliKind::PositionalJoined,
         required: true,
         help: "Search query.",
+        mcp_help: Some(
+            "Primary search formulation. Include required entities, dates, versions and exclusions; do not include a guessed answer.",
+        ),
     },
     ParamSpec {
         name: "query_variants",
@@ -268,6 +321,9 @@ const SEARCH_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Optional alternate formulations of the same information need (max 2). DonSeTch searches the base query and variants in parallel and returns one clearly separated result set per query. Use for ambiguous, multilingual, exploratory, or hard-to-recall searches; never put a guessed answer in a variant.",
+        mcp_help: Some(
+            "Optional array; maximum 2 alternate formulations for the same unmet requirement. Preserve entities and hard constraints; vary vocabulary, terminology, language or answer-bearing phrasing. Omit when no distinct retrieval angle exists.",
+        ),
     },
     ParamSpec {
         name: "max_results",
@@ -276,6 +332,9 @@ const SEARCH_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Max results (default 7, max 12). The most relevant results almost always live in the top 7. Increase only when results are weak.",
+        mcp_help: Some(
+            "Maximum ranked candidates to return (default 7, max 12). Increase only when the returned candidate set is insufficient.",
+        ),
     },
     ParamSpec {
         name: "deadline_ms",
@@ -284,6 +343,7 @@ const SEARCH_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Hard time budget in ms (500-600000). Engines have their own timeouts; this caps the whole call. On expiry: honest deadline error.",
+        mcp_help: None,
     },
     ParamSpec {
         name: "intent",
@@ -292,6 +352,7 @@ const SEARCH_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "auto (default) detects from query. code: adds GitHub, HN, StackExchange, MDN verticals. paper: adds Scholar, arXiv. news: adds Google News, HN. entity: adds Wikipedia. web: general only.",
+        mcp_help: None,
     },
 ];
 
@@ -305,6 +366,7 @@ const CRAWL_PARAMS: &[ParamSpec] = &[
         cli: CliKind::PositionalSingle,
         required: true,
         help: "Seed http(s) URL to crawl from.",
+        mcp_help: None,
     },
     ParamSpec {
         name: "mode",
@@ -313,6 +375,9 @@ const CRAWL_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "full (default): sitemap map + content. map: URL inventory only (very cheap). content: skip sitemap, BFS from seed.",
+        mcp_help: Some(
+            "full (default) discovers pages and reads content; map returns only the URL inventory; content follows links from the seed when no usable site map exists.",
+        ),
     },
     ParamSpec {
         name: "focus",
@@ -321,6 +386,9 @@ const CRAWL_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Relevance query : ranks the frontier by BM25-lite keyword scoring over link text + URL path (site-wide IDF from the map inventory when one exists), then crawls only matching pages. No semantic matching before fetch; a link sharing no token with the query is never enqueued. Fetched pages are then focus-filtered as in web_fetch. Essential for large sites; without it the crawl burns budget on noise.",
+        mcp_help: Some(
+            "Topic or question for selecting relevant pages and passages. Set when the request targets one subject; omit only when the whole site scope is relevant.",
+        ),
     },
     ParamSpec {
         name: "max_pages",
@@ -329,6 +397,7 @@ const CRAWL_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Max pages to fetch+extract (default 10, cap 200).",
+        mcp_help: None,
     },
     ParamSpec {
         name: "max_depth",
@@ -337,6 +406,7 @@ const CRAWL_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Max link depth from seed (default 2). 0 = seed only.",
+        mcp_help: None,
     },
     ParamSpec {
         name: "max_total_chars",
@@ -345,6 +415,7 @@ const CRAWL_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Total extracted-char budget across all pages (default 60000, range 4000-500000).",
+        mcp_help: None,
     },
     ParamSpec {
         name: "per_page_max",
@@ -353,6 +424,7 @@ const CRAWL_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Max markdown chars per page (default 8000, range 400-40000).",
+        mcp_help: None,
     },
     ParamSpec {
         name: "include_paths",
@@ -361,6 +433,7 @@ const CRAWL_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Path globs to include (e.g. [\"/docs/*\"]). Empty = all.",
+        mcp_help: None,
     },
     ParamSpec {
         name: "exclude_paths",
@@ -369,6 +442,7 @@ const CRAWL_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Path globs to exclude (e.g. [\"*/tags/*\", \"*/archive/*\"]).",
+        mcp_help: None,
     },
     ParamSpec {
         name: "same_host",
@@ -377,6 +451,7 @@ const CRAWL_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Stay on seed's host (default true). false = follow cross-domain links.",
+        mcp_help: None,
     },
     ParamSpec {
         name: "respect_robots",
@@ -385,6 +460,7 @@ const CRAWL_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Obey robots.txt Disallow + crawl-delay (default true).",
+        mcp_help: None,
     },
     ParamSpec {
         name: "deadline_s",
@@ -393,6 +469,7 @@ const CRAWL_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Hard crawl deadline in seconds (default 120, range 5-600). Partial results return after.",
+        mcp_help: None,
     },
     ParamSpec {
         name: "since_last",
@@ -401,6 +478,9 @@ const CRAWL_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Delta crawl: skip pages you already fetched in the last 24h (fingerprint on file) : only new/changed pages are fetched and counted. Monitoring and re-crawls at a fraction of the cost.",
+        mcp_help: Some(
+            "Return only pages new or changed since the last crawl of this site. Use for monitoring or a repeated crawl, not a first visit.",
+        ),
     },
     ParamSpec {
         name: "resume",
@@ -409,6 +489,9 @@ const CRAWL_PARAMS: &[ParamSpec] = &[
         cli: CliKind::Flag,
         required: false,
         help: "Resume token from a previous response to continue a stopped crawl. Valid for 30 min.",
+        mcp_help: Some(
+            "Opaque token returned by a stopped crawl. Send it instead of url to continue saved progress; do not invent or alter it. A new crawl requires url and omits resume.",
+        ),
     },
 ];
 
@@ -419,7 +502,8 @@ pub static TOOLS: &[ToolSpec] = &[
         name: "web_fetch",
         cli_cmd: "fetch",
         summary: "Fetch a URL as clean markdown (auto bot-wall bypass, PDF, JS render)",
-        description: "Fetch one URL (or a batch) as clean markdown : use when you have a specific URL to read. To find URLs use web_search; for whole sites use web_crawl.\n\nURL forms: a URL · an L-handle from earlier fetch output ([text](LxK7mP2q) → fetch LxK7mP2q) · an S-handle from search (fetch the S-handle shown next to a result) · an array of up to 12 for ONE parallel batch call (share a budget with budget_tokens).\n\nPick the CHEAPEST reading mode for the job:\n- Verification question (\"does it mention X?\") → must_contain=\"X\" (or /regex/) : returns MATCH/NO-MATCH + ≤3 excerpts, ~60 tokens.\n- Don't know where it is in a long page → toc=true (outline with section ids+sizes) → section=\"s3\" or section=\"heading text\" for just that part.\n- Know the topic → focus=\"query\" : only relevant blocks, 50-80% cheaper.\n- Just reading → default full page.\n\nRe-checking a page you fetched before: since_last=true → one-line unchanged verdict, or the section-level diff if it changed (~30 tokens). structuredContent.changed carries the verdict on every fetch.\n\nMulti-page articles (rel=next chains): stitch=true returns the whole article in one call (≤6 parts, *(part N)* markers).\n\nDead links: archive=auto (default) serves the nearest Wayback snapshot, honestly labeled with its age; archive=only skips the live web.\n\nReliability: PDFs (even scanned, ≤100MB) auto-parsed; bot walls auto-escalate to a headless browser, solve, and hand back to fast HTTP; known-walled sites that return decoy content to plain HTTP get an equivalence check (decoy_suspected flag). JS-only pages need actions=[{click|type|press|scroll|wait,...}] : deterministic wait_selector/wait_text beats blind sleeps. image_text=true OCRs content images (infographics/comics).\n\nTime control: deadline_ms caps any fetch (honest deadline error, never a hang). Send _meta.progressToken for per-URL progress on batches. Long output: structuredContent.next_offset → call again with offset.\n\nDomain intelligence: reddit threads/listings, npm/PyPI/crates.io/Go/RubyGems pages, GitHub issues/releases/commits, Stack Overflow, Wikipedia infoboxes and docs sites are auto-restructured from each site's best source (labeled via=adapter:... in structuredContent) : no special params, it just returns clean structure.\n\nResponse: content[0].text = markdown; structuredContent = {status, tier, verdict, content_ok, thin, content_kind (Article|Listing|Forum|Docs|Table|Page), quality 0-1, lang, title, changed, fingerprint, via, stitched, prewarmed_by_search, next_offset, tokens_est, ms, escalation (per-step ms trace), url}. content_ok=false or thin=true = possible JS shell. Errors: isError=true with structuredContent {code (stable: wall.challenge, wall.paywall, guard.ssrf, deadline.hit, content.binary, archive.stale, ...), next_action, escalation} : next_action says exactly what to do next",
+        description: "Fetch one URL (or a batch) as clean markdown : use when you have a specific URL to read. To find URLs use web_search; for whole sites use web_crawl.\n\nURL forms: a URL · an L-handle from earlier fetch output ([text](LxK7mP2q) → fetch LxK7mP2q) · an S-handle from search (fetch the S-handle shown next to a result) · an array of up to 12 for ONE parallel batch call (share a budget with budget_tokens).\n\nPick the CHEAPEST reading mode for the job:\n- Verification question (\"does it mention X?\") → must_contain=\"X\" (or /regex/) : returns MATCH/NO-MATCH + ≤3 excerpts, ~60 tokens.\n- Don't know where it is in a long page → toc=true (outline with section ids+sizes) → section=\"s3\" or section=\"heading text\" for just that part.\n- Know the topic → focus=\"query\" : only relevant blocks, 50-80% cheaper.\n- Just reading → default full page.\n\nRe-checking a page you fetched before: since_last=true → one-line unchanged verdict, or the section-level diff if it changed (~30 tokens). structuredContent.changed carries the verdict on every fetch.\n\nMulti-page articles (rel=next chains): stitch=true returns the whole article in one call (≤6 parts, *(part N)* markers).\n\nDead links: archive=auto (default) serves the nearest Wayback snapshot, honestly labeled with its age; archive=only skips the live web.\n\nReliability: PDFs (even scanned, ≤100MB) auto-parsed; bot walls auto-escalate to a headless browser, solve, and hand back to fast HTTP; known-walled sites that return decoy content to plain HTTP get an equivalence check (decoy_suspected flag). JS-only pages need actions=[{click|type|press|scroll|wait,...}] : deterministic wait_selector/wait_text beats blind sleeps. image_text=true OCRs content images (infographics/comics).\n\nTime control: deadline_ms caps any fetch (honest deadline error, never a hang). Send _meta.progressToken for per-URL progress on batches. Long output: structuredContent.next_offset → call again with offset.\n\nDomain intelligence: reddit threads/listings, npm/PyPI/crates.io/Go/RubyGems pages, GitHub issues/releases/commits, Stack Overflow, Wikipedia infoboxes and docs sites are auto-restructured from each site's best source : no special params, it just returns clean structure.\n\nResponse: content[0].text is one canonical source document. structuredContent contains only actionable model state such as url, content_ok, content_kind, thin, changed, next_offset, PDF summary, stitch count, cloak warning and error code/next_action. Transport tier, timing, quality, adapter and escalation diagnostics live in _meta.",
+        mcp_description: "Read one URL or a deliberate URL batch as source markdown. Use search to discover URLs and crawl for multiple pages from one site. Prefer the smallest view that can supply the required evidence, and continue only from returned continuation state. Do not repeat a successful read unless it was thin, truncated, or failed. Automatic acquisition may use HTTP, a browser, an adapter, PDF extraction, or an archive. Treat content_ok=false, thin=true, or a stable error code as unresolved; follow next_action or choose another source. Cite the returned source URL.",
         params: FETCH_PARAMS,
         examples: &[
             "donsetch fetch https://example.com/article",
@@ -433,7 +517,8 @@ pub static TOOLS: &[ToolSpec] = &[
         name: "web_search",
         cli_cmd: "search",
         summary: "Web search : 5 keyless engines merged + reranked, or your API keys",
-        description: "Web search : returns ranked URLs + titles + snippets. Use to decide WHAT to fetch (web_fetch reads content; this never does).\n\nOne query is the normal path. For an ambiguous, multilingual, exploratory, or hard-to-recall information need, add up to two query_variants: all searches run in parallel and come back as clearly separated result sets, with no automatic rewriting or guessed answers.\n\nResults list random handles: each result shows an S-handle (fetch the S-handle shown next to a result; raw URLs in structuredContent for citation). Domains known to need the browser carry a ⚠ needs-browser hint : pick a faster source or budget time before fetching. A *degraded:* footer names any engines that failed : silent quality loss is visible.\n\nEngines: 10+ keyless backends fused by cross-engine consensus + local semantic reranking (automatic). Verticals via intent: GitHub, Wikipedia, HN, Scholar, news, StackExchange, MDN. BYOK: providers configured via `donsetch keys` (Tavily/Exa/Serper/TinyFish/Parallel/BrightData) take over; structuredContent.provider names what served (null = local keyless).\n\ndeadline_ms caps the whole call (honest deadline error, never a hang).\n\nSingle-query response: numbered markdown list and structuredContent = {intent, weak, cached, elapsed_ms, provider, results:[...], engines:[...]}. Multi-query response: one Search section per query and structuredContent = {query_count, ok, errors, elapsed_ms, searches:[{query, ...single-query fields}]}. Key signals: weak=true = low consensus, treat with care; consensus = independent engines agreeing (authority); engines[].status = per-engine health.\n\nAfter search: fetch the best result via its S-handle : enrichment pre-fetches top results, so the next fetch is near-instant (prewarmed_by_search=true)",
+        description: "Web search : returns ranked URLs + titles + snippets. Use to decide WHAT to fetch (web_fetch reads content; this never does).\n\nOne query is the normal path. For an ambiguous, multilingual, exploratory, or hard-to-recall information need, add up to two query_variants: all searches run in parallel and come back as clearly separated result sets, with no automatic rewriting or guessed answers.\n\nEach result is one compact evidence row: fetch handle (or raw URL), title, host, focused snippet, and a browser-cost warning only when relevant. Rank already represents DonSeTch's scoring decision, so per-engine scores and timing are not repeated in model context. Weak or degraded retrieval remains explicitly labeled. Multi-query mode keeps one clearly labeled ranked section per formulation.\n\nEngines: 10+ keyless backends fused by cross-engine consensus + local semantic reranking (automatic). Verticals via intent: GitHub, Wikipedia, HN, Scholar, news, StackExchange, MDN. BYOK: providers configured via `donsetch keys` (Tavily/Exa/Serper/TinyFish/Parallel/BrightData) take over automatically.\n\ndeadline_ms caps the whole call (honest deadline error, never a hang).\n\nResponse: content[0].text is the ranked evidence list. structuredContent contains weak plus rank, URL and optional fetch handle for each result; multi-query mode keeps those lists separate. Engine health, score, cache, provider, reranker and timing diagnostics live in _meta.\n\nAfter search: fetch the best result via its S-handle : enrichment pre-fetches top results, so the next fetch is near-instant.",
+        mcp_description: "Discover ranked candidate sources. Use this before fetch when you do not already have a URL; it returns titles and snippets, not page contents. A snippet supports only claims it states explicitly. Treat weak or degraded results as incomplete, and fetch a candidate when its full text is required. Search handles resolve directly in fetch; cite source URLs from structuredContent.",
         params: SEARCH_PARAMS,
         examples: &[
             "donsetch search rust async trait objects",
@@ -446,7 +531,8 @@ pub static TOOLS: &[ToolSpec] = &[
         name: "web_crawl",
         cli_cmd: "crawl",
         summary: "Crawl a site into markdown (sitemap-aware, focus-ranked, resumable)",
-        description: "Crawl a site from a seed : for multi-page extraction (docs, API refs, wikis). Single page → web_fetch; finding sites → web_search.\n\nTwo-phase: sitemap discovery (cheap URL inventory) first, then focus-ranked page fetching with adaptive per-host pacing. Docs sites (mkdocs/docusaurus/sphinx/antora) get their nav as the site map automatically.\n\nModes: full (default) = map + content · map = URL inventory only, very cheap : see what a site has before committing · content = BFS from seed, no sitemap (use when sitemap is missing). PDF pages auto-parsed, not skipped.\n\nBudgets: focus (topic) ranks the frontier by BM25-lite link-text/URL-path keyword scoring and crawls only matches : set it whenever you have a topic. max_pages / max_total_chars / deadline_s cap the run; resume tokens continue across calls. since_last=true skips pages unchanged since your last crawl of the site (fingerprint memory : returns only what moved). Send _meta.progressToken for live per-page progress (\"12 pages, 34 queued\"); cancellation stops gracefully and keeps the resume token.\n\nResponse: map (if any) + pages as markdown. structuredContent = {seed, pages:[{url,title,kind,chars,quality}], map, queued, filtered_out, skipped:[{url,reason}], stop, elapsed_s, resume}. stop = FrontierEmpty (done) | MaxPages|CharBudget|DepthLimit|Deadline (budget : resume to continue) | ThrottledOut (site pushed back : wait, then resume) | Cancelled (resume token kept)",
+        description: "Crawl a site from a seed : for multi-page extraction (docs, API refs, wikis). Single page → web_fetch; finding sites → web_search.\n\nTwo-phase: sitemap discovery (cheap URL inventory) first, then focus-ranked page fetching with adaptive per-host pacing. Docs sites (mkdocs/docusaurus/sphinx/antora) get their nav as the site map automatically.\n\nModes: full (default) = map + content · map = URL inventory only, very cheap : see what a site has before committing · content = BFS from seed, no sitemap (use when sitemap is missing). PDF pages auto-parsed, not skipped.\n\nBudgets: focus (topic) ranks the frontier by BM25-lite link-text/URL-path keyword scoring and crawls only matches : set it whenever you have a topic. max_pages / max_total_chars / deadline_s cap the run; resume tokens continue across calls. since_last=true skips pages unchanged since your last crawl of the site (fingerprint memory : returns only what moved). Send _meta.progressToken for live per-page progress (\"12 pages, 34 queued\"); cancellation stops gracefully and keeps the resume token.\n\nResponse: content[0].text is one linear site-evidence document. structuredContent contains seed, completion, page URLs, stop reason and any resume/next action. Map, queue, skip, score, quality, crawl-delay and timing diagnostics live in _meta. FrontierEmpty is complete; MaxPages, CharBudget, DepthLimit, Deadline, ThrottledOut and Cancelled are incomplete.",
+        mcp_description: "Read multiple pages from one known site. Use search to discover a site and fetch for one page. Scope the crawl to the requested evidence and set explicit budgets. FrontierEmpty means complete; budget, deadline, throttle, cancellation, or depth stops are incomplete and may return a resume token. Cite the returned page URLs.",
         params: CRAWL_PARAMS,
         examples: &[
             "donsetch crawl https://docs.site.com --topic \"authentication\"",
@@ -481,7 +567,7 @@ pub fn mcp_schema(tool: &ToolSpec) -> Value {
                         { "type": "array", "items": { "type": "string" } }
                     ]),
                 );
-                schema.insert("description".into(), json!(p.help));
+                schema.insert("description".into(), json!(p.mcp_help.unwrap_or(p.help)));
                 props.insert(p.name.into(), Value::Object(schema));
                 if p.required {
                     required.push(json!(p.name));
@@ -489,7 +575,7 @@ pub fn mcp_schema(tool: &ToolSpec) -> Value {
                 continue;
             }
             ParamKind::Usize => "integer",
-            ParamKind::StrList | ParamKind::StrListMax(_) | ParamKind::JsonStr => "array",
+            ParamKind::StrList | ParamKind::StrListMax(_) | ParamKind::ActionList => "array",
             ParamKind::SetTrue | ParamKind::SetFalse => "boolean",
         };
         schema.insert("type".into(), json!(ty));
@@ -502,10 +588,38 @@ pub fn mcp_schema(tool: &ToolSpec) -> Value {
         if let ParamKind::StrListMax(max) = p.kind {
             schema.insert("maxItems".into(), json!(max));
         }
-        if p.kind == ParamKind::JsonStr {
-            schema.insert("items".into(), json!({ "type": "object" }));
+        if p.kind == ParamKind::ActionList {
+            schema.insert(
+                "items".into(),
+                json!({
+                    "type": "object",
+                    "properties": {
+                        "do": {
+                            "type": "string",
+                            "enum": [
+                                "wait", "wait_selector", "wait_text", "click", "hover",
+                                "type", "press", "scroll"
+                            ]
+                        },
+                        "selector": { "type": "string" },
+                        "text": { "type": "string" },
+                        "key": { "type": "string" },
+                        "to": {
+                            "type": "string",
+                            "enum": ["top", "bottom", "down", "px"]
+                        },
+                        "px": { "type": "integer" },
+                        "ms": { "type": "integer" },
+                        "timeout_ms": { "type": "integer" }
+                    },
+                    "required": ["do"],
+                    "additionalProperties": false
+                }),
+            );
+            schema.insert("minItems".into(), json!(1));
+            schema.insert("maxItems".into(), json!(16));
         }
-        schema.insert("description".into(), json!(p.help));
+        schema.insert("description".into(), json!(p.mcp_help.unwrap_or(p.help)));
         props.insert(p.name.into(), Value::Object(schema));
         if p.required {
             required.push(json!(p.name));
@@ -513,7 +627,7 @@ pub fn mcp_schema(tool: &ToolSpec) -> Value {
     }
     json!({
         "name": tool.name,
-        "description": tool.description,
+        "description": tool.mcp_description,
         "inputSchema": {
             "type": "object",
             "properties": Value::Object(props),
@@ -575,7 +689,7 @@ fn cli_arg(p: &ParamSpec) -> Arg {
                             variants.iter().copied(),
                         ))
                 }
-                ParamKind::JsonStr => arg.value_name("JSON"),
+                ParamKind::ActionList => arg.value_name("JSON"),
                 ParamKind::StrList => arg
                     .value_name("GLOB")
                     .action(ArgAction::Append)
@@ -618,7 +732,7 @@ pub fn matches_to_json(tool: &ToolSpec, m: &clap::ArgMatches) -> Value {
                         map.insert(p.name.into(), json!(v));
                     }
                 }
-                ParamKind::JsonStr => {
+                ParamKind::ActionList => {
                     if let Some(v) = m.get_one::<String>(p.name)
                         && let Ok(parsed) = serde_json::from_str::<Value>(v)
                     {
@@ -658,6 +772,13 @@ pub fn matches_to_json(tool: &ToolSpec, m: &clap::ArgMatches) -> Value {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn fetch_tool() -> &'static ToolSpec {
+        TOOLS
+            .iter()
+            .find(|tool| tool.name == "web_fetch")
+            .expect("web_fetch spec")
+    }
 
     fn search_tool() -> &'static ToolSpec {
         TOOLS
@@ -699,6 +820,48 @@ mod tests {
         assert_eq!(
             args["query_variants"],
             json!(["rust async trait objects", "async fn in trait rust"])
+        );
+    }
+
+    #[test]
+    fn mcp_contract_is_compact_without_reducing_cli_help() {
+        for tool in TOOLS {
+            let schema = mcp_schema(tool);
+            assert_eq!(schema["description"], tool.mcp_description);
+            assert!(
+                tool.mcp_description.len() < tool.description.len(),
+                "{} model description should be shorter than CLI long help",
+                tool.name
+            );
+        }
+
+        let mut command = cli_command(fetch_tool());
+        let long_help = command.render_long_help().to_string();
+        assert!(long_help.contains("Domain intelligence"));
+        assert!(long_help.contains("cross-encoder pass"));
+    }
+
+    #[test]
+    fn action_field_describes_the_runtime_shape() {
+        let schema = mcp_schema(fetch_tool());
+        let actions = &schema["inputSchema"]["properties"]["actions"];
+        assert_eq!(actions["type"], "array");
+        assert_eq!(actions["minItems"], 1);
+        assert_eq!(actions["maxItems"], 16);
+        assert_eq!(actions["items"]["required"], json!(["do"]));
+        assert_eq!(actions["items"]["additionalProperties"], false);
+        assert_eq!(
+            actions["items"]["properties"]["do"]["enum"],
+            json!([
+                "wait",
+                "wait_selector",
+                "wait_text",
+                "click",
+                "hover",
+                "type",
+                "press",
+                "scroll"
+            ])
         );
     }
 }

--- a/tests/fixtures/tools_list.json
+++ b/tests/fixtures/tools_list.json
@@ -1,18 +1,66 @@
 {
   "tools": [
     {
-      "description": "Fetch one URL (or a batch) as clean markdown : use when you have a specific URL to read. To find URLs use web_search; for whole sites use web_crawl.\n\nURL forms: a URL · an L-handle from earlier fetch output ([text](LxK7mP2q) → fetch LxK7mP2q) · an S-handle from search (fetch the S-handle shown next to a result) · an array of up to 12 for ONE parallel batch call (share a budget with budget_tokens).\n\nPick the CHEAPEST reading mode for the job:\n- Verification question (\"does it mention X?\") → must_contain=\"X\" (or /regex/) : returns MATCH/NO-MATCH + ≤3 excerpts, ~60 tokens.\n- Don't know where it is in a long page → toc=true (outline with section ids+sizes) → section=\"s3\" or section=\"heading text\" for just that part.\n- Know the topic → focus=\"query\" : only relevant blocks, 50-80% cheaper.\n- Just reading → default full page.\n\nRe-checking a page you fetched before: since_last=true → one-line unchanged verdict, or the section-level diff if it changed (~30 tokens). structuredContent.changed carries the verdict on every fetch.\n\nMulti-page articles (rel=next chains): stitch=true returns the whole article in one call (≤6 parts, *(part N)* markers).\n\nDead links: archive=auto (default) serves the nearest Wayback snapshot, honestly labeled with its age; archive=only skips the live web.\n\nReliability: PDFs (even scanned, ≤100MB) auto-parsed; bot walls auto-escalate to a headless browser, solve, and hand back to fast HTTP; known-walled sites that return decoy content to plain HTTP get an equivalence check (decoy_suspected flag). JS-only pages need actions=[{click|type|press|scroll|wait,...}] : deterministic wait_selector/wait_text beats blind sleeps. image_text=true OCRs content images (infographics/comics).\n\nTime control: deadline_ms caps any fetch (honest deadline error, never a hang). Send _meta.progressToken for per-URL progress on batches. Long output: structuredContent.next_offset → call again with offset.\n\nDomain intelligence: reddit threads/listings, npm/PyPI/crates.io/Go/RubyGems pages, GitHub issues/releases/commits, Stack Overflow, Wikipedia infoboxes and docs sites are auto-restructured from each site's best source (labeled via=adapter:... in structuredContent) : no special params, it just returns clean structure.\n\nResponse: content[0].text = markdown; structuredContent = {status, tier, verdict, content_ok, thin, content_kind (Article|Listing|Forum|Docs|Table|Page), quality 0-1, lang, title, changed, fingerprint, via, stitched, prewarmed_by_search, next_offset, tokens_est, ms, escalation (per-step ms trace), url}. content_ok=false or thin=true = possible JS shell. Errors: isError=true with structuredContent {code (stable: wall.challenge, wall.paywall, guard.ssrf, deadline.hit, content.binary, archive.stale, ...), next_action, escalation} : next_action says exactly what to do next",
+      "description": "Read one URL or a deliberate URL batch as source markdown. Use search to discover URLs and crawl for multiple pages from one site. Prefer the smallest view that can supply the required evidence, and continue only from returned continuation state. Do not repeat a successful read unless it was thin, truncated, or failed. Automatic acquisition may use HTTP, a browser, an adapter, PDF extraction, or an archive. Treat content_ok=false, thin=true, or a stable error code as unresolved; follow next_action or choose another source. Cite the returned source URL.",
       "inputSchema": {
         "properties": {
           "actions": {
-            "description": "Browser steps to run BEFORE extraction : page control inside fetch: [{\"do\":\"click\",\"selector\":\"#load-more\"},{\"do\":\"type\",\"selector\":\"input[q]\",\"text\":\"query\"},{\"do\":\"press\",\"key\":\"Enter\"},{\"do\":\"wait_text\",\"text\":\"results\"}]. Steps: wait {ms}, wait_selector {selector,timeout_ms}, wait_text {text,timeout_ms}, click {selector OR text}, hover, type {selector?,text}, press {key: Enter|Tab|Escape|Backspace|ArrowDown|...}, scroll {to: top|bottom|down | px}. Max 16 steps. Actions run in the headless browser (tier auto/2, never 1); after them the page is extracted normally : focus/section/toc still apply. First failing step aborts honestly with per-step results in structuredContent.actions; fix that step and re-run.",
+            "description": "Ordered page interactions before reading (1-16 objects). Each object requires do. Required fields: wait uses ms; wait_selector uses selector; wait_text uses text; click/hover uses selector or text; type uses text and optional selector; press uses key; scroll uses to or px. The first failed step stops and is reported.",
             "items": {
+              "additionalProperties": false,
+              "properties": {
+                "do": {
+                  "enum": [
+                    "wait",
+                    "wait_selector",
+                    "wait_text",
+                    "click",
+                    "hover",
+                    "type",
+                    "press",
+                    "scroll"
+                  ],
+                  "type": "string"
+                },
+                "key": {
+                  "type": "string"
+                },
+                "ms": {
+                  "type": "integer"
+                },
+                "px": {
+                  "type": "integer"
+                },
+                "selector": {
+                  "type": "string"
+                },
+                "text": {
+                  "type": "string"
+                },
+                "timeout_ms": {
+                  "type": "integer"
+                },
+                "to": {
+                  "enum": [
+                    "top",
+                    "bottom",
+                    "down",
+                    "px"
+                  ],
+                  "type": "string"
+                }
+              },
+              "required": [
+                "do"
+              ],
               "type": "object"
             },
+            "maxItems": 16,
+            "minItems": 1,
             "type": "array"
           },
           "archive": {
-            "description": "Dead-page recovery via the keyless Wayback Machine. auto (default): on hard failure (404/paywall/unsolvable wall) serve the nearest archived snapshot, clearly labeled with its date. only: skip the live fetch, go straight to the archive. off: never.",
+            "description": "Archived-page policy: auto (default) falls back when the live page is unavailable; only skips the live page; off disables archive recovery.",
             "enum": [
               "auto",
               "only",
@@ -21,7 +69,7 @@
             "type": "string"
           },
           "budget_tokens": {
-            "description": "Batch mode (array url): total output token budget shared across all results (200-500k). DonSeTch allocates it across pages by size : small pages stay whole, big ones get sliced with a resume note. Without it each page uses max_chars independently.",
+            "description": "Shared output-token limit for a URL batch (200-500000). Omit for one URL. Truncated members return continuation information.",
             "type": "integer"
           },
           "deadline_ms": {
@@ -29,15 +77,15 @@
             "type": "integer"
           },
           "focus": {
-            "description": "Relevance query : returns ONLY blocks that score against it, cutting tokens 50-80% on long pages. Scoring is BM25 keyword matching; a cross-encoder pass also catches blocks that use different words, but only on pages of 80 blocks or fewer AND only when the rerank model is already cached from prior search use (plain BM25 otherwise, never a download mid-fetch). If nothing matches, returns the full page with a notice. ALWAYS set when you know what you're looking for : #1 token saver.",
+            "description": "Topic or question for returning only relevant passages. Set when the requested evidence is known; omit only when the whole page is needed. A no-match response is labeled and falls back to the full page.",
             "type": "string"
           },
           "image_text": {
-            "description": "OCR the page's content images (up to 4) and append an 'image text' section. For infographics/comics/screenshots whose meaning IS the image. Costs extra fetch+compute : only when image content matters.",
+            "description": "Extract words from up to 4 content images. Enable only when requested evidence is inside an infographic, screenshot, comic or other image.",
             "type": "boolean"
           },
           "links": {
-            "description": "Include [text](url) link URLs. Default false : saves ~30% tokens. Enable only when you need the URLs.",
+            "description": "Include destination URLs found inside page content. The fetched page's own citation URL is always returned separately; enable only when outbound targets are requested evidence.",
             "type": "boolean"
           },
           "max_chars": {
@@ -45,15 +93,15 @@
             "type": "integer"
           },
           "media": {
-            "description": "Include image alt text and sources. Default false.",
+            "description": "Include image alt text and source URLs. Use image_text instead when words inside an image must be read.",
             "type": "boolean"
           },
           "must_contain": {
-            "description": "Probe mode: verify the page mentions a string/pattern WITHOUT loading it into context. Output = MATCH/NO-MATCH verdict + up to 3 short context excerpts. Case-insensitive substring, or /regex/ (e.g. \"/CVE-2026-\\d+/\"). Full fetch still happens (tiers, walls, PDFs) : only the output collapses. For verification questions, not reading.",
+            "description": "Case-insensitive string or /regex/ presence check. Returns MATCH/NO-MATCH and up to 3 excerpts instead of the full page; use for verification, not general reading.",
             "type": "string"
           },
           "offset": {
-            "description": "Resume from a previous response's next_offset to continue a truncated page.",
+            "description": "Continue from a previous next_offset. Reuse the same URL and any focus, section, selector or rendering fields from that fetch.",
             "type": "integer"
           },
           "section": {
@@ -61,7 +109,7 @@
             "type": "string"
           },
           "selector": {
-            "description": "CSS selector : extract only from matching elements. Narrows scope precisely.",
+            "description": "CSS selector for extracting only matching elements. Set only when the selector is known; focus may filter passages inside that region.",
             "type": "string"
           },
           "shot": {
@@ -69,11 +117,11 @@
             "type": "string"
           },
           "since_last": {
-            "description": "Change check instead of full read: if the page is unchanged since your last fetch, output collapses to a one-line verdict; if changed, you get the section-level delta (added/removed/changed). Refetch without it for full content. Monitoring/re-verification at ~zero tokens.",
+            "description": "Standalone change check for a previously fetched URL. Returns an unchanged verdict or changed sections instead of the full page. Do not combine with reading filters or rendering fields.",
             "type": "boolean"
           },
           "stitch": {
-            "description": "Multi-page articles: follow rel=next pagination and return the WHOLE article in one call (up to 6 parts / 48k chars) with *(part N)* markers, instead of re-fetching page by page. Same-host only.",
+            "description": "Read all parts of a paginated article in one call (up to 6 parts / 48000 chars). Enable only when the requested source spans article pages.",
             "type": "boolean"
           },
           "tier": {
@@ -86,7 +134,7 @@
             "type": "string"
           },
           "toc": {
-            "description": "true = heading outline only, no body text. Read structure first, then target with section or focus.",
+            "description": "Return only the heading outline. Use as a standalone first read, then make a new fetch with section or focus.",
             "type": "boolean"
           },
           "url": {
@@ -101,7 +149,7 @@
                 "type": "array"
               }
             ],
-            "description": "URL to fetch: http(s) URL, a handle (L/S from earlier results), or an array of up to 12 for one parallel batch call."
+            "description": "One http(s) URL, an S/L handle returned earlier, or an array of up to 12 URLs or handles for one batch read."
           }
         },
         "required": [
@@ -112,7 +160,7 @@
       "name": "web_fetch"
     },
     {
-      "description": "Web search : returns ranked URLs + titles + snippets. Use to decide WHAT to fetch (web_fetch reads content; this never does).\n\nOne query is the normal path. For an ambiguous, multilingual, exploratory, or hard-to-recall information need, add up to two query_variants: all searches run in parallel and come back as clearly separated result sets, with no automatic rewriting or guessed answers.\n\nResults list random handles: each result shows an S-handle (fetch the S-handle shown next to a result; raw URLs in structuredContent for citation). Domains known to need the browser carry a ⚠ needs-browser hint : pick a faster source or budget time before fetching. A *degraded:* footer names any engines that failed : silent quality loss is visible.\n\nEngines: 10+ keyless backends fused by cross-engine consensus + local semantic reranking (automatic). Verticals via intent: GitHub, Wikipedia, HN, Scholar, news, StackExchange, MDN. BYOK: providers configured via `donsetch keys` (Tavily/Exa/Serper/TinyFish/Parallel/BrightData) take over; structuredContent.provider names what served (null = local keyless).\n\ndeadline_ms caps the whole call (honest deadline error, never a hang).\n\nSingle-query response: numbered markdown list and structuredContent = {intent, weak, cached, elapsed_ms, provider, results:[...], engines:[...]}. Multi-query response: one Search section per query and structuredContent = {query_count, ok, errors, elapsed_ms, searches:[{query, ...single-query fields}]}. Key signals: weak=true = low consensus, treat with care; consensus = independent engines agreeing (authority); engines[].status = per-engine health.\n\nAfter search: fetch the best result via its S-handle : enrichment pre-fetches top results, so the next fetch is near-instant (prewarmed_by_search=true)",
+      "description": "Discover ranked candidate sources. Use this before fetch when you do not already have a URL; it returns titles and snippets, not page contents. A snippet supports only claims it states explicitly. Treat weak or degraded results as incomplete, and fetch a candidate when its full text is required. Search handles resolve directly in fetch; cite source URLs from structuredContent.",
       "inputSchema": {
         "properties": {
           "deadline_ms": {
@@ -132,15 +180,15 @@
             "type": "string"
           },
           "max_results": {
-            "description": "Max results (default 7, max 12). The most relevant results almost always live in the top 7. Increase only when results are weak.",
+            "description": "Maximum ranked candidates to return (default 7, max 12). Increase only when the returned candidate set is insufficient.",
             "type": "integer"
           },
           "query": {
-            "description": "Search query.",
+            "description": "Primary search formulation. Include required entities, dates, versions and exclusions; do not include a guessed answer.",
             "type": "string"
           },
           "query_variants": {
-            "description": "Optional alternate formulations of the same information need (max 2). DonSeTch searches the base query and variants in parallel and returns one clearly separated result set per query. Use for ambiguous, multilingual, exploratory, or hard-to-recall searches; never put a guessed answer in a variant.",
+            "description": "Optional array; maximum 2 alternate formulations for the same unmet requirement. Preserve entities and hard constraints; vary vocabulary, terminology, language or answer-bearing phrasing. Omit when no distinct retrieval angle exists.",
             "items": {
               "type": "string"
             },
@@ -156,7 +204,7 @@
       "name": "web_search"
     },
     {
-      "description": "Crawl a site from a seed : for multi-page extraction (docs, API refs, wikis). Single page → web_fetch; finding sites → web_search.\n\nTwo-phase: sitemap discovery (cheap URL inventory) first, then focus-ranked page fetching with adaptive per-host pacing. Docs sites (mkdocs/docusaurus/sphinx/antora) get their nav as the site map automatically.\n\nModes: full (default) = map + content · map = URL inventory only, very cheap : see what a site has before committing · content = BFS from seed, no sitemap (use when sitemap is missing). PDF pages auto-parsed, not skipped.\n\nBudgets: focus (topic) ranks the frontier by BM25-lite link-text/URL-path keyword scoring and crawls only matches : set it whenever you have a topic. max_pages / max_total_chars / deadline_s cap the run; resume tokens continue across calls. since_last=true skips pages unchanged since your last crawl of the site (fingerprint memory : returns only what moved). Send _meta.progressToken for live per-page progress (\"12 pages, 34 queued\"); cancellation stops gracefully and keeps the resume token.\n\nResponse: map (if any) + pages as markdown. structuredContent = {seed, pages:[{url,title,kind,chars,quality}], map, queued, filtered_out, skipped:[{url,reason}], stop, elapsed_s, resume}. stop = FrontierEmpty (done) | MaxPages|CharBudget|DepthLimit|Deadline (budget : resume to continue) | ThrottledOut (site pushed back : wait, then resume) | Cancelled (resume token kept)",
+      "description": "Read multiple pages from one known site. Use search to discover a site and fetch for one page. Scope the crawl to the requested evidence and set explicit budgets. FrontierEmpty means complete; budget, deadline, throttle, cancellation, or depth stops are incomplete and may return a resume token. Cite the returned page URLs.",
       "inputSchema": {
         "properties": {
           "deadline_s": {
@@ -171,7 +219,7 @@
             "type": "array"
           },
           "focus": {
-            "description": "Relevance query : ranks the frontier by BM25-lite keyword scoring over link text + URL path (site-wide IDF from the map inventory when one exists), then crawls only matching pages. No semantic matching before fetch; a link sharing no token with the query is never enqueued. Fetched pages are then focus-filtered as in web_fetch. Essential for large sites; without it the crawl burns budget on noise.",
+            "description": "Topic or question for selecting relevant pages and passages. Set when the request targets one subject; omit only when the whole site scope is relevant.",
             "type": "string"
           },
           "include_paths": {
@@ -194,7 +242,7 @@
             "type": "integer"
           },
           "mode": {
-            "description": "full (default): sitemap map + content. map: URL inventory only (very cheap). content: skip sitemap, BFS from seed.",
+            "description": "full (default) discovers pages and reads content; map returns only the URL inventory; content follows links from the seed when no usable site map exists.",
             "enum": [
               "full",
               "map",
@@ -211,7 +259,7 @@
             "type": "boolean"
           },
           "resume": {
-            "description": "Resume token from a previous response to continue a stopped crawl. Valid for 30 min.",
+            "description": "Opaque token returned by a stopped crawl. Send it instead of url to continue saved progress; do not invent or alter it. A new crawl requires url and omits resume.",
             "type": "string"
           },
           "same_host": {
@@ -219,7 +267,7 @@
             "type": "boolean"
           },
           "since_last": {
-            "description": "Delta crawl: skip pages you already fetched in the last 24h (fingerprint on file) : only new/changed pages are fetched and counted. Monitoring and re-crawls at a fraction of the cost.",
+            "description": "Return only pages new or changed since the last crawl of this site. Use for monitoring or a repeated crawl, not a first visit.",
             "type": "boolean"
           },
           "url": {

--- a/tests/token_invariants.rs
+++ b/tests/token_invariants.rs
@@ -126,6 +126,18 @@ fn mcp_instructions_stay_cheap() {
 }
 
 #[test]
+fn split_mcp_contract_stays_under_2500_estimated_tokens() {
+    // chars/4 is the repository-wide offline estimator. Exact tokenizer
+    // measurements belong in the external evaluation report.
+    let bytes = donsetch::mcp::tools::list().to_string().len();
+    let estimated_tokens = bytes.div_ceil(4);
+    assert!(
+        estimated_tokens <= 2_500,
+        "split MCP schema costs ~{estimated_tokens} tokens (>2500)"
+    );
+}
+
+#[test]
 fn links_on_renders_real_links() {
     // Wikipedia article body: hundreds of interwiki links. With
     // links=true the pipeline must render them as markdown links


### PR DESCRIPTION
# Compact model-facing MCP contracts

## What I found

I found two different contracts sharing the same representation.

On input, DonSeTch used the same long description for human CLI help and for
the MCP schema shown to a model. That put implementation details, backend
behavior, response internals, and repeated examples into `tools/list`, even
when those details did not help the model select a tool or compile a field.

On output, successful calls often represented the same information on several
model-visible surfaces. A title or URL could appear in a metadata text block,
the evidence document, and `structuredContent`; ranking, engine, timing,
provider, transport, or extraction diagnostics could appear next to evidence
even though the tool contract defines no model action that consumes most of
them.

This is broader than shortening prose. The proposal gives each MCP surface one
responsibility:

- `content`: the linear evidence document read by the model;
- `structuredContent`: routing, continuation, recovery, and exceptional state
  that can change the model's next action;
- `_meta`: bounded client diagnostics that remain available without competing
  with evidence in model context.

No evidence or diagnostic capability is silently deleted. Evidence remains in
`content`; actionable state remains in `structuredContent`; operational
diagnostics move to namespaced `_meta`.

## Before and after

### 1. Tool schemas

Before, one `description` or parameter `help` string was emitted verbatim to
both clap and MCP. Browser actions were exposed as an untyped array of objects,
while their real shape existed only inside prose.

After, complete CLI help remains unchanged and MCP gets a dedicated compact
contract. General lifecycle instructions live on the tool, field-specific
compilation rules live on the field, and concise fields reuse their existing
help instead of duplicating text. Browser actions expose the actual runtime
shape: one to sixteen ordered objects, a required `do` discriminator, the
supported actions, typed operands, and no unknown properties.

No tool, parameter, default, or supported action is removed.

### 2. Single fetch

Before, a successful fetch returned an embedded JSON metadata block followed
by extracted markdown and repeated many of the same values in
`structuredContent`.

After, it returns one canonical document: title when available, resolved source
URL, and the complete evidence body. Frontmatter cleanup removes only a
matching wrapper title and URL near the beginning; bylines, dates, summaries,
headings, and unrelated evidence are retained.

The model-facing state keeps the source URL, usability, content kind, thin
state, continuation, compact PDF state, change verdict, cloak/archive state,
and stable errors. Status, tier, verdict, quality, extraction counts, timing,
adapter, full PDF diagnostics, and escalation trace remain in `_meta`.

This applies consistently to HTTP, browser actions, bypass, archive recovery,
OCR, history checks, link handles, and search-prewarmed fetches. Cache keys,
stored outcomes, TTL behavior, extraction, and fallback logic do not change.

### 3. Batch fetch

Before, the batch wrapper added another title, URL, tier, and token estimate
around every already-rendered member, then repeated transport state for every
healthy result.

After, one ordered evidence document contains one numbered source header per
member. A healthy member carries only URL and success in structured state.
Additional state appears only when actionable: incomplete or thin content,
continuation, meaningful change, cloak suspicion, archive recovery, budget
slicing, or a stable failure code. Mixed and all-failed batches preserve the
per-URL evidence and recovery path.

Batch concurrency, ordering, deadlines, caches, and proportional token-budget
slicing are unchanged.

### 4. Crawl

Before, crawl mixed an embedded metadata block, timing, quality, character
counts, map entries, fetched pages, skipped entries, and resume guidance on the
same model-facing surface. Page identity and resume state were repeated.

After, output follows the selected mode:

- map: discovered URL inventory;
- content: each non-duplicate fetched page once;
- full: fetched evidence plus only discovered URLs not already rendered.

`structuredContent` retains seed, completion, page URLs, last-modified values,
stop reason, resume token, and next action. Queue, filtering, skipped reasons,
duplicate state, kind, size, quality, score, crawl delay, and timing remain in
`_meta`.

Discovery, robots handling, pacing, scope, budgets, stop semantics, resume, and
page evidence are unchanged.

### 5. Search

Before, the ranked text repeated engine names and numeric scores per result,
then added provider, timing, degraded-engine, and fetch guidance in footers.
`structuredContent` repeated title, URL, snippet, engines, score, cache, and
timing alongside the visible evidence.

After, each result is rendered once as rank, fetch handle or raw URL, title,
host, optional browser-cost warning, and the existing focused snippet. Weak and
degraded retrieval stay visible because they can change whether the caller
retries or chooses another source.

`structuredContent` retains weak state plus rank, URL, and optional handle.
Engine reports, consensus, scores, cache state, provider, intent, reranker
provenance, and timing remain in `_meta` without another copy of title, URL, or
snippet.

Explicit variants remain separate as labeled `q0 primary` and `qN variant`
sections. Each section keeps DonSeTch's existing independent ranking. This does
not add fusion, change acquisition, reorder candidates, shorten snippets, or
change result limits.

## Measured impact

Measurements use `tiktoken 0.14.0`, `o200k_base`, canonical compact JSON,
isolated caches, and live core-only runs against DonSeTch v3.6.0.

| Surface | Before | After | Reduction |
|---|---:|---:|---:|
| MCP `tools/list` | 3,466 tokens | 1,968 tokens | 43.22% |
| Fetch, model-visible | 301 | 87 | 71.10% |
| Search, model-visible | 1,406 | 600 | 57.33% |
| Crawl, model-visible | 288 | 109 | 62.15% |
| Healthy three-result batch | 304 | 166 | 45.39% |

The non-fused three-formulation search surface also falls from 2,403 to 1,888
model-visible tokens, a further 21.43% reduction over the compact response
container alone.

Controlled comparisons preserve all seven URLs in every search section. Fetch
and crawl retain the same source and evidence. These are contract and
presentation measurements, not ranking or latency claims.

## Commit structure

The proposal is intentionally reviewable as six focused commits:

1. `feat(mcp)!: separate model contracts from CLI help`
2. `refactor(mcp)!: render fetch evidence once`
3. `refactor(mcp)!: make batch fetch state sparse`
4. `refactor(mcp)!: separate crawl evidence from diagnostics`
5. `refactor(mcp)!: render compact ranked search evidence`
6. `docs(changelog): describe the compact MCP contract`

Every functional commit describes its previous representation, new contract,
unchanged behavior, measurement, and focused test.

## Compatibility

Tool names and input capabilities remain stable. Two deliberate contract
changes require review:

1. browser actions now have a strict schema matching the runtime;
2. successful `structuredContent` is slimmer, so diagnostic consumers must
   read moved fields from `_meta`.

That is why the affected commits carry a breaking-change marker. DonSeTch's
internal search/fetch caches are not versioned or invalidated by this work.
Changing the exposed MCP schema may make a model provider's prompt-prefix cache
cold once after deployment; the new stable prefix then warms normally and is
43.22% smaller.

## Validation

- `cargo fmt --all -- --check`: passed;
- `git diff --check`: passed;
- focused contract tests: passed independently for schema, fetch, batch,
  crawl, and search;
- `cargo test --features ocr,rerank -- --test-threads=1`: 878 passed, zero
  failures.

The changelog entry is included.

## Review boundary

This proposal contains no unified tool, ranking calibration, query fusion,
provider, proxy, authentication, acquisition, or model change. It is limited
to the MCP input contract and presentation of results already produced by
DonSeTch.
