### PR TITLE
fix(transport): 3 bugs in the new warm TCP Fast Open connect path (dangling pointer, blocking-timeout defeat, byte-order reversal)

### DIFF
--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -111,13 +111,39 @@ async fn connect_one(addr: SocketAddr, warm: bool) -> Result<TcpStream, FetchErr
 /// Linux TFO-capable connect for warm hosts. Everything else runs
 /// tokio's normal connect (Chrome does not TFO on Windows/macOS in
 /// the same way; parity with the host platform matters more).
+///
+/// The raw handshake runs on a `spawn_blocking` thread, not inline:
+/// `libc::connect()` on this TFO-requesting socket is a genuine
+/// blocking syscall, and measured directly against a local listener
+/// it can take well over a minute to return (a real ~135s handshake
+/// was observed here, against ~220us for a plain connect to the same
+/// listener) instead of the near-instant loopback connect one would
+/// expect. Run inline, that stalls the tokio worker thread carrying
+/// it for the same duration, which silently defeats connect_all's
+/// outer `tokio::time::timeout(CONNECT_TIMEOUT, ..)` -- a blocking
+/// syscall never yields, so the timeout's own timer can't be polled
+/// until the syscall returns on its own. spawn_blocking keeps it off
+/// the reactor so that outer timeout can actually fire.
 #[cfg(target_os = "linux")]
 async fn tcp_connect(addr: SocketAddr, warm: bool) -> Result<TcpStream, FetchError> {
-    use std::os::fd::FromRawFd;
-
     if !warm {
         return TcpStream::connect(addr).await.map_err(Into::into);
     }
+    match tokio::task::spawn_blocking(move || tfo_connect_blocking(addr)).await {
+        Ok(Some(std_stream)) => {
+            std_stream.set_nonblocking(true).ok();
+            TcpStream::from_std(std_stream).map_err(Into::into)
+        }
+        _ => TcpStream::connect(addr).await.map_err(Into::into),
+    }
+}
+
+/// Everything here runs on a blocking-pool thread: `None` on any
+/// failure just tells the caller to fall back to a normal connect.
+#[cfg(target_os = "linux")]
+fn tfo_connect_blocking(addr: SocketAddr) -> Option<std::net::TcpStream> {
+    use std::os::fd::FromRawFd;
+
     let domain = if addr.is_ipv4() {
         libc::AF_INET
     } else {
@@ -125,7 +151,7 @@ async fn tcp_connect(addr: SocketAddr, warm: bool) -> Result<TcpStream, FetchErr
     };
     let fd = unsafe { libc::socket(domain, libc::SOCK_STREAM | libc::SOCK_CLOEXEC, 0) };
     if fd < 0 {
-        return TcpStream::connect(addr).await.map_err(Into::into);
+        return None;
     }
     // Request fastopen: the kernel decides per peer TFO-cookie state.
     let one: libc::c_int = 1;
@@ -140,17 +166,16 @@ async fn tcp_connect(addr: SocketAddr, warm: bool) -> Result<TcpStream, FetchErr
     };
     if rc != 0 {
         unsafe { libc::close(fd) };
-        return TcpStream::connect(addr).await.map_err(Into::into);
+        return None;
     }
-    let (ptr, len) = sockaddr_of(addr);
+    let storage = sockaddr_of(addr);
+    let (ptr, len) = storage.as_ptr_len();
     let rc = unsafe { libc::connect(fd, ptr, len) };
     if rc != 0 {
         unsafe { libc::close(fd) };
-        return TcpStream::connect(addr).await.map_err(Into::into);
+        return None;
     }
-    let std_stream = unsafe { std::net::TcpStream::from_raw_fd(fd) };
-    std_stream.set_nonblocking(true).ok();
-    TcpStream::from_std(std_stream).map_err(Into::into)
+    Some(unsafe { std::net::TcpStream::from_raw_fd(fd) })
 }
 
 #[cfg(not(target_os = "linux"))]
@@ -158,37 +183,172 @@ async fn tcp_connect(addr: SocketAddr, _warm: bool) -> Result<TcpStream, FetchEr
     TcpStream::connect(addr).await.map_err(Into::into)
 }
 
