### PR TITLE
feat(cli): Show the display name in the help header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   read by the CLI titles, the MCP title and build.rs alike : the last by
   `include!`, since a build script cannot `use` items from the crate it
   builds.
+- **`donsetch help` header now reads `DonSeTch`,** not the lowercase
+  `donsetch`: the invocation name is already on the `USAGE:` line below
+  it. Every `USAGE:`/`Usage:` line still shows the command exactly as
+  typed.
 
 ### Fixed
 

--- a/src/cli/tool.rs
+++ b/src/cli/tool.rs
@@ -4,6 +4,7 @@
 //! calls the exact same `call_tool`, and renders the result.
 //! Zero logic duplication : all behavior lives in the core.
 
+use crate::DISPLAY_NAME;
 use crate::mcp::server::{self, Daemon};
 use crate::spec;
 use clap::error::ErrorKind as ClapErrorKind;
@@ -481,7 +482,7 @@ fn machine_meta(result: &Value, sc: &Value) -> Value {
 
 /// Print top-level help (when no subcommand given or --help).
 pub fn print_top_help() {
-    println!("donsetch : web research for AI agents: fetch, search, crawl");
+    println!("{DISPLAY_NAME} : web research for AI agents: fetch, search, crawl");
     println!();
     println!("USAGE: donsetch <command> [args]");
     println!();


### PR DESCRIPTION
# Show the display name in the help header
## Summary

The first line of `donsetch help` is a title, so it now reads `DonSeTch`
instead of the lowercase package id. The invocation name is already on the
`USAGE:` line directly below it, so nothing is lost by using the product name
where a product name belongs.

Stacked on the display-name constant PR. Base that branch, not master.

## The change

```
-donsetch : web research for AI agents: fetch, search, crawl
+DonSeTch : web research for AI agents: fetch, search, crawl

 USAGE: donsetch <command> [args]
```

One line. Every `USAGE:`/`Usage:` line across the CLI still shows the command
exactly as typed, and no other help text changes.

The ` : ` separator is left as it is. It is inconsistent with the second colon
on the same line, but it predates this PR and changing it is a separate
decision.

## Type

- [x] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — deps, CI, tooling
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only

## Checks

- [x] `cargo test --features ocr,rerank -- --test-threads=1` passes\
      (serial run needed: `tests/auth_login.rs` shares one state dir across the
      whole binary, so two logout tests race under parallel execution — pre-existing,
      untouched by this PR)
- [x] `cargo clippy --all-targets --features ocr,rerank -- -Dwarnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes
- [ ] CI is green on all 3 platforms (Linux, macOS, Windows)

## Breaking changes

None for machine consumers: help text is human output, and no command,
subcommand or flag name changes. Anything scraping the first line of `--help`
for the literal `donsetch` would see the new casing.

## Test plan

`donsetch help`, after:

```
DonSeTch : web research for AI agents: fetch, search, crawl

USAGE: donsetch <command> [args]

AGENT TOOLS:
  fetch    Fetch a URL as clean markdown (auto bot-wall bypass, PDF, JS render)
```
