### PR TITLE
fix(search): engine trust EWMA eroded by dead-proxy/auth-fail infra noise, not engine quality

### DIFF
--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -88,6 +88,17 @@ fn norm_query(q: &str) -> String {
         .join(" ")
 }
 
+/// Whether a failure `status` reflects the engine actually behaving
+/// badly (worth quarantining via `record_outcome` and eroding trust
+/// via `bump_trust`), as opposed to infra noise -- a dead egress
+/// (`"dead-proxy"`), a BYOK key problem (`"auth-fail"`), or simply no
+/// results (`"no-results"`) -- none of which are the engine's fault.
+/// A single predicate so quarantine and trust tracking can't drift
+/// out of sync with each other again.
+fn is_engine_fault(status: &str) -> bool {
+    !status.starts_with("dead") && status != "auth-fail" && status != "no-results"
+}
+
 pub struct Searcher {
     fetcher: Fetcher,
     pool: EgressPool,
@@ -640,12 +651,10 @@ impl Searcher {
                 }
                 Err((status, egress_id, was_engine)) => {
                     let base = engine.split('_').next().unwrap_or(&engine);
-                    // Dead proxies are egress failures, not
-                    // engine failures : don't quarantine.
-                    if !status.starts_with("dead")
-                        && status != "auth-fail"
-                        && status != "no-results"
-                    {
+                    // Dead proxies and auth failures are egress/BYOK
+                    // problems, not engine failures : don't quarantine
+                    // or distrust the engine over them.
+                    if is_engine_fault(&status) {
                         self.record_outcome(base, false);
                     }
                     if (was_engine || ghost_lane) && !ghost_lane {
@@ -657,7 +666,7 @@ impl Searcher {
                             self.pool.report_blocked(base, &egress_id);
                         }
                     }
-                    if (was_engine || ghost_lane) && status != "no-results" {
+                    if (was_engine || ghost_lane) && is_engine_fault(&status) {
                         self.bump_trust(base, false);
                     }
                     report.push(EngineReport {
@@ -1617,6 +1626,26 @@ impl Drop for InflightGuard<'_> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // Egress/BYOK-auth noise must never look like the engine
+    // misbehaving: record_outcome (quarantine) and bump_trust (the
+    // ranking-weight EWMA) both gate on this predicate, and had
+    // drifted out of sync before (bump_trust used to fire on
+    // "dead-proxy"/"auth-fail" too, eroding trust for infra failures
+    // the engine had nothing to do with).
+    #[test]
+    fn is_engine_fault_excludes_infra_and_no_results() {
+        assert!(!is_engine_fault("dead-proxy"));
+        assert!(!is_engine_fault("auth-fail"));
+        assert!(!is_engine_fault("no-results"));
+        assert!(is_engine_fault("blocked:403"));
+        assert!(is_engine_fault("blocked:captcha"));
+        assert!(is_engine_fault("empty-parse"));
+        assert!(is_engine_fault("ghost-timeout"));
+        assert!(is_engine_fault("timeout"));
+        assert!(is_engine_fault("no-url"));
+        assert!(is_engine_fault("net"));
+    }
 
     #[test]
     fn google_ghost_is_its_own_family_for_ranking_math() {


### PR DESCRIPTION
## What's broken

`Searcher`'s per-engine outcome handling (in the fan-out result loop)
updates two separate signals on failure:

- `record_outcome(base, false)` — a quarantine-streak counter.
- `bump_trust(base, false)` — an EWMA-smoothed "trust" score. This
  isn't cosmetic: `rank::merge()` reads it (`trust.get(engine).unwrap_or(1.0)`)
  and uses it as a real multiplicative weight on that engine's hits in
  the final ranked result set.

Both are meant to exclude failures that are the fetch infrastructure's
fault, not the engine's — a dead egress proxy (`status` starting with
`"dead"`, e.g. `"dead-proxy"`) or a BYOK key problem (`"auth-fail"`).
There's an explicit comment saying exactly this, right above
`record_outcome`'s guard:

```rust
// Dead proxies are egress failures, not
// engine failures : don't quarantine.
if !status.starts_with("dead")
    && status != "auth-fail"
    && status != "no-results"
{
    self.record_outcome(base, false);
}
```

But `bump_trust`'s guard, a few lines below, only excluded
`"no-results"`:

```rust
if (was_engine || ghost_lane) && status != "no-results" {
    self.bump_trust(base, false);
}
```

So an engine whose egress happened to die, or whose BYOK key had an
auth hiccup, got its *ranking-weight* trust score eroded toward
"untrustworthy" even though neither failure says anything about the
engine's actual result quality — directly contradicting the design
intent stated one line above. This looks like an unintended side
effect of the recent ghost-SERP-cascade refactor that pulled
`bump_trust` out into its own top-level condition.

## Fix

Extracted a single predicate so the two signals can't drift apart
again:

```rust
fn is_engine_fault(status: &str) -> bool {
    !status.starts_with("dead") && status != "auth-fail" && status != "no-results"
}
```

Both call sites now use it. The `pool.report_dead`/`report_auth_fail`/
`report_blocked` branch in between is untouched.

Audited every status string this file actually produces (grepped all
`Err((status, ..))` construction sites) against `is_engine_fault`:
`"dead-proxy"`, `"auth-fail"`, `"no-results"` correctly excluded;
`"blocked:{code}"`, `"blocked:captcha"`, `"empty-parse"`,
`"ghost-timeout"`, `"timeout"`, `"no-url"`, `"net"`, and the
`format!("{e}")` case for direct-vertical `FetchError`s (whose
`Display` strings — `"invalid url: .."`, `"tls: .."`, `"timeout"`,
etc. — never start with `"dead"` or literally equal `"auth-fail"`)
all correctly counted as real engine faults.

Added `is_engine_fault_excludes_infra_and_no_results` covering all of
the above.

## Test plan

```
LIBCLANG_PATH=/usr/lib/llvm-19/lib cargo test --lib search::tests    # 35 passed
LIBCLANG_PATH=/usr/lib/llvm-19/lib cargo clippy --lib --tests -- -D warnings   # clean
cargo fmt --check                                                     # clean
```

- [x] `cargo build --lib`
- [x] `cargo test --lib search::tests`
- [x] `cargo clippy --lib --tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] Independent adversarial review: confirmed `trust` is a real ranking input (not cosmetic) by reading `rank::merge()`, independently audited every status-string construction site in the file for a classification gap, checked the success-path (`Ok(...)` arm) for a parallel inconsistency (none found — the asymmetry there is intentional, since success is never infra's fault), and re-ran the test suite/clippy/fmt itself