### PR TITLE
feat(build): Stamp Windows version metadata into the binary

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Windows binaries carry a version resource:** Explorer, Task Manager,
+  UAC prompts and `Get-Command` showed no publisher, description or
+  version. `build.rs` now stamps `VERSIONINFO` derived entirely from
+  `Cargo.toml`: `FileDescription` the display name, `Comments` the
+  package description, `LegalCopyright` the license. The numeric
+  `FILEVERSION` carries `MAJOR.MINOR.PATCH`, the string field the full
+  version, and a version suffix marks the build unofficial (`rc`/`beta`
+  set `VS_FF_PRERELEASE`, anything else `VS_FF_PRIVATEBUILD`). Best
+  effort: a missing `rc.exe` warns instead of failing the build.
+  `CompanyName` is left as a disabled hook : there is no publisher to
+  claim.
+- **`serverInfo.title` in the MCP handshake:** MCP separates the
+  programmatic identifier from the display label (`title`, optional
+  since 2025-06-18), so clients that prefer it now show `DonSeTch`
+  instead of the `donsetch` package id. Older clients ignore the field.
+
 ### Fixed
 
 - **False-like private-egress values no longer disable SSRF guards:**

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -994,6 +994,7 @@ dependencies = [
  "unicode-bidi",
  "url",
  "windows-sys 0.61.2",
+ "winresource",
  "zip",
  "zstd",
 ]
