### PR TITLE
fix(mcp): search validation failures report errorKind "transient" instead of "permanent"

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -3680,6 +3680,10 @@ fn make_ghost_hook(
 struct SearchFailure {
     cause: String,
     byok_tried: bool,
+    /// "permanent" for bad input that no retry or fallback fixes
+    /// (validate_query rejected it before any engine was contacted);
+    /// "transient" for exhausted engines/providers.
+    kind: &'static str,
 }
 
 /// The search pipeline: BYOK providers (if configured) with
@@ -3697,7 +3701,7 @@ async fn search_inner(
             maybe_pre_solve(daemon, top);
             render_search_outcome(daemon, &out).await
         }
-        Err(failure) => search_error(query, &failure.cause, failure.byok_tried),
+        Err(failure) => search_error(query, &failure.cause, failure.byok_tried, failure.kind),
     }
 }
 
@@ -3747,6 +3751,20 @@ fn search_debug_meta(out: &crate::search::SearchOutcome) -> Value {
     search::render_meta(out)
 }
 
+/// Retrying a fully-failed batch only makes sense if at least one
+/// variant failed for a transient (engine/provider) reason; if every
+/// variant was rejected by validate_query ("permanent"), no engine
+/// was ever contacted and retrying the same queries won't help.
+/// Pulled out as a pure function so this logic is testable without a
+/// live `Daemon`.
+fn batch_failure_kind<'a>(kinds: impl Iterator<Item = &'a str>) -> &'static str {
+    if kinds.into_iter().all(|k| k == "permanent") {
+        "permanent"
+    } else {
+        "transient"
+    }
+}
+
 /// Execute explicit query variants concurrently and keep every result set
 /// separate. Grouped evidence lets the calling model compare formulations
 /// while each query retains DonSeTch's established ranking semantics.
@@ -3775,13 +3793,22 @@ async fn search_batch_inner(
                 Err(failure) => Some(json!({"query": query, "error": failure.cause})),
             })
             .collect::<Vec<_>>();
+        let kind = batch_failure_kind(outcomes.iter().filter_map(|outcome| match outcome {
+            Ok(_) => None,
+            Err(f) => Some(f.kind),
+        }));
+        let next_action = if kind == "permanent" {
+            "fix the queries and search again"
+        } else {
+            "retry once, then reduce to the strongest single query"
+        };
         return tool_error_structured(
             format!("search: all {} query variants failed", queries.len()),
-            "transient",
+            kind,
             Some(json!({
                 "queries": queries,
                 "errors": errors,
-                "next_action": "retry once, then reduce to the strongest single query",
+                "next_action": next_action,
             })),
         );
     }
@@ -3873,6 +3900,7 @@ async fn search_outcome(
         return Err(SearchFailure {
             cause: problem,
             byok_tried: false,
+            kind: "permanent",
         });
     }
     // Reload from disk first : picks up keys added/removed
@@ -3909,12 +3937,14 @@ async fn search_outcome(
                     Err(e2) => Err(SearchFailure {
                         cause: format!("local ({e}); byok ({e2})"),
                         byok_tried: true,
+                        kind: "transient",
                     }),
                 }
             } else {
                 Err(SearchFailure {
                     cause: e.to_string(),
                     byok_tried: false,
+                    kind: "transient",
                 })
             }
         }
@@ -4021,7 +4051,21 @@ impl Drop for PreSolveGuard<'_> {
     }
 }
 
