### PR TITLE
fix(extract, pdf): three char-boundary slice panics on non-ASCII metadata (daemon abort)

### DIFF
--- a/src/extract/metadata.rs
+++ b/src/extract/metadata.rs
@@ -95,7 +95,13 @@ fn json_ld_find(doc: &Html, key: &str, subkey: &str) -> Option<String> {
     for script in doc.select(&sel) {
         let text: String = script.text().collect();
         let Some(ki) = text.find(key) else { continue };
-        let region = &text[ki + key.len()..text.len().min(ki + key.len() + 300)];
+        // The window end is a byte offset into text that is usually
+        // raw UTF-8 (only Wikipedia-style output \u-escapes it), so
+        // it must be pulled back onto a char boundary or the slice
+        // panics on an ordinary non-English page.
+        let start = ki + key.len();
+        let end = text.floor_char_boundary(text.len().min(start + 300));
+        let region = &text[start..end];
         let hay = if subkey.is_empty() {
             region
         } else {
@@ -130,8 +136,11 @@ fn decode_unicode_escapes(s: &str) -> String {
     while let Some(pos) = rest.find("\\u") {
         result.push_str(&rest[..pos]);
         rest = &rest[pos + 2..];
-        if rest.len() >= 4
-            && let Ok(code) = u32::from_str_radix(&rest[..4], 16)
+        // `get` (not a slice) : the 4 bytes after \u are only a
+        // valid str if they're ASCII hex, and a multibyte char in
+        // there would otherwise panic the slice.
+        if let Some(hex) = rest.get(..4)
+            && let Ok(code) = u32::from_str_radix(hex, 16)
             && let Some(ch) = char::from_u32(code)
         {
             result.push(ch);
@@ -143,4 +152,43 @@ fn decode_unicode_escapes(s: &str) -> String {
     }
     result.push_str(rest);
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // json_ld_find used to slice the ld+json text at a fixed +300
+    // BYTE offset after the key. Most CMSs emit raw UTF-8 in ld+json
+    // (only Wikipedia-style output \u-escapes it), so on an ordinary
+    // non-English page that offset lands inside a multibyte char
+    // about half the time -- a str-slice panic, which under this
+    // crate's panic = "abort" release profile takes the whole MCP
+    // daemon down on a plain fetch.
+    #[test]
+    fn json_ld_window_end_inside_multibyte_char_does_not_panic() {
+        // One ASCII byte then 3-byte chars: byte 300 after the key is
+        // never a char boundary (boundaries sit at 1 + 3k).
+        let pad: String = std::iter::once('x')
+            .chain(std::iter::repeat_n('年', 150))
+            .collect();
+        let html = format!(
+            r#"<html><head><script type="application/ld+json">{{"author"{pad},"name":"X"}}</script></head><body></body></html>"#
+        );
+        let doc = Html::parse_document(&html);
+        // Must not panic; the value is whatever the tolerant search
+        // finds (or nothing) -- the assertion is that we get here.
+        let _ = json_ld_find(&doc, "\"author\"", "\"name\"");
+        let _ = json_ld_find(&doc, "\"datePublished\"", "");
+    }
+
+    // decode_unicode_escapes sliced `rest[..4]` after every `\u`,
+    // which panics when a multibyte char sits inside those 4 bytes.
+    #[test]
+    fn unicode_escape_decoder_survives_multibyte_after_backslash_u() {
+        // rest = "aëüller": a(1) ë(2) ü(2) -> byte 4 is inside 'ü'.
+        assert_eq!(decode_unicode_escapes("Zo\\uaëüller"), "Zo\\uaëüller");
+        // Still decodes real escapes.
+        assert_eq!(decode_unicode_escapes("\\u7ef4\\u57fa"), "维基");
+    }
 }

--- a/src/pdf/mod.rs
+++ b/src/pdf/mod.rs
@@ -95,7 +95,15 @@ pub struct PageMeta {
 fn pdf_date(raw: &Option<String>) -> Option<String> {
     let r = raw.as_ref()?;
     let d = r.strip_prefix("D:").unwrap_or(r);
-    if d.len() >= 8 && d[..8].chars().all(|c| c.is_ascii_digit()) {
+    // Check the bytes, not a str slice: the Info dict is
+    // producer-controlled and a localized date puts a multibyte
+    // char inside the first 8 bytes, where `d[..8]` would panic.
+    // All-ASCII-digit bytes make the slices below boundary-safe.
+    let leading_digits = d
+        .as_bytes()
+        .get(..8)
+        .is_some_and(|b| b.iter().all(u8::is_ascii_digit));
+    if leading_digits {
         Some(format!("{}-{}-{}", &d[..4], &d[4..6], &d[6..8]))
     } else if r.trim().is_empty() {
         None

--- a/src/pdf/tests.rs
+++ b/src/pdf/tests.rs
@@ -428,3 +428,22 @@ fn pdf_date_normalized() {
         );
     }
 }
+
+// pdf_date sliced `d[..8]` on the raw Info-dict string. A producer
+// writing a localized date (Japanese/Chinese-locale tools do) puts a
+// multibyte char inside the first 8 bytes -- a str-slice panic on a
+// producer-controlled field, which under panic = "abort" takes the
+// daemon down on a plain PDF fetch. No corpus file needed.
+#[test]
+fn pdf_date_non_ascii_does_not_panic() {
+    let raw = Some("D:202605年25日".to_string());
+    assert_eq!(
+        crate::pdf::pdf_date(&raw),
+        Some("D:202605年25日".to_string()),
+        "unparseable dates pass through verbatim"
+    );
+    assert_eq!(
+        crate::pdf::pdf_date(&Some("D:20260525080808+00'00'".to_string())),
+        Some("2026-05-25".to_string())
+    );
+}


### PR DESCRIPTION
## What's broken

Three `str` slices at byte offsets that can land inside a multibyte char. Under this crate's `panic = "abort"` release profile a str-slice panic isn't a failed extraction — it's the MCP daemon exiting mid-fetch. None need a hostile page; an ordinary non-English one does it.

**1. `extract/metadata.rs::json_ld_find`** — fixed +300 *byte* window after the key:
```rust
let region = &text[ki + key.len()..text.len().min(ki + key.len() + 300)];
```
Most CMSs emit raw UTF-8 inside `<script type="application/ld+json">` (only Wikipedia-style output `\u`-escapes it), so on a French/German/CJK page byte 300 is inside a char roughly half the time. Reached on every page that lacks a `<meta name="author">` / `article:published_time` fallback (the `"author"` and `"datePublished"` lookups).

**2. `extract/metadata.rs::decode_unicode_escapes`** — `&rest[..4]` after every `\u`; panics when a multibyte char sits inside those 4 bytes (`"Zo\uaëüller"`).

**3. `pdf/mod.rs::pdf_date`** — `d[..8]` on the Info-dict `CreationDate`/`ModDate`, which is producer-controlled; Japanese/Chinese-locale tools write localized dates (`D:202605年25日`).

The `extract` fuzz target never hit these: each needs an ld+json script + a specific key + a multibyte char at one exact offset.

## Fix

- `json_ld_find`: pull the window end back with `str::floor_char_boundary` (stable on the pinned 1.98). `start` is always a boundary (ASCII key found by `find`), and floor never moves `end` below `start`, so the slice can't invert; only a partial trailing char is ever trimmed, never an ASCII `"`, so output on any previously-working input is identical.
- `decode_unicode_escapes`: `rest.get(..4)` — `None` exactly when the old code would have panicked, falling into the existing keep-literal path.
- `pdf_date`: check the first 8 *bytes* are ASCII digits before slicing; that also guarantees the `..4`/`4..6`/`6..8` slices are boundary-safe. Non-matching dates still pass through verbatim as before.

## Tests

Three regression tests; each fails on the parent commit at exactly the line above (`metadata.rs:98`, `:134`, `pdf/mod.rs:98`) and passes now. The PDF one needs no corpus file.

```
LIBCLANG_PATH=… cargo test --lib -- extract::metadata pdf::tests::pdf_date   # 4 passed
cargo clippy --lib --tests -- -D warnings                                   # clean
cargo fmt --check                                                           # clean
```

- [x] Independent adversarial review: reproduced all three panics against the parent commit's functions in a scratch crate, brute-forced `floor_char_boundary` window/start invariants over 1.19M inputs, differential-tested `pdf_date` old vs new on ASCII inputs, and grepped `src/extract/` + `src/pdf/` for sibling sites of the same class (none — remaining slices are at `find`-returned or ASCII-byte offsets, or already floored)
