### PR TITLE
refactor(cli): Route CLI titles through one display-name constant

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   since 2025-06-18), so clients that prefer it now show `DonSeTch`
   instead of the `donsetch` package id. Older clients ignore the field.
 
+### Changed
+
+- **One source for the product name:** hardcoded in 16 places across the
+  CLI, it now lives in `src/display_name.rs` (`donsetch::DISPLAY_NAME`),
+  read by the CLI titles, the MCP title and build.rs alike : the last by
+  `include!`, since a build script cannot `use` items from the crate it
+  builds.
+
 ### Fixed
 
 - **False-like private-egress values no longer disable SSRF guards:**

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -14,6 +14,7 @@
 
 use std::path::Path;
 
+use crate::DISPLAY_NAME;
 use crate::cli;
 use crate::fetch::client::Fetcher;
 use crate::paths;
@@ -39,7 +40,7 @@ pub async fn run() {
     let fix = args.iter().any(|a| a == "--fix");
     let only_mcp = args.iter().any(|a| a == "--mcp");
 
-    cli::print_title("DonSeTch Doctor");
+    cli::print_title(&format!("{DISPLAY_NAME} Doctor"));
     println!();
 
     let mut p = 0u32; // passed

--- a/src/cli/keys.rs
+++ b/src/cli/keys.rs
@@ -13,6 +13,7 @@
 
 use super::{bold, dim, green, red};
 
+use crate::DISPLAY_NAME;
 use crate::search::byok::plugin::{
     DEFAULT_TIMEOUT_MS, PluginConfig, tokenize_cmd, validate_plugin_name,
 };
@@ -838,14 +839,14 @@ fn print_help() {
     println!("    the next key is tried automatically.");
     println!();
     println!("  {}", bold("Fallback:"));
-    println!("    If all providers are exhausted, DonSeTch falls back");
+    println!("    If all providers are exhausted, {DISPLAY_NAME} falls back");
     println!("    to the local keyless 5-engine search system.");
     println!();
     println!("  {}", bold("Plugins (for unsupported providers):"));
     println!("    If the platform you have a key for is not natively");
     println!("    supported, register any executable that answers our");
     println!("    stdin/stdout JSON contract as a plugin, with no code");
-    println!("    changes to DonSeTch:");
+    println!("    changes to {DISPLAY_NAME}:");
     println!(
         "      {}",
         dim("donsetch keys add plugin myprovider --cmd 'python3 ~/adapter.py' --test")

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -17,6 +17,7 @@ use std::time::{Duration, Instant};
 
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 
+use crate::DISPLAY_NAME;
 use crate::cli;
 use crate::transport::proxy::{self, Proxy, ProxyScheme};
 
@@ -69,7 +70,7 @@ async fn cmd_add(args: &[String]) {
         std::process::exit(1);
     }
 
-    cli::print_title("DonSeTch Proxy Add");
+    cli::print_title(&format!("{DISPLAY_NAME} Proxy Add"));
     println!();
 
     let existing = proxy::load_config();
@@ -196,7 +197,7 @@ async fn cmd_remove(args: &[String]) {
         std::process::exit(1);
     }
 
-    cli::print_title("DonSeTch Proxy Remove");
+    cli::print_title(&format!("{DISPLAY_NAME} Proxy Remove"));
     println!();
 
     let mut proxies = proxy::load_config();
@@ -261,7 +262,7 @@ async fn cmd_remove(args: &[String]) {
 }
 
 async fn cmd_list() {
-    cli::print_title("DonSeTch Proxy Configuration");
+    cli::print_title(&format!("{DISPLAY_NAME} Proxy Configuration"));
     println!();
 
     let proxies = proxy::load_config();
@@ -300,7 +301,7 @@ async fn cmd_list() {
 }
 
 async fn cmd_check() {
-    cli::print_title("DonSeTch Proxy Check");
+    cli::print_title(&format!("{DISPLAY_NAME} Proxy Check"));
     println!();
 
     let proxies = proxy::load_config();
@@ -379,7 +380,7 @@ async fn cmd_check() {
 }
 
 async fn cmd_clear() {
-    cli::print_title("DonSeTch Proxy Clear");
+    cli::print_title(&format!("{DISPLAY_NAME} Proxy Clear"));
     println!();
 
     let existing = proxy::load_config();
@@ -416,7 +417,7 @@ async fn cmd_test(args: &[String]) {
     let p = match Proxy::parse(url) {
         Ok(p) => p,
         Err(e) => {
-            cli::print_title("DonSeTch Proxy Test");
+            cli::print_title(&format!("{DISPLAY_NAME} Proxy Test"));
             println!();
             println!("  {} Invalid proxy URL: {}", cli::icon_fail(), e);
             println!();
@@ -425,7 +426,7 @@ async fn cmd_test(args: &[String]) {
         }
     };
 
-    cli::print_title("DonSeTch Proxy Test");
+    cli::print_title(&format!("{DISPLAY_NAME} Proxy Test"));
     println!();
 
     let spinner = cli::Spinner::new("Probing proxy...");
@@ -471,7 +472,7 @@ async fn cmd_import(args: &[String]) {
         }
     };
 
-    cli::print_title("DonSeTch Proxy Import");
+    cli::print_title(&format!("{DISPLAY_NAME} Proxy Import"));
     println!();
 
     let content = match std::fs::read_to_string(path) {
@@ -542,7 +543,7 @@ async fn cmd_export(args: &[String]) {
 
     match args.first() {
         Some(path) => {
-            cli::print_title("DonSeTch Proxy Export");
+            cli::print_title(&format!("{DISPLAY_NAME} Proxy Export"));
             println!();
             let content: String = proxies
                 .iter()

--- a/src/cli/rollback.rs
+++ b/src/cli/rollback.rs
@@ -13,12 +13,13 @@
 
 use std::path::{Path, PathBuf};
 
+use crate::DISPLAY_NAME;
 use crate::cli;
 
 #[allow(clippy::needless_borrows_for_generic_args)]
 pub fn run() {
     cli::init();
-    cli::print_title("DonSeTch Rollback");
+    cli::print_title(&format!("{DISPLAY_NAME} Rollback"));
 
     let current = env!("CARGO_PKG_VERSION");
     cli::print_kv("current", current);

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -5,6 +5,7 @@
 //! "I just installed it, what's the state?" command : fast, no
 //! network probes, no browser launch.
 
+use crate::DISPLAY_NAME;
 use crate::cli;
 use crate::fetch::client::Fetcher;
 use crate::profile::BrowserProfile;
@@ -16,7 +17,7 @@ const REPO: &str = "dondai44423/donsetch";
 pub async fn run() {
     cli::init();
     let current = env!("CARGO_PKG_VERSION");
-    cli::print_title(&format!("DonSeTch {current} : Status"));
+    cli::print_title(&format!("{DISPLAY_NAME} {current} : Status"));
     println!();
 
     // ── Version + update ────────────────────────────────────

--- a/src/cli/update.rs
+++ b/src/cli/update.rs
@@ -19,6 +19,7 @@
 
 use std::path::Path;
 
+use crate::DISPLAY_NAME;
 use crate::cli;
 use crate::fetch::client::Fetcher;
 use crate::paths;
@@ -28,7 +29,7 @@ const REPO: &str = "dondai44423/donsetch";
 
 pub async fn run() {
     cli::init();
-    cli::print_title("DonSeTch Update");
+    cli::print_title(&format!("{DISPLAY_NAME} Update"));
 
     let current = env!("CARGO_PKG_VERSION");
     cli::print_kv("current", current);

--- a/src/cli/version.rs
+++ b/src/cli/version.rs
@@ -5,6 +5,7 @@
 //! feed (no API key, no rate limits) and shows whether the current
 //! version is up to date.
 
+use crate::DISPLAY_NAME;
 use crate::cli;
 use crate::fetch::client::Fetcher;
 use crate::profile::BrowserProfile;
@@ -15,7 +16,7 @@ pub async fn run() {
     crate::cli::init();
 
     let current = env!("CARGO_PKG_VERSION");
-    cli::print_title(&format!("DonSeTch {current}"));
+    cli::print_title(&format!("{DISPLAY_NAME} {current}"));
 
     let exe = std::env::current_exe()
         .map(|p| p.display().to_string())


### PR DESCRIPTION
# Route CLI titles through one display-name constant
## Summary

The product name `DonSeTch` was hardcoded in 16 places across the CLI. It now
comes from one constant, `donsetch::DISPLAY_NAME` in `src/display_name.rs`,
which the exe's `FileDescription` and the MCP `serverInfo.title` already read.
Rendered output is unchanged: every substitution expands to the same string.

Stacked on the Windows version resource PR, which introduced the constant.
Base that branch, not master.

## What moved

| Site | Count |
|---|---|
| `proxy` subcommand titles | 9 |
| `doctor`, `update`, `rollback`, `status`, `version` titles | 5 |
| `keys` help prose | 2 |

`USAGE:`/`Usage:` lines are deliberately untouched — those show the command as
typed, which is the lowercase `donsetch`, not the product name.

## Why

A rename is one edit instead of a grep, and the CLI can no longer drift from
the two places the name is already consumed: the Windows `FileDescription`
stamped by `build.rs`, and `serverInfo.title` in the MCP handshake. That drift
is the failure this prevents — three surfaces disagreeing about what the
product is called, with nothing to catch it.

## Type

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — deps, CI, tooling
- [x] `refactor` — no behavior change
- [ ] `test` — tests only

## Checks

- [x] `cargo test --features ocr,rerank -- --test-threads=1` passes\
      (serial run needed: `tests/auth_login.rs` shares one state dir across the
      whole binary, so two logout tests race under parallel execution — pre-existing,
      untouched by this PR)
- [x] `cargo clippy --all-targets --features ocr,rerank -- -Dwarnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes
- [ ] CI is green on all 3 platforms (Linux, macOS, Windows)

## Breaking changes

None. Output is byte-identical — the constant expands to the same literal each
call site held before.

## Test plan

- Rendered a title through the changed path to confirm the output is unchanged:

```
DonSeTch Proxy Configuration
─────────────────────────────────────────────────────────

  No proxies configured.
  Use `donsetch proxy add <url>` to add one.

─────────────────────────────────────────────────────────
```

- `grep -rn "DonSeTch" src/` returns no string literals outside
  `src/display_name.rs`; the remaining hits are doc comments and prose.
- Full suite and clippy as above.