-fn search_error(query: &str, cause: &str, byok_tried: bool) -> Value {
+fn search_error(query: &str, cause: &str, byok_tried: bool, kind: &str) -> Value {
+    if kind == "permanent" {
+        // validate_query rejected the query before any engine or
+        // provider was ever contacted : no escalation trace to show,
+        // and retrying the same query (or adding an API key) won't
+        // help, unlike the exhausted-engines case below.
+        return tool_error_structured(
+            format!("search: {cause}"),
+            "permanent",
+            Some(json!({
+                "query": query,
+                "next_action": "fix the query and search again",
+            })),
+        );
+    }
     let mut trace = Trace::default();
     trace.step("search", "engines", "error", 0);
     if byok_tried {
@@ -4216,6 +4260,57 @@ fn fetch_error_kind(e: &FetchError) -> &'static str {
 #[cfg(test)]
 mod stitch_tests {
     use super::*;
+
+    // search_error used to hardcode errorKind: "transient" for every
+    // failure, including validate_query rejections (empty/oversized
+    // query) that never contact an engine -- contradicting its own
+    // caller's comment ("a bad query is a permanent-shaped failure")
+    // and, via exit_code_of in cli/tool.rs, handing scripts the wrong
+    // exit code for a non-retryable input error.
+    #[test]
+    fn search_error_permanent_has_no_false_escalation_trace() {
+        let v = search_error(
+            "",
+            "empty query : pass a non-empty query string",
+            false,
+            "permanent",
+        );
+        assert_eq!(v["errorKind"], "permanent");
+        assert!(
+            v["structuredContent"].get("escalation").is_none(),
+            "a validation failure never contacted an engine: no escalation trace to show"
+        );
+    }
+
+    #[test]
+    fn search_error_transient_keeps_engine_escalation_trace() {
+        let v = search_error("q", "all engines timed out", false, "transient");
+        assert_eq!(v["errorKind"], "transient");
+        assert!(v["structuredContent"].get("escalation").is_some());
+    }
+
+    #[test]
+    fn batch_failure_kind_permanent_only_when_every_variant_is() {
+        assert_eq!(
+            batch_failure_kind(["permanent", "permanent"].into_iter()),
+            "permanent"
+        );
+        assert_eq!(batch_failure_kind(["permanent"].into_iter()), "permanent");
+    }
+
+    #[test]
+    fn batch_failure_kind_transient_if_any_variant_is() {
+        // One transient variant means a retry could still succeed :
+        // the batch as a whole should be reported retryable.
+        assert_eq!(
+            batch_failure_kind(["permanent", "transient"].into_iter()),
+            "transient"
+        );
+        assert_eq!(
+            batch_failure_kind(["transient", "transient"].into_iter()),
+            "transient"
+        );
+    }
 
     #[test]
     fn rel_next_found_and_resolved() {


### PR DESCRIPTION
## What's broken

`search_outcome()` runs `validate_query()` before ever contacting an
engine or BYOK provider, and its own comment says exactly what that
means:

```rust
// Input hygiene first: a bad query is a permanent-shaped failure
// whether the fanout would have been BYOK or local.
if let Some(problem) = search::validate_query(query) {
    return Err(SearchFailure {
        cause: problem,
        byok_tried: false,
    });
}
```

But `SearchFailure` had no field to actually carry that classification
— it only had `cause` and `byok_tried`. Every `SearchFailure`,
validation rejection or genuinely-exhausted-engines alike, flowed into
`search_error()`, which unconditionally set `errorKind: "transient"`,
built an escalation trace claiming `search`→`engines`→`error` was
attempted (false for a validation rejection — no engine was ever
contacted), and appended "retry once, then simplify the query... add
an API key provider" advice that's actively wrong for a malformed
query (retrying the same empty/oversized query changes nothing).

**Concrete impact:** `donsetch search ""` (or any MCP client passing
an empty or >512-character query, both trivially real inputs per
`validate_query`) got `errorKind: "transient"`, which
`cli/tool.rs::exit_code_of()` maps to `EXIT_TRANSIENT` (2) instead of
`EXIT_PERMANENT` (1) — the wrong signal for any exit-code-driven retry
automation, plus a misleading escalation trace and hint shown to both
CLI users and MCP agent callers. The CLI's `search`/`fetch` commands
both go through this same `exit_code_of()`/`render_result` path.

`search_batch_inner()` (multi-query mode) had the identical bug in its
own all-variants-failed branch: it always reported `"transient"`
regardless of whether every variant failed validation or engines were
genuinely exhausted.

## Fix

- Added `kind: &'static str` to `SearchFailure`, set correctly at all
  three construction sites in `search_outcome()`: the `validate_query`
  rejection gets `"permanent"`; the two "engines/BYOK exhausted" sites
  get `"transient"`.
- `search_error()` now takes `kind` and returns early for
  `"permanent"` with a clean payload (no false trace, no
  retry/API-key hint) before falling through to the unchanged
  transient-path logic.
- `search_batch_inner()`'s all-failed branch computes its own `kind`
  via a new pure `batch_failure_kind()` helper: `"permanent"` only if
  *every* variant failed for a permanent reason (if even one failed
  transiently, a retry could still help the batch as a whole), else
  `"transient"`. Extracted as a standalone function specifically so
  this logic is unit-testable without spinning up a live `Daemon`.

## Tests

`mod stitch_tests` gained four:
- `search_error_permanent_has_no_false_escalation_trace` /
  `search_error_transient_keeps_engine_escalation_trace` — the
  dispatch in `search_error()`.
- `batch_failure_kind_permanent_only_when_every_variant_is` /
  `batch_failure_kind_transient_if_any_variant_is` — the batch
  aggregation logic in isolation.

## Test plan

```
LIBCLANG_PATH=/usr/lib/llvm-19/lib cargo test --lib mcp::server::stitch_tests   # 8 passed
LIBCLANG_PATH=/usr/lib/llvm-19/lib cargo clippy --lib --tests -- -D warnings    # clean
cargo fmt --check                                                                # clean
```

- [x] `cargo build --lib`
- [x] `cargo test --lib mcp::server::stitch_tests`
- [x] `cargo clippy --lib --tests -- -D warnings`
- [x] `cargo fmt --check`
- [x] Independent adversarial review: confirmed all `SearchFailure` construction sites were updated (grepped for the literal), independently verified `exit_code_of()`'s behavior and that this is genuinely CLI-reachable (not MCP-only), scrutinized the batch-mode "permanent only if all" rule against the alternative ("permanent if any") and confirmed the chosen rule is the correct one, and checked a related but out-of-scope latent issue (an error-path `_meta`/`machine_meta` divergence noted by an earlier audit) to confirm this fix doesn't touch or worsen it