### PR TITLE
fix(search): rerank topup() leaves results non-monotonically sorted for max_results > 8

### DIFF
--- a/src/search/rerank.rs
+++ b/src/search/rerank.rs
@@ -548,13 +548,30 @@ mod inner {
         if scores.len() != n {
             return;
         }
+        apply_topup_scores(results, n, &scores, NUDGE);
+    }
+
+    /// The score-nudge-and-resort half of `topup`, split out so it's
+    /// testable without a real cross-encoder model.
+    fn apply_topup_scores(
+        results: &mut [crate::search::rank::Merged],
+        n: usize,
+        scores: &[f64],
+        nudge: f64,
+    ) {
         for (r, s) in results[..n].iter_mut().zip(scores) {
             // scores are probabilities (0=irrelevant, 1=exact); the
             // 0.5-centered product keeps the nudge zero-sum around
             // the midpoint.
-            r.score += NUDGE * (s - 0.5);
+            r.score += nudge * (s - 0.5);
         }
-        results[..n].sort_by(|a, b| b.score.total_cmp(&a.score));
+        // Sort the whole slice, not just the nudged prefix: the
+        // nudge can push results[n-1] below results[n]'s untouched
+        // score (a near-tied pair straddling the depth boundary),
+        // and callers taking more than `depth` results (merge()
+        // always keeps 12; topup runs at depth=8) would otherwise
+        // get a slice that isn't sorted by score at that boundary.
+        results.sort_by(|a, b| b.score.total_cmp(&a.score));
     }
 
     #[cfg(test)]
@@ -696,6 +713,52 @@ mod inner {
                 blend[0] - blend[1] < rrf_n[0] - rrf_n[1],
                 "xenc should narrow the gap even if it doesn't flip"
             );
+        }
+
+        fn merged(url: &str, score: f64) -> Merged {
+            Merged {
+                title: url.into(),
+                url: url.into(),
+                snippet: String::new(),
+                sources: vec![],
+                score,
+                published: None,
+            }
+        }
+
+        // apply_topup_scores used to only re-sort results[..n], leaving
+        // results[n..] untouched: a nudge that pushes results[n-1]
+        // below results[n]'s original score left the overall vector
+        // non-monotonic at that boundary. depth=n=2 here; result[1]
+        // ("boundary") starts just above result[2] ("untouched") and
+        // gets nudged down past it.
+        #[test]
+        fn apply_topup_scores_keeps_the_whole_vector_sorted() {
+            let mut results = vec![
+                merged("top", 1.0),
+                merged("boundary", 0.60),
+                merged("untouched", 0.55),
+                merged("tail", 0.1),
+            ];
+            apply_topup_scores(&mut results, 2, &[1.0, 0.0], 0.2);
+            // "top" nudged up (+0.1 -> 1.1), "boundary" nudged down
+            // (0.60 - 0.1 = 0.50), which is now below "untouched"
+            // (0.55). The whole vector must reflect that, not just
+            // the first two entries.
+            for pair in results.windows(2) {
+                assert!(
+                    pair[0].score >= pair[1].score,
+                    "not sorted: {} ({}) before {} ({})",
+                    pair[0].url,
+                    pair[0].score,
+                    pair[1].url,
+                    pair[1].score
+                );
+            }
+            assert_eq!(results[0].url, "top");
+            assert_eq!(results[1].url, "untouched");
+            assert_eq!(results[2].url, "boundary");
+            assert_eq!(results[3].url, "tail");
         }
 
         #[test]


### PR DESCRIPTION
## What's broken

`rerank::topup()` (behind the `rerank` feature) re-scores the top
`depth` results with a cross-encoder, nudges each result's score by
up to ±0.05, then re-sorts:

```rust
for (r, s) in results[..n].iter_mut().zip(scores) {
    r.score += NUDGE * (s - 0.5);
}
results[..n].sort_by(|a, b| b.score.total_cmp(&a.score));
```

Only `results[..n]` (`n = depth.min(results.len())`, called with
`depth=8` from `src/search/mod.rs`) gets re-sorted. `results[n..]` —
indices 8..12, since `merge()` always keeps 12 results for the cache
before trimming to `max_results` for the response — is left exactly
where it was.

The nudge can move a score by up to 0.05 in either direction. If
`results[7]` (rank 8, last of the nudged prefix) starts only slightly
ahead of `results[8]` (rank 9, untouched), the nudge can push it below
`results[8]`'s original score — but since only the first 8 get
re-sorted, the final 12-element vector ends up out of order at that
boundary. Any caller with `max_results` between 9 and 12 (both real,
documented values — `spec.rs` says "default 7, max 12," and bumping
past the default is an explicitly sanctioned way to get more results
when the first batch looks weak) gets a response that isn't actually
sorted by relevance.

## Fix

Sort the whole slice instead of just the prefix. Also extracted the
nudge-and-sort logic into a new `apply_topup_scores()` function so
it's unit-testable without a real cross-encoder model — `topup()`
itself calls `cross_encoder_scores()`, which needs a downloaded ONNX
model on disk and returns `None` (making `topup()` a no-op) without
one, so there was no way to exercise the actual bug in a test before
this split.

## Test

`apply_topup_scores_keeps_the_whole_vector_sorted` constructs a small
4-result case (`top`, `boundary`, `untouched`, `tail`) where the nudge
pushes `boundary` below `untouched`, and asserts the whole vector
stays monotonically sorted by score, with the exact expected final
order. I confirmed by hand (and the independent reviewer separately
confirmed with their own standalone repro of the old logic) that this
test fails under the original `results[..n]`-only sort and passes
under the fix.

## Test plan

```
LIBCLANG_PATH=/usr/lib/llvm-19/lib cargo test --lib --features rerank search::rerank::inner::tests   # 17 passed
LIBCLANG_PATH=/usr/lib/llvm-19/lib cargo clippy --lib --features rerank --tests -- -D warnings        # clean
cargo fmt --check                                                                                       # clean
```

- [x] `cargo build --lib --features rerank`
- [x] `cargo test --lib --features rerank search::rerank::inner::tests`
- [x] `cargo clippy --lib --features rerank --tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] Independent adversarial review: independently re-derived the score arithmetic and reproduced the old buggy ordering with a standalone script, confirmed `apply_topup_scores` can't be called with `n > results.len()` (single private call site, upstream `n = depth.min(results.len())` already guarantees this), checked `rerank()`'s main blend for a similar prefix-only-sort pattern (none found — it never sorts internally), and assessed real-world reach via `max_results`'s documented range in `spec.rs`