### PR TITLE
fix(login): donsetch login crashes because reqwest::blocking panics inside its own tokio runtime

### DIFF
--- a/src/auth.rs
+++ b/src/auth.rs
@@ -359,6 +359,22 @@ pub fn probe_domain(
         .map(|c| format!("{}={}", c.name, c.value))
         .collect::<Vec<_>>()
         .join("; ");
+
+    // Dedicated plain thread: `reqwest::blocking` panics when built or
+    // dropped on a thread that already has a tokio runtime context,
+    // and `commit_login` (hence `probe_domain`) is called synchronously
+    // from `donsetch login`'s async command handler, which runs under
+    // `#[tokio::main]`. With this crate's `panic = "abort"` release
+    // profile, that panic would abort the whole process.
+    std::thread::Builder::new()
+        .name("login-probe".into())
+        .spawn(move || probe_once(&url, &cookie_header))
+        .map_err(|e| format!("probe thread spawn: {e}"))?
+        .join()
+        .map_err(|_| "probe thread panicked".to_string())?
+}
+
+fn probe_once(url: &str, cookie_header: &str) -> Result<ProbeResult, String> {
     let client = reqwest::blocking::Client::builder()
         .redirect(reqwest::redirect::Policy::limited(4))
         .timeout(std::time::Duration::from_secs(15))
@@ -370,8 +386,8 @@ pub fn probe_domain(
         .map_err(|e| format!("probe client: {e}"))?;
 
     let resp = client
-        .get(&url)
-        .header(reqwest::header::COOKIE, &cookie_header)
+        .get(url)
+        .header(reqwest::header::COOKIE, cookie_header)
         .send()
         .map_err(|e| format!("probe failed: {e}"))?;
     let status = resp.status();

--- a/src/cli/login.rs
+++ b/src/cli/login.rs
@@ -314,14 +314,18 @@ async fn interactive(site: Option<&str>, fresh: bool, probe: bool) -> Result<(),
 }
 
 async fn retrieve_ws(endpoint: &str, total_ms: u64) -> Result<String, String> {
-    let client = reqwest::blocking::Client::builder()
+    // Async client: this loop runs inside the tokio runtime driving
+    // `donsetch login`, and `reqwest::blocking` panics (aborting the
+    // process, since this crate builds with panic = "abort") when
+    // built or dropped on a thread that already has a runtime context.
+    let client = reqwest::Client::builder()
         .timeout(std::time::Duration::from_secs(3))
         .build()
         .map_err(|e| e.to_string())?;
     let start = std::time::Instant::now();
     loop {
-        if let Ok(resp) = client.get(endpoint).send()
-            && let Ok(v) = resp.json::<serde_json::Value>()
+        if let Ok(resp) = client.get(endpoint).send().await
+            && let Ok(v) = resp.json::<serde_json::Value>().await
             && let Some(ws) = v
                 .get("webSocketDebuggerUrl")
                 .and_then(serde_json::Value::as_str)
@@ -555,5 +559,23 @@ impl AuthLock {
 impl Drop for AuthLock {
     fn drop(&mut self) {
         let _ = std::fs::remove_file(&self.path);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `retrieve_ws` runs inside the tokio runtime driving `donsetch
+    // login`. It used to build a `reqwest::blocking::Client` there,
+    // which panics (and, with this crate's panic = "abort" release
+    // profile, aborts the process) when built or dropped on a thread
+    // that already has a runtime context.
+    #[tokio::test]
+    async fn retrieve_ws_times_out_without_panicking() {
+        let err = retrieve_ws("http://127.0.0.1:1/json/version", 300)
+            .await
+            .expect_err("nothing listens on this port");
+        assert!(err.contains("timeout"));
     }
 }

--- a/tests/auth_login.rs
+++ b/tests/auth_login.rs
@@ -381,3 +381,23 @@ fn commit_login_groups_per_domain_and_skips_noise() {
     let vault = load_session_cookies();
     assert!(!vault.iter().any(|c| c.name == "tracker"));
 }
+
+// ── pillar 9: the post-login probe must not crash the CLI's tokio
+// runtime. `probe_domain` (and `commit_login` with probing on) are
+// called synchronously from `donsetch login`'s async command handler,
+// which runs under `#[tokio::main]`. `reqwest::blocking::Client`
+// panics (and aborts, since this crate builds with panic = "abort")
+// when built/dropped on a thread that already has a tokio runtime
+// context, so this must run on a dedicated thread. ──
+
+#[tokio::test]
+async fn probe_domain_does_not_panic_inside_a_tokio_runtime() {
+    isolate_state();
+    let cookies = vec![cookie(".probe.test", "s", "v", None)];
+    // Loopback + an unprivileged port with no listener: the probe is
+    // expected to fail fast, but it must fail by returning an Err,
+    // never by panicking (and, since this crate builds with
+    // panic = "abort", never by aborting the process).
+    let result = auth::probe_domain("127.0.0.1", &cookies, Some(1));
+    assert!(result.is_err(), "expected a connection-refused Err, got Ok");
+}


### PR DESCRIPTION
## What's broken

`donsetch login` runs under `#[tokio::main]`. Two code paths in that
feature build a `reqwest::blocking::Client` from code that is already
executing *inside* that tokio runtime:

1. `retrieve_ws()` in `src/cli/login.rs` — an async fn, polling for the
   Chrome remote-debugging endpoint right after the browser is
   launched. It built `reqwest::blocking::Client` and called
   `.send()`/`.json()` synchronously.
2. `auth::probe_domain()` in `src/auth.rs` — a plain sync fn, reached
   synchronously (no `spawn_blocking`) via `commit_login()` from both
   `interactive()` and `import()` in `src/cli/login.rs`, both of which
   run inside `run()` (`async fn`, awaited from
   `#[tokio::main] async fn main()`).

`reqwest::blocking::Client` panics when built or dropped on a thread
that already has an active tokio runtime context:

```
thread 'main' panicked at .../tokio-1.53.1/src/runtime/blocking/shutdown.rs:51:21:
Cannot drop a runtime in a context where blocking is not allowed. This happens when a runtime is dropped from within an asynchronous context.
```

I reproduced this standalone in a scratch crate pinned to this repo's
exact `reqwest`/`tokio` versions, and reproduced it as a failing test
inside this repo's own suite before applying the fix (see below).
Since this crate builds with `panic = "abort"` in
`[profile.release]`, that panic **aborts the whole process** in a
release build — meaning `donsetch login`'s interactive flow crashes
right after opening the browser (at `retrieve_ws`), and the post-login
verification probe (`--no-probe` not passed, which is the default)
would crash again even if that first call were fixed.

The codebase already has a documented workaround for exactly this
gotcha in `src/search/rerank.rs` (`download`) and `src/pdf/ocr.rs`:
run the blocking client on a dedicated plain thread. `probe_domain`
now follows that same pattern (existing tests call `commit_login`
synchronously outside any runtime, so it has to stay a plain sync fn).
`retrieve_ws` was already async with an `.await` sleep loop, so it's
simpler to just switch it to the async `reqwest::Client`.

I also checked the other `reqwest::blocking` call site
(`src/ghost/cloak.rs`, gated behind an opt-in download flag) — its
callers already wrap it in `tokio::task::spawn_blocking`, so it's not
affected by this bug.

## Fix

- `src/cli/login.rs::retrieve_ws` — switched to async `reqwest::Client`.
- `src/auth.rs::probe_domain` — split into a thread-spawning wrapper
  and a new private `probe_once` holding the actual blocking-client
  logic, run on a dedicated `std::thread`.

## Tests

- `tests/auth_login.rs::probe_domain_does_not_panic_inside_a_tokio_runtime`
  — a `#[tokio::test]` calling `auth::probe_domain` directly; fails
  (panics) against the old code, passes against the fix.
- `src/cli/login.rs::tests::retrieve_ws_times_out_without_panicking`
  — a `#[tokio::test]` calling the private `retrieve_ws` against a
  closed loopback port; same before/after behavior.

```
LIBCLANG_PATH=/usr/lib/llvm-19/lib cargo test --lib cli::login        # 1 passed
LIBCLANG_PATH=/usr/lib/llvm-19/lib cargo test --test auth_login -- --test-threads=1   # 13 passed
LIBCLANG_PATH=/usr/lib/llvm-19/lib cargo clippy --lib --tests -- -D warnings   # clean
cargo fmt --check                                                      # clean
```

Note: `tests/auth_login.rs::logout_of_one_domain_leaves_others_untouched`
and `src/ghost/xvfb.rs::tests::concurrent_start_serializes_and_reuses`
are pre-existing, unrelated flakes under default test-thread
parallelism (shared global test state) — both pass in isolation and
under `--test-threads=1`; this PR doesn't touch either area.

## Test plan

- [x] `cargo build --lib`
- [x] `cargo test --lib cli::login`
- [x] `cargo test --test auth_login -- --test-threads=1`
- [x] `cargo clippy --lib --tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] Independent adversarial review of the fix (reproduced the panic standalone against pinned dependency versions, verified error propagation through the thread spawn/join, verified no other unfixed `reqwest::blocking` call sites reachable from async context)