+/// Owns the raw sockaddr bytes. `sockaddr_of` used to hand back a
+/// `*const libc::sockaddr` pointing at a `let` inside its own match
+/// arm: that local goes out of scope the instant the function
+/// returns, so the pointer was dangling at the call site (confirmed
+/// under Miri: "constructing invalid value ... dangling reference
+/// (use-after-free)"). Returning the struct by value keeps the bytes
+/// alive in the caller's frame for as long as the pointer is used.
 #[cfg(target_os = "linux")]
-fn sockaddr_of(addr: SocketAddr) -> (*const libc::sockaddr, libc::socklen_t) {
-    match addr {
-        SocketAddr::V4(v4) => {
-            let sockaddr = libc::sockaddr_in {
-                sin_family: libc::AF_INET as libc::sa_family_t,
-                sin_port: v4.port().to_be(),
-                sin_addr: libc::in_addr {
-                    s_addr: u32::from_ne_bytes(v4.ip().octets()).to_be(),
-                },
-                sin_zero: [0; 8],
-            };
-            (
-                &sockaddr as *const _ as *const libc::sockaddr,
+enum SockAddrStorage {
+    V4(libc::sockaddr_in),
+    V6(libc::sockaddr_in6),
+}
+
+#[cfg(target_os = "linux")]
+impl SockAddrStorage {
+    fn as_ptr_len(&self) -> (*const libc::sockaddr, libc::socklen_t) {
+        match self {
+            SockAddrStorage::V4(s) => (
+                s as *const _ as *const libc::sockaddr,
                 std::mem::size_of::<libc::sockaddr_in>() as libc::socklen_t,
-            )
-        }
-        SocketAddr::V6(v6) => {
-            let sockaddr = libc::sockaddr_in6 {
-                sin6_family: libc::AF_INET6 as libc::sa_family_t,
-                sin6_port: v6.port().to_be(),
-                sin6_flowinfo: v6.flowinfo(),
-                sin6_addr: libc::in6_addr {
-                    s6_addr: v6.ip().octets(),
-                },
-                sin6_scope_id: v6.scope_id(),
-            };
-            (
-                &sockaddr as *const _ as *const libc::sockaddr,
+            ),
+            SockAddrStorage::V6(s) => (
+                s as *const _ as *const libc::sockaddr,
                 std::mem::size_of::<libc::sockaddr_in6>() as libc::socklen_t,
-            )
+            ),
         }
+    }
+}
+
+#[cfg(target_os = "linux")]
+fn sockaddr_of(addr: SocketAddr) -> SockAddrStorage {
+    match addr {
+        SocketAddr::V4(v4) => SockAddrStorage::V4(libc::sockaddr_in {
+            sin_family: libc::AF_INET as libc::sa_family_t,
+            sin_port: v4.port().to_be(),
+            // `s_addr` must hold the address's raw octets, in order,
+            // regardless of host endianness -- `from_ne_bytes` alone
+            // already does that (it's an identity on the bytes: on
+            // any platform, `from_ne_bytes(o).to_ne_bytes() == o`).
+            // The extra `.to_be()` this used to carry reverses those
+            // bytes on every little-endian target (all of this
+            // project's real deployments), pointing the raw connect
+            // at the octet-reversed address instead of the one asked
+            // for -- e.g. 203.0.113.7 became 7.113.0.203.
+            sin_addr: libc::in_addr {
+                s_addr: u32::from_ne_bytes(v4.ip().octets()),
+            },
+            sin_zero: [0; 8],
+        }),
+        SocketAddr::V6(v6) => SockAddrStorage::V6(libc::sockaddr_in6 {
+            sin6_family: libc::AF_INET6 as libc::sa_family_t,
+            sin6_port: v6.port().to_be(),
+            sin6_flowinfo: v6.flowinfo(),
+            sin6_addr: libc::in6_addr {
+                s6_addr: v6.ip().octets(),
+            },
+            sin6_scope_id: v6.scope_id(),
+        }),
+    }
+}
+
+#[cfg(all(test, target_os = "linux"))]
+mod tests {
+    use super::*;
+
+    // `sockaddr_of` used to hand back a `*const libc::sockaddr`
+    // pointing at a `let` inside its own match arm: that local goes
+    // out of scope the instant the function returns, so the pointer
+    // was dangling at the call site (confirmed under Miri:
+    // "constructing invalid value ... dangling reference
+    // (use-after-free)"). Reading the fields back immediately through
+    // the returned storage is exactly what a dangling pointer would
+    // get wrong (garbage instead of the address that went in) -- and,
+    // unlike a live connect, it needs no real syscalls, so it stays
+    // fast and deterministic on every platform.
+    #[test]
+    fn sockaddr_of_v4_roundtrips_correctly() {
+        let addr: SocketAddr = "203.0.113.7:4242".parse().unwrap();
+        let storage = sockaddr_of(addr);
+        let (ptr, len) = storage.as_ptr_len();
+        assert_eq!(len as usize, std::mem::size_of::<libc::sockaddr_in>());
+        let sin = unsafe { &*(ptr as *const libc::sockaddr_in) };
+        assert_eq!(sin.sin_family as i32, libc::AF_INET);
+        assert_eq!(u16::from_be(sin.sin_port), 4242);
+        // s_addr's raw bytes must equal the octets exactly, in order
+        // (that's what network byte order means for an address) --
+        // this is what an extraneous byte swap or a dangling pointer
+        // would both get wrong.
+        assert_eq!(sin.sin_addr.s_addr.to_ne_bytes(), [203, 0, 113, 7]);
+    }
+
+    #[test]
+    fn sockaddr_of_v6_roundtrips_correctly() {
+        let addr: SocketAddr = "[2001:db8::1]:4242".parse().unwrap();
+        let storage = sockaddr_of(addr);
+        let (ptr, len) = storage.as_ptr_len();
+        assert_eq!(len as usize, std::mem::size_of::<libc::sockaddr_in6>());
+        let sin6 = unsafe { &*(ptr as *const libc::sockaddr_in6) };
+        assert_eq!(sin6.sin6_family as i32, libc::AF_INET6);
+        assert_eq!(u16::from_be(sin6.sin6_port), 4242);
+        let SocketAddr::V6(v6) = addr else {
+            unreachable!()
+        };
+        assert_eq!(std::net::Ipv6Addr::from(sin6.sin6_addr.s6_addr), *v6.ip());
+    }
+
+    // Control: a plain connect (warm=false) to a real local listener
+    // must stay fast and correct.
+    #[tokio::test]
+    async fn cold_connect_reaches_the_real_listener() {
+        let listener = std::net::TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().expect("addr");
+        let accept = tokio::task::spawn_blocking(move || listener.accept());
+        let stream =
+            tokio::time::timeout(std::time::Duration::from_secs(3), tcp_connect(addr, false))
+                .await
+                .expect("cold connect must not block the executor")
+                .expect("cold connect to a real local listener must succeed");
+        assert_eq!(stream.peer_addr().expect("peer addr"), addr);
+        let _ = accept.await;
+    }
+
+    // `tcp_connect(addr, true)`'s raw handshake used to run inline
+    // instead of via spawn_blocking (see tcp_connect's doc comment):
+    // measured directly against a real local listener in this
+    // environment, the raw blocking libc::connect() call took ~135s
+    // against ~220us for the plain connect above -- a real blocking
+    // syscall that, run inline, would starve this #[tokio::test]'s
+    // single worker thread for the same duration. This is
+    // deliberately NOT re-exercised as a live connect here: with the
+    // fix in place the async logic returns promptly (verified by hand
+    // against a standalone repro pinned to this crate's exact libc +
+    // tokio versions), but tokio's runtime teardown waits for any
+    // outstanding spawn_blocking task to finish before returning
+    // control -- so a live test would still take the full ~135s to
+    // report a result in an environment like this one, entirely
+    // independent of whether the fix is correct. (Tried routing
+    // around it with a destination expected to fail connect() fast
+    // -- an unassigned Class E address, no route -- but that hung
+    // here too: whatever this sandbox does to TCP_FASTOPEN_CONNECT
+    // SYNs isn't specific to the loopback listener.) That means this
+    // test proves the spawn_blocking-keeps-the-executor-free pattern
+    // in isolation, not that `tcp_connect` itself still dispatches
+    // through it -- a regression re-inlining the raw connect there
+    // would slip past this test.
+    #[tokio::test]
+    async fn warm_connect_stays_off_the_executor_thread() {
+        let ticks = std::sync::Arc::new(std::sync::atomic::AtomicU32::new(0));
+        let ticks_bg = ticks.clone();
+        let ticker = tokio::spawn(async move {
+            loop {
+                tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+                ticks_bg.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+            }
+        });
+        // A slow synchronous closure standing in for the real raw
+        // connect: spawn_blocking is what keeps either one off this
+        // thread, and that's the property under test here.
+        drop(tokio::task::spawn_blocking(|| {
+            std::thread::sleep(std::time::Duration::from_millis(300))
+        }));
+        tokio::time::sleep(std::time::Duration::from_millis(320)).await;
+        ticker.abort();
+        assert!(
+            ticks.load(std::sync::atomic::Ordering::Relaxed) >= 10,
+            "the executor was starved while a spawn_blocking task was in flight"
+        );
     }
 }


### PR DESCRIPTION
## What's broken

`src/transport/tcp.rs`'s Linux `TCP_FASTOPEN_CONNECT` path for warm
(repeat-navigation) connections, added in `add1d97` ("ironcloak part
1"), has three independent bugs. All three are in the same small
block of new code.

### 1. Dangling pointer (undefined behavior)

`sockaddr_of()` built a `libc::sockaddr_in`/`sockaddr_in6` as a `let`
inside its own `match` arm, then returned a raw pointer to it:

```rust
fn sockaddr_of(addr: SocketAddr) -> (*const libc::sockaddr, libc::socklen_t) {
    match addr {
        SocketAddr::V4(v4) => {
            let sockaddr = libc::sockaddr_in { .. };
            (&sockaddr as *const _ as *const libc::sockaddr, ..)
        }
        ...
```

That local's stack slot is invalid the instant the function returns,
so the pointer is dangling at the call site. I confirmed this is
genuine, real UB (not just "technically against the rules") with a
standalone Miri repro of the exact pattern:

```
error: Undefined Behavior: constructing invalid value of type &libc::sockaddr_in: encountered a dangling reference (use-after-free)
```

Fixed by returning an owned `SockAddrStorage` enum by value, with
`as_ptr_len(&self)` deriving the pointer at the call site so the bytes
live in the caller's own stack frame for as long as they're needed.

### 2. A blocking syscall defeats the connect timeout

The raw `socket()`/`setsockopt()`/`connect()` sequence ran inline
inside the `async fn tcp_connect()` — a genuine blocking syscall
executed directly on whatever tokio worker thread happened to be
polling that task. Measured directly against a real local
`TcpListener` on this dev machine:

- plain `tokio::net::TcpStream::connect` to the listener: **~220us**
- the raw TFO `connect()` to the *same* listener: **~134.7s** (and it
  ultimately failed)

I believe the ~135s figure itself is specific to this sandboxed dev
environment (it shows Docker network namespaces in `ps`/`lsof`, which
may be mishandling the TFO cookie-request SYN option) and don't claim
it reproduces exactly everywhere. But the architectural bug is real
regardless of the exact number: `libc::connect()` on a blocking socket
never yields control back to the async runtime, so
`connect_all`'s outer `tokio::time::timeout(CONNECT_TIMEOUT, ..)`
(10s) cannot fire — a *real* blocking syscall run inline silently
defeats it on any network condition slow enough to hit it, not just
this one.

This codebase already has a documented workaround for exactly this
"blocking call inside async code" class of bug in `search/rerank.rs`
and `pdf/ocr.rs` (run it on a dedicated thread). Fixed the same way
here: the raw handshake moved into a new `tfo_connect_blocking()`
function, run via `tokio::task::spawn_blocking`, falling back to a
normal connect on any failure (matching the original semantics).

I verified the *async correctness* of this fix in isolation (a
standalone repro, not the full crate): wrapped in a
`tokio::time::timeout(3s, ..)`, the async logic returned right on
schedule with a concurrent ticking task proving the executor stayed
live throughout — even though the underlying blocking connect()
eventually failed on its own detached thread 134.7s later, entirely
harmlessly in the background.

### 3. IPv4 address byte-order reversal

`sockaddr_of()`'s V4 arm built the address like this:

```rust
sin_addr: libc::in_addr {
    s_addr: u32::from_ne_bytes(v4.ip().octets()).to_be(),
},
```

The trailing `.to_be()` is an extra byte swap. `s_addr` needs to hold
the address's raw octets unchanged in memory (that's what "network
byte order" means for an address), and `from_ne_bytes(octets)` alone
already produces exactly that on any host endianness (it's an
identity on the raw bytes by definition). The extra `.to_be()`
reverses those bytes on every little-endian target — this project's
entire deployment matrix (x86_64, aarch64) — so e.g. `203.0.113.7`
would actually get dialed as `7.113.0.203`.

I caught this with a new test asserting `s_addr`'s raw bytes equal the
address's octets exactly; it failed against the original code with
precisely the reversed bytes (`[7, 113, 0, 203]` instead of
`[203, 0, 113, 7]`), and I cross-checked the correct construction two
more ways (manual byte tracing, and independently via
`std::net::Ipv4Addr::into()` + `.to_be()` on *that* value) before
concluding the fix is just to drop the extra `.to_be()`. IPv6 was
never affected — it copies the 16-byte address array directly, with
no integer/endian conversion attempted at all.

## Tests

All fast and deterministic on every platform — none exercise a live
slow syscall:

- `sockaddr_of_v4/v6_roundtrips_correctly` — read the raw struct bytes
  back immediately after construction (no syscalls at all); this is
  what both bug #1 (a dangling pointer would read garbage) and bug #3
  (a byte swap would read the reversed address) get wrong.
- `cold_connect_reaches_the_real_listener` — timeout-bounded control
  for the plain (non-TFO) path.
- `warm_connect_stays_off_the_executor_thread` — proves the
  `spawn_blocking` pattern keeps a slow synchronous closure off the
  async executor thread (a concurrent ticker keeps advancing while a
  300ms blocking sleep is in flight). This intentionally does **not**
  invoke the real TFO connect path: even with the fix, tokio's
  `Runtime::drop()` blocks on any outstanding `spawn_blocking` task
  before returning, so in an environment where the raw connect stalls
  (as observed here), a live test would still take the full ~135s to
  report a result — entirely independent of whether the fix is
  correct. I also tried routing around this with a destination
  expected to fail `connect()` immediately (an unassigned Class E
  address with no route), but that hung too, so whatever this sandbox
  does to `TCP_FASTOPEN_CONNECT` SYNs isn't specific to loopback. This
  is a known, acknowledged gap: this test proves the general pattern
  in isolation, not that `tcp_connect` itself still dispatches through
  it — a regression re-inlining the raw connect there wouldn't be
  caught by it.

```
LIBCLANG_PATH=/usr/lib/llvm-19/lib cargo test --lib transport::tcp   # 4 passed, 0.32s
LIBCLANG_PATH=/usr/lib/llvm-19/lib cargo clippy --lib --tests -- -D warnings   # clean
cargo fmt --check                                                      # clean
```

## Test plan

- [x] `cargo build --lib`
- [x] `cargo test --lib transport::tcp`
- [x] `cargo clippy --lib --tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] Independent adversarial review: re-derived the byte-order math from scratch, independently reproduced the dangling-pointer UB under Miri, independently verified the blocking-syscall/timeout-defeat mechanism (and the `Runtime::drop`-blocks-on-outstanding-`spawn_blocking` claim) with its own scratch-crate experiments rather than trusting the numbers above, and checked for fd leaks / missed fallback paths in the fix