### PR TITLE
fix(fetch): require explicit private egress opt-in

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **False-like private-egress values no longer disable SSRF guards:**
+  `DONSETCH_ALLOW_PRIVATE_EGRESS` previously enabled private egress from
+  presence alone, so `false`, `0`, an empty string, or an unknown value
+  bypassed the URL, DNS, and socket checks. One shared fail-closed parser now
+  accepts only `1`, `true`, or `on` (case-insensitive, with surrounding
+  whitespace ignored); malformed and non-Unicode values remain disabled.
 - **Engine trust EWMA was eroded by infra failures:** the quarantine
   gate excluded `dead-proxy`/`auth-fail`/`no-results` but the trust
   EWMA only excluded `no-results`, so dead egresses and BYOK key

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,62 @@
+//! Small, shared parsers for process-level runtime configuration.
+
+use std::ffi::OsStr;
+
+/// Read a security-sensitive opt-in flag from the environment.
+///
+/// Only explicit affirmative values enable the flag. Matching is
+/// ASCII-case-insensitive and ignores surrounding ASCII/Unicode
+/// whitespace; missing, non-Unicode, false, and unknown values all
+/// fail closed.
+pub(crate) fn env_flag(name: &str) -> bool {
+    env_flag_value(std::env::var_os(name).as_deref())
+}
+
+fn env_flag_value(value: Option<&OsStr>) -> bool {
+    value
+        .and_then(OsStr::to_str)
+        .map(str::trim)
+        .is_some_and(|value| {
+            value.eq_ignore_ascii_case("1")
+                || value.eq_ignore_ascii_case("true")
+                || value.eq_ignore_ascii_case("on")
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn opt_in_flags_accept_only_explicit_true_values() {
+        for value in ["1", "true", "TRUE", "on", "ON", " true ", "\t1\n"] {
+            assert!(env_flag_value(Some(OsStr::new(value))), "{value:?}");
+        }
+
+        for value in [
+            "",
+            "0",
+            "false",
+            "FALSE",
+            "off",
+            "OFF",
+            "yes",
+            "no",
+            "enabled",
+            "anything",
+            " true-ish ",
+        ] {
+            assert!(!env_flag_value(Some(OsStr::new(value))), "{value:?}");
+        }
+
+        assert!(!env_flag_value(None));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn opt_in_flags_reject_non_unicode_values() {
+        use std::os::unix::ffi::OsStrExt;
+
+        assert!(!env_flag_value(Some(OsStr::from_bytes(b"true\xff"))));
+    }
+}

--- a/src/fetch/guards.rs
+++ b/src/fetch/guards.rs
@@ -65,11 +65,10 @@ pub fn is_ssrf_resolved_ip(ip: &IpAddr) -> bool {
 }
 
 /// Escape hatch for deliberate private egress (CLI power users,
-/// local services): DONSETCH_ALLOW_PRIVATE_EGRESS set to anything
-/// disables the SSRF guard chain end to end, matching the
-/// transport layer's hatch. Default off.
-fn private_egress_allowed() -> bool {
-    std::env::var_os("DONSETCH_ALLOW_PRIVATE_EGRESS").is_some()
+/// local services): DONSETCH_ALLOW_PRIVATE_EGRESS must be explicitly
+/// true to disable the SSRF guard chain end to end. Default off.
+pub(crate) fn private_egress_allowed() -> bool {
+    crate::config::env_flag("DONSETCH_ALLOW_PRIVATE_EGRESS")
 }
 
 fn is_private_ip(ip: &IpAddr) -> bool {
@@ -134,6 +133,13 @@ fn is_private_ip(ip: &IpAddr) -> bool {
 /// caller should surface directly. This is the single sync gate
 /// used by both fetch and browser tiers.
 pub fn validate_url_basic(url_str: &str) -> Result<url::Url, crate::error::FetchError> {
+    validate_url_basic_with_policy(url_str, private_egress_allowed())
+}
+
+fn validate_url_basic_with_policy(
+    url_str: &str,
+    allow_private_egress: bool,
+) -> Result<url::Url, crate::error::FetchError> {
     let url = url::Url::parse(url_str)
         .map_err(|_| crate::error::FetchError::InvalidUrl(url_str.into()))?;
     let scheme = url.scheme();
@@ -150,7 +156,7 @@ pub fn validate_url_basic(url_str: &str) -> Result<url::Url, crate::error::Fetch
     let host = url
         .host_str()
         .ok_or_else(|| crate::error::FetchError::InvalidUrl(url_str.into()))?;
-    if is_ssrf_host(host) && !private_egress_allowed() {
+    if is_ssrf_host(host) && !allow_private_egress {
         return Err(crate::error::FetchError::Http(format!(
             "blocked: {host} is a private/loopback address : SSRF guard (set DONSETCH_ALLOW_PRIVATE_EGRESS to override)"
         )));
@@ -186,9 +192,10 @@ pub fn validate_url_basic(url_str: &str) -> Result<url::Url, crate::error::Fetch
 /// Redirects are re-validated per hop via `validate_redirect_url`
 /// (sync) and `ensure_url_safe` (async) where applicable.
 pub async fn ensure_url_safe(url_str: &str) -> Result<url::Url, crate::error::FetchError> {
-    let url = validate_url_basic(url_str)?;
+    let allow_private_egress = private_egress_allowed();
+    let url = validate_url_basic_with_policy(url_str, allow_private_egress)?;
     // Deliberate opt-out: skip the DNS resolution tier entirely.
-    if private_egress_allowed() {
+    if allow_private_egress {
         return Ok(url);
     }
     let host: String = url.host_str().unwrap_or("").to_owned();
@@ -622,26 +629,14 @@ mod tests {
     }
 
     #[test]
-    fn private_egress_hatch_disables_both_tiers() {
-        unsafe { std::env::set_var("DONSETCH_ALLOW_PRIVATE_EGRESS", "1") };
-        // Literal gate relaxed.
-        assert!(validate_url_basic("http://127.0.0.1/").is_ok());
-        assert!(validate_url_basic("http://198.18.0.25/").is_ok());
-        assert!(validate_url_basic("http://[::ffff:169.254.169.254]/").is_ok());
-        unsafe { std::env::remove_var("DONSETCH_ALLOW_PRIVATE_EGRESS") };
-        // Strict again.
-        assert!(validate_url_basic("http://127.0.0.1/").is_err());
-        assert!(validate_url_basic("http://198.18.0.25/").is_err());
-    }
-
-    #[tokio::test]
-    async fn hatch_also_relaxes_resolved_tier() {
-        unsafe { std::env::set_var("DONSETCH_ALLOW_PRIVATE_EGRESS", "1") };
-        // A genuinely private target would still be dialed here, so
-        // use a blocked literal to prove the whole async chain is
-        // skipped without performing a resolution at all.
-        assert!(ensure_url_safe("http://192.168.1.1/").await.is_ok());
-        unsafe { std::env::remove_var("DONSETCH_ALLOW_PRIVATE_EGRESS") };
-        assert!(ensure_url_safe("http://192.168.1.1/").await.is_err());
+    fn private_egress_policy_controls_literal_guard() {
+        for target in [
+            "http://127.0.0.1/",
+            "http://198.18.0.25/",
+            "http://[::ffff:169.254.169.254]/",
+        ] {
+            assert!(validate_url_basic_with_policy(target, true).is_ok());
+            assert!(validate_url_basic_with_policy(target, false).is_err());
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@
 pub mod adapters;
 pub mod auth;
 pub mod cli;
+mod config;
 pub mod cpu;
 pub mod crawl;
 pub mod detect;

--- a/src/transport/tcp.rs
+++ b/src/transport/tcp.rs
@@ -39,7 +39,7 @@ pub async fn happy_connect_with(
     // dial : not the name : also closes rebinding TOCTOU.
     // Escape hatch for deliberate local-egress use (CLI
     // power users, tests): DONSETCH_ALLOW_PRIVATE_EGRESS=1.
-    let addrs: Vec<SocketAddr> = if std::env::var_os("DONSETCH_ALLOW_PRIVATE_EGRESS").is_some() {
+    let addrs: Vec<SocketAddr> = if crate::fetch::guards::private_egress_allowed() {
         addrs
     } else {
         let blocked: Vec<&SocketAddr> = addrs


### PR DESCRIPTION
## Summary

`DONSETCH_ALLOW_PRIVATE_EGRESS` was previously interpreted by presence alone. That meant values such as `false`, `0`, an empty string, an unknown value, or malformed/non-Unicode input still disabled the URL, DNS, and socket SSRF protections.

This PR introduces one shared, fail-closed opt-in parser and uses it at all three enforcement points. Only `1`, `true`, and `on` enable private egress, case-insensitively after trimming surrounding whitespace. The secure default and the deliberate private-egress escape hatch remain intact; the change prevents configuration values that read as false from silently enabling it.

The parser lives in a small configuration module so future security-sensitive boolean flags can reuse the same explicit contract instead of drifting between call sites. The changelog documents the behavior correction.

## Type

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — deps, CI, tooling
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only

## Checks

- [x] `cargo test --features ocr,rerank` passes (891 tests, Rust 1.98)
- [x] `cargo clippy --all-targets --features ocr,rerank -- -Dwarnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes
- [ ] CI is green on all 3 platforms (Linux, macOS, Windows)

## Breaking changes

No change to the secure default. Operators intentionally using the escape hatch with an arbitrary non-empty value must change it to `1`, `true`, or `on`.

## Test plan

- Verified accepted values: `1`, `true`, `on`, mixed/uppercase forms, and surrounding whitespace.
- Verified missing, empty, `0`, `false`, `off`, unknown, malformed, and non-Unicode values remain disabled.
- Added an end-to-end policy regression test at literal URL validation without mutating process-global environment state.
- Verified the URL, DNS, and socket layers share the same decision function.
- Ran the complete OCR/rerank suite and Clippy with the repository-pinned Rust 1.98 toolchain after rebasing onto the latest `master`.
