### PR TITLE
fix(ci): gate the Chrome h2 probe on non-Linux targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to DonSeTch are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`chrome_h2_probe` non-Linux CI:** gate the Linux-only imports,
+  ALPN callback, and frame-decoding helpers together with the probe entry
+  point, so `cargo clippy --all-targets -- -Dwarnings` does not compile them
+  as unused code on Windows or macOS.
+
+
 ## [3.6.0] - 2026-09-04
 
 ### Added

--- a/examples/chrome_h2_probe.rs
+++ b/examples/chrome_h2_probe.rs
@@ -10,14 +10,18 @@
 //! Dev-only rig: the unsafe server code never ships (examples are not
 //! part of the release binary).
 
+#[cfg(target_os = "linux")]
 use boring_sys as bs;
 
+#[cfg(target_os = "linux")]
 use std::net::TcpListener;
-#[cfg(not(windows))]
+#[cfg(target_os = "linux")]
 use std::os::fd::AsRawFd;
+#[cfg(target_os = "linux")]
 use std::process::Command;
 
 /// ALPN select callback: hand h2 back when the client offers it.
+#[cfg(target_os = "linux")]
 extern "C" fn alpn_select(
     _ssl: *mut bs::SSL,
     out: *mut *const u8,
@@ -46,12 +50,12 @@ extern "C" fn alpn_select(
     }
 }
 
-#[cfg(windows)]
+#[cfg(not(target_os = "linux"))]
 fn main() {
-    eprintln!("chrome_h2_probe is a Linux dev rig; it never runs on Windows");
+    eprintln!("chrome_h2_probe is a Linux-only dev rig");
 }
 
-#[cfg(not(windows))]
+#[cfg(target_os = "linux")]
 fn main() {
     let root = std::env::var("CARGO_MANIFEST_DIR").unwrap_or_else(|_| ".".into());
     let cert = format!("{root}/tests/landmarks/h2cert.pem\0");
@@ -169,6 +173,7 @@ fn main() {
     browser.join().ok();
 }
 
+#[cfg(target_os = "linux")]
 fn complete(buf: &[u8]) -> bool {
     let mut off = 0usize;
     while off + 9 <= buf.len() {
@@ -186,10 +191,12 @@ fn complete(buf: &[u8]) -> bool {
     false
 }
 
+#[cfg(target_os = "linux")]
 fn u24(b: &[u8]) -> u32 {
     ((b[0] as u32) << 16) | ((b[1] as u32) << 8) | b[2] as u32
 }
 
+#[cfg(target_os = "linux")]
 fn parse_and_print(buf: &[u8]) {
     let start = if buf.starts_with(b"PRI * HTTP/2.0") {
         24
@@ -225,6 +232,7 @@ fn parse_and_print(buf: &[u8]) {
 
 /// Decode the first request HEADERS with OUR hpack decoder: proves
 /// both Chrome's header list and our decoder on real Chrome bytes.
+#[cfg(target_os = "linux")]
 fn decode_and_print(buf: &[u8]) {
     let mut off = if buf.starts_with(b"PRI * HTTP/2.0") {
         24


### PR DESCRIPTION
## Summary

This fixes the current Windows `build-test` failure caused by the Linux-only
`chrome_h2_probe` example.

The probe already had separate Windows and non-Windows entry points, but the
Linux-specific imports, ALPN callback, and frame-decoding helpers remained
visible to the Windows compiler. Because CI runs:

```text
cargo clippy --profile ci --all-targets -- -Dwarnings
```

those unused imports and dead functions fail the required Windows check.

The same failure is present on current master; the MCP contract PR merely
surfaced it again and does not modify this example.

## Change

- Gate `boring_sys`, `TcpListener`, `AsRawFd`, and `Command` imports with
  `cfg(target_os = "linux")`.
- Apply the same gate to the ALPN callback and frame-decoding helpers.
- Run the capture implementation only on Linux.
- Keep a small informational `main` for every non-Linux target.

This follows the example's documented Linux-only contract. I intentionally did
not add `allow(unused_imports)` or `allow(dead_code)`, because that would hide
the incomplete target boundary instead of fixing it.

## Scope

`chrome_h2_probe` is a development example and does not ship in the DonSeTch
binary. The Linux capture path, raw TLS handling, frame parser, HPACK output,
and parity-generation workflow are unchanged.

## Validation

- `cargo fmt --all -- --check`: passed.
- `git diff --check`: passed.
- Rust/Clippy 1.98 `cargo clippy --profile ci --all-targets -- -Dwarnings`:
  passed on the non-Linux path.
- Direct Rust 1.98 metadata compilation with `-Dwarnings`: passed.
- Core library tests: 827 passed, zero failed.
- The POSIX permission integration test also passes on the native filesystem;
  its first isolated run on exFAT was discarded because exFAT cannot represent
  the asserted Unix `0600` mode.

The changelog entry is included.