@@ -4401,6 +4402,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winresource"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0986a8b1d586b7d3e4fe3d9ea39fb451ae22869dcea4aa109d287a374d866087"
+dependencies = [
+ "version_check",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,6 +87,17 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 sha2 = "0.11"
 flate2 = "1"
 
+# cfg() on build-dependencies resolves against the HOST, not the target, so this
+# only applies when building *on* Windows -- matching the #[cfg(windows)] gate on
+# the version-resource code in build.rs. Cross-compiling to Windows from another
+# host therefore yields an exe with no version resource; if that is ever needed,
+# move this to the plain [build-dependencies] above and drop the #[cfg(windows)]
+# in build.rs.
+[target.'cfg(windows)'.build-dependencies]
+# default-features = false drops the "toml" feature, which only exists to parse
+# [package.metadata.winresource]; build.rs sets every field programmatically.
+winresource = { version = "0.1", default-features = false }
+
 [profile.release]
 lto = "fat"
 codegen-units = 1

--- a/build.rs
+++ b/build.rs
@@ -199,6 +199,10 @@ fn main() {
     // always re-runs this build script and triggers the download.
     println!("cargo:rerun-if-changed=build.rs");
     println!("cargo:rerun-if-changed=vendor/pdfium/lib");
+    // The version resource is derived from these two files alone, so a version
+    // bump or a rename must re-run this script or the exe keeps a stale one.
+    println!("cargo:rerun-if-changed=Cargo.toml");
+    println!("cargo:rerun-if-changed=src/display_name.rs");
 
     // ── LLD auto-detection (Linux) ────────────────────────────
     //
@@ -253,6 +257,10 @@ fn main() {
             println!("cargo:rustc-link-arg=/STACK:8388608");
         }
     }
+
+    // ── Windows version resource ──────────────────────────────
+    // The metadata Explorer, Task Manager and Get-Command read off the exe.
+    stamp_version_resource(&os);
 
     // ── aarch64 + ONNX note ──────────────────────────────────
     //
@@ -661,3 +669,92 @@ fn sha256_hex(data: &[u8]) -> String {
     let hash = Sha256::digest(data);
     hash.iter().map(|b| format!("{b:02x}")).collect()
 }
+
+// Shared with the crate : see src/display_name.rs. Item position: include!
+// cannot expand items inside a function body.
+#[cfg(windows)]
+include!("src/display_name.rs");
+
+/// Publisher shown by Explorer, Task Manager and UAC elevation prompts.
+///
+/// The Win32 spec marks CompanyName as required, but there is no company or
+/// publisher behind this project to claim, and an invented one would be worse
+/// than none. Maintainer: set this to `Some("...")` -- a name or handle -- and
+/// it is stamped into every Windows build; leave it `None` to omit the field.
+#[cfg(windows)]
+const COMPANY_NAME: Option<&str> = None;
+
+/// Stamp a Windows version resource (`VERSIONINFO`) into the executable.
+///
+/// Without one the binary reports no publisher, description or version in
+/// Explorer, Task Manager or `Get-Command`. Every field is derived from
+/// `Cargo.toml`, so nothing has to be maintained alongside a release. Best
+/// effort: a missing resource compiler downgrades to a warning rather than
+/// failing the build.
+///
+/// `os` is the target: a Windows host can still be building for something else.
+/// The `#[cfg(windows)]` gate is the host : see the `winresource` entry in
+/// Cargo.toml.
+#[cfg(windows)]
+fn stamp_version_resource(os: &str) {
+    if os != "windows" {
+        return;
+    }
+
+    use winresource::{VersionInfo, WindowsResource};
+
+    // `new()` already fills ProductName from the package name and both version
+    // strings from the full package version.
+    let mut res = WindowsResource::new();
+
+    // FileDescription is a short label shown to users -- Task Manager treats it
+    // as the app name -- so it takes the display title. The prose belongs in
+    // Comments, which is specified as "additional information ... for
+    // diagnostic purposes".
+    res.set("FileDescription", DISPLAY_NAME);
+    if let Some(company) = COMPANY_NAME {
+        res.set("CompanyName", company);
+    }
+    if let Ok(description) = env::var("CARGO_PKG_DESCRIPTION")
+        && !description.is_empty()
+    {
+        res.set("Comments", &description);
+    }
+    if let Ok(license) = env::var("CARGO_PKG_LICENSE")
+        && !license.is_empty()
+    {
+        res.set("LegalCopyright", &license);
+    }
+
+    // The numeric FILEVERSION is four 16-bit words, so it carries only
+    // MAJOR.MINOR.PATCH; the string field keeps the full version verbatim.
+    // Anything trailing the numbers means this is not an upstream release:
+    // rc/beta are pre-releases, anything else is a private build.
+    let version = env::var("CARGO_PKG_VERSION").unwrap_or_default();
+    let numeric = format!(
+        "{}.{}.{}",
+        env::var("CARGO_PKG_VERSION_MAJOR").unwrap_or_default(),
+        env::var("CARGO_PKG_VERSION_MINOR").unwrap_or_default(),
+        env::var("CARGO_PKG_VERSION_PATCH").unwrap_or_default(),
+    );
+    let suffix = version.strip_prefix(&numeric).unwrap_or_default();
+    if !suffix.is_empty() {
+        let suffix = suffix.to_ascii_lowercase();
+        if suffix.contains("rc") || suffix.contains("beta") {
+            res.set_version_info(VersionInfo::FILEFLAGS, VersionInfo::VS_FF_PRERELEASE);
+        } else {
+            // VS_FF_PRIVATEBUILD requires the PrivateBuild string to be set.
+            res.set("PrivateBuild", &version);
+            res.set_version_info(VersionInfo::FILEFLAGS, VersionInfo::VS_FF_PRIVATEBUILD);
+        }
+    }
+
+    if let Err(e) = res.compile() {
+        println!("cargo:warning=skipping Windows version resource: {e}");
+    }
+}
+
+/// No-op off Windows: `winresource` is a host-gated build-dependency, so it is
+/// not even in the graph here.
+#[cfg(not(windows))]
+fn stamp_version_resource(_os: &str) {}

--- a/src/display_name.rs
+++ b/src/display_name.rs
@@ -1,0 +1,8 @@
+// Read as a module by the crate and verbatim by build.rs (`include!`), which
+// cannot `use` items from the crate it builds: the exe's FileDescription and
+// the title reported over MCP must not drift apart.
+// `pub` is required by the crate's re-export and inert in build.rs, where an
+// include!'d item has no external consumer.
+
+/// Human-readable product name, as distinct from the `donsetch` identifier.
+pub const DISPLAY_NAME: &str = "DonSeTch";

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,9 @@ pub mod cpu;
 pub mod crawl;
 pub mod detect;
 pub mod dev;
+// Also read verbatim by build.rs : see the file.
+mod display_name;
+pub use display_name::DISPLAY_NAME;
 pub mod error;
 pub mod extract;
 pub mod fetch;

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -378,6 +378,7 @@ fn initialize(params: &Value) -> Value {
         "instructions": tools::instructions(),
         "serverInfo": {
             "name": tools::SERVER_NAME,
+            "title": tools::SERVER_TITLE,
             "version": tools::SERVER_VERSION
         }
     })

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -22,6 +22,11 @@ pub const PROTOCOL_VERSIONS: &[&str] = &[
 ];
 
 pub const SERVER_NAME: &str = "donsetch";
+
+/// Human-readable label for UI surfaces: MCP keeps `name` programmatic and
+/// `title` for display (optional since 2025-06-18, ignored by older clients).
+/// Shared with the exe's FileDescription : see src/display_name.rs.
+pub const SERVER_TITLE: &str = crate::DISPLAY_NAME;
 pub const SERVER_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 /// The `instructions` string sent at initialize. Generated from

--- a/tests/fixtures/initialize.json
+++ b/tests/fixtures/initialize.json
@@ -6,6 +6,7 @@
   "protocolVersion": "2026-07-28",
   "serverInfo": {
     "name": "donsetch",
+    "title": "DonSeTch",
     "version": "<CARGO_PKG_VERSION>"
   }
 }


### PR DESCRIPTION
# Stamp Windows version metadata into the binary
## Summary

Windows binaries shipped with no identity: Explorer, Task Manager, System
Informer and `Get-Command` all reported a blank publisher, description and
version. `build.rs` now stamps a `VERSIONINFO` resource into the executable,
with every field derived from `Cargo.toml`, so nothing has to be maintained
alongside a release. The same display name is also sent as `serverInfo.title`
in the MCP handshake, so a client that prefers the title shows `DonSeTch`
rather than the `donsetch` package id.

A follow-up PR routes the CLI's 16 hardcoded titles through the same
constant; this one keeps the diff to what the version resource needs.

## What is stamped, and from where

| Field | Source |
|---|---|
| `FileDescription` | display name (`DonSeTch`) : Task Manager shows this as the app name |
| `ProductName`, `ProductVersion` | package name and version, filled by `WindowsResource::new()` |
| `FileVersion` (string) | full package version, suffix included |
| `FILEVERSION` (numeric) | `MAJOR.MINOR.PATCH` : the field is four 16-bit words and cannot hold a suffix |
| `Comments` | `package.description` : the spec reserves this for "additional information … for diagnostic purposes" |
| `LegalCopyright` | `package.license` |
| `PrivateBuild` + `VS_FF_PRIVATEBUILD` | set when the version carries a non-`rc`/`beta` suffix |
| `VS_FF_PRERELEASE` | set when the suffix contains `rc` or `beta` |
| `CompanyName` | **deliberately empty** : see below |

`CompanyName` is left as a disabled `COMPANY_NAME` hook in `build.rs`. The Win32
spec marks it required and it is what Explorer, Task Manager and UAC elevation
prompts show as the publisher, but there is no company or publisher behind the
project to claim, and an invented one would be worse than none. A maintainer
sets it to `Some("…")` once and every Windows build carries it.

## Build-side notes

- **Host-gated, not target-gated.** `cfg()` on build-dependencies resolves
  against the host, so `winresource` is declared under
  `[target.'cfg(windows)'.build-dependencies]` to match the `#[cfg(windows)]`
  on the stamping function. Cross-compiling *to* Windows from another host
  therefore produces no resource; lifting both together is the change to make
  if that is ever wanted. Called out in a comment at the dependency.
- **Best effort.** A missing resource compiler emits `cargo:warning=` instead
  of failing the build.
- **No new maintenance.** Every field derives from `Cargo.toml`;
  `rerun-if-changed` covers `Cargo.toml` and the display-name file, so a
  version bump cannot leave a stale resource behind.
- **One new dependency:** `winresource` (+ `version_check`), build-side only,
  `default-features = false` (its `toml` feature only parses
  `[package.metadata.winresource]`, which this does not use).
- **The display name has one home.** `FileDescription` and the MCP title must
  not drift apart, so both read `src/display_name.rs` : the crate as a module,
  `build.rs` verbatim via `include!`, since a build script cannot `use` items
  from the crate it builds.

## Also included: `serverInfo.title`

MCP separates the programmatic identifier from the display label (`title`,
optional since the 2025-06-18 revision), so `initialize` now answers with both.
Clients that prefer the title show `DonSeTch`; older clients ignore the field.
The golden `initialize` fixture is updated to match.

## Type

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — deps, CI, tooling
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only

## Checks
- [x] `cargo test --features ocr,rerank -- --test-threads=1` passes\
      (serial run needed: `tests/auth_login.rs` shares one state dir across the
      whole binary, so two logout tests race under parallel execution — pre-existing,
      untouched by this PR)
- [x] `cargo clippy --all-targets --features ocr,rerank -- -Dwarnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes
- [ ] CI is green on all 3 platforms (Linux, macOS, Windows)

## Breaking changes

None. `serverInfo.title` is an optional field added alongside `name`, which is
unchanged, so clients that do not know it ignore it. The version resource is
metadata in the executable and changes no behavior. Non-Windows targets compile
the stamping function to an empty no-op and never see the dependency.

## Test plan

`Get-Command` and the version APIs, before and after:

```
## OLD version

PS C:\Proj\donsetch> Get-Command donsetch

CommandType     Name                                               Version    Source
-----------     ----                                               -------    ------
Application     donsetch.exe                                       0.0.0.0    C:\XXXX\donsetch.exe

PS C:\Proj\donsetch> (Get-Item (Get-Command donsetch).Source).VersionInfo

ProductVersion   FileVersion      FileName
--------------   -----------      --------
                                  C:\XXXX\donsetch.exe

## New version

PS C:\Proj\donsetch> Get-Command .\target\debug\donsetch.exe

CommandType     Name                                               Version    Source
-----------     ----                                               -------    ------
Application     donsetch.exe                                       3.6.2.0    C:\Proj\donsetch\target\debug\donsetch...


PS C:\Proj\donsetch> (Get-Item .\target\debug\donsetch.exe).VersionInfo | Format-List *


FileVersionRaw     : 3.6.2.0
ProductVersionRaw  : 3.6.2.0
Comments           : Web fetch, search and crawl for AI agents. Custom stealthy HTTP fetch tier on BoringSSL.
CompanyName        :
FileBuildPart      : 2
FileDescription    : DonSeTch
FileMajorPart      : 3
FileMinorPart      : 6
FileName           : C:\Proj\donsetch\target\debug\donsetch.exe
FilePrivatePart    : 0
FileVersion        : 3.6.2-bm.1
InternalName       :
IsDebug            : False
IsPatched          : False
IsPrivateBuild     : True
IsPreRelease       : False
IsSpecialBuild     : False
Language           : Language Neutral
LegalCopyright     : AGPL-3.0-only
LegalTrademarks    :
OriginalFilename   :
PrivateBuild       : 3.6.2-bm.1
ProductBuildPart   : 2
ProductMajorPart   : 3
ProductMinorPart   : 6
ProductName        : donsetch
ProductPrivatePart : 0
ProductVersion     : 3.6.2-bm.1
SpecialBuild       :
```

That capture is a local `3.6.2-bm.1` build, so it also exercises the suffix
path: the numeric `FILEVERSION` holds `3.6.2.0` while the string field keeps
the full version, and the non-release suffix sets `VS_FF_PRIVATEBUILD`
(`IsPrivateBuild : True`, `PrivateBuild : 3.6.2-bm.1`).

**Task Manager** — the stamped binary above four unstamped ones:

<!-- upload win-task-manager.png here -->

**Explorer, Details tab:**

<!-- upload "windows property explorer.png" here -->

**System Informer, Description column** — empty before, populated after:

<!-- upload "sys informer-before.png" and "sys informer-after.png" here -->

Also checked:

- The `initialize` golden-fixture test covers the new `serverInfo.title`.
- A release-version build (`3.6.2`, no suffix) sets neither
  `VS_FF_PRERELEASE` nor `VS_FF_PRIVATEBUILD`.
- Non-Windows hosts compile the stamping function to an empty no-op and do not
  resolve the dependency at all.

Not exercised locally: the missing-`rc.exe` warning path, cross-compilation to
Windows from a non-Windows host (documented as producing no resource), and the
`rc`/`beta` pre-release branch — CI covers the three platforms building.
