### PR TITLE
fix(byok): SerpApi key leaked into search error text via reqwest's error URL

### DIFF
--- a/src/search/byok/bravesearch.rs
+++ b/src/search/byok/bravesearch.rs
@@ -89,13 +89,7 @@ pub async fn search(
         .timeout(TIMEOUT)
         .send()
         .await
-        .map_err(|e| {
-            if e.is_timeout() {
-                KeyError::NetworkError
-            } else {
-                KeyError::UnknownError(format!("network: {e}"))
-            }
-        })?;
+        .map_err(KeyError::from_transport)?;
 
     let status = resp.status().as_u16();
     let text = resp.text().await.unwrap_or_default();

--- a/src/search/byok/brightdata.rs
+++ b/src/search/byok/brightdata.rs
@@ -108,13 +108,7 @@ pub(crate) async fn search(
         .timeout(TIMEOUT)
         .send()
         .await
-        .map_err(|e| {
-            if e.is_timeout() {
-                KeyError::NetworkError
-            } else {
-                KeyError::UnknownError(format!("network: {e}"))
-            }
-        })?;
+        .map_err(KeyError::from_transport)?;
 
     let status = resp.status().as_u16();
     let text = resp.text().await.unwrap_or_default();

--- a/src/search/byok/exa.rs
+++ b/src/search/byok/exa.rs
@@ -52,13 +52,7 @@ pub async fn search(
         .timeout(TIMEOUT)
         .send()
         .await
-        .map_err(|e| {
-            if e.is_timeout() {
-                KeyError::NetworkError
-            } else {
-                KeyError::UnknownError(format!("network: {e}"))
-            }
-        })?;
+        .map_err(KeyError::from_transport)?;
 
     let status = resp.status().as_u16();
     let text = resp.text().await.unwrap_or_default();

--- a/src/search/byok/mod.rs
+++ b/src/search/byok/mod.rs
@@ -89,6 +89,24 @@ impl KeyError {
             Self::ServerError(_) | Self::NetworkError | Self::UnknownError(_) => None,
         }
     }
+
+    /// The one place a transport failure becomes a KeyError.
+    ///
+    /// `reqwest::Error`'s Display includes the full request URL,
+    /// query string and all. SerpApi's API takes the key as
+    /// `?api_key=`, so rendering that error verbatim put the whole
+    /// key into `last_error`, and from there into the MCP search
+    /// error the model sees, the CLI's stderr and the DONSEEK_DEBUG
+    /// log on any non-timeout transport failure (DNS, refused, TLS).
+    /// The URL adds nothing here anyway: the provider name is
+    /// prepended by the caller and the endpoint is a constant.
+    pub(crate) fn from_transport(e: reqwest::Error) -> Self {
+        if e.is_timeout() {
+            Self::NetworkError
+        } else {
+            Self::UnknownError(format!("network: {}", e.without_url()))
+        }
+    }
 }
 
 impl std::fmt::Display for KeyError {
@@ -377,6 +395,37 @@ mod tests {
         assert_eq!(KeyError::ServerError("500".into()).to_key_state(), None);
         assert_eq!(KeyError::NetworkError.to_key_state(), None);
         assert_eq!(KeyError::UnknownError("x".into()).to_key_state(), None);
+    }
+
+    // A real transport error from a refused loopback connect, with the
+    // key where SerpApi's API puts it (the query string). The raw
+    // reqwest error renders the full URL, so this is exactly the path
+    // that used to put the key into the model-visible search error.
+    #[tokio::test]
+    async fn transport_errors_never_carry_the_request_url() {
+        const KEY: &str = "SUPERSECRETKEY123";
+        // no_proxy: a reachable HTTP_PROXY in the environment would
+        // turn the refused connect into a 502 *response*.
+        let client = reqwest::Client::builder()
+            .no_proxy()
+            .build()
+            .expect("client");
+        let err = client
+            .get("http://127.0.0.1:1/search")
+            .query(&[("q", "hello"), ("api_key", KEY)])
+            .send()
+            .await
+            .expect_err("nothing listens on port 1");
+        assert!(!err.is_timeout(), "connection refused, not a timeout");
+        // Sanity: the unredacted error really does carry the key,
+        // otherwise this test proves nothing.
+        assert!(err.to_string().contains(KEY));
+        let mapped = KeyError::from_transport(err);
+        assert!(
+            !mapped.to_string().contains(KEY),
+            "key leaked into KeyError: {mapped}"
+        );
+        assert!(matches!(mapped, KeyError::UnknownError(_)));
     }
 
     #[test]

--- a/src/search/byok/parallel.rs
+++ b/src/search/byok/parallel.rs
@@ -50,13 +50,7 @@ pub async fn search(
         .timeout(TIMEOUT)
         .send()
         .await
-        .map_err(|e| {
-            if e.is_timeout() {
-                KeyError::NetworkError
-            } else {
-                KeyError::UnknownError(format!("network: {e}"))
-            }
-        })?;
+        .map_err(KeyError::from_transport)?;
 
     let status = resp.status().as_u16();
     let text = resp.text().await.unwrap_or_default();

--- a/src/search/byok/serpapi.rs
+++ b/src/search/byok/serpapi.rs
@@ -99,13 +99,7 @@ pub async fn search(
         .timeout(TIMEOUT)
         .send()
         .await
-        .map_err(|e| {
-            if e.is_timeout() {
-                KeyError::NetworkError
-            } else {
-                KeyError::UnknownError(format!("network: {e}"))
-            }
-        })?;
+        .map_err(KeyError::from_transport)?;
 
     let status = resp.status().as_u16();
     let text = resp.text().await.unwrap_or_default();

--- a/src/search/byok/serpbase.rs
+++ b/src/search/byok/serpbase.rs
@@ -90,13 +90,7 @@ pub async fn search(
         .timeout(TIMEOUT)
         .send()
         .await
-        .map_err(|e| {
-            if e.is_timeout() {
-                KeyError::NetworkError
-            } else {
-                KeyError::UnknownError(format!("network: {e}"))
-            }
-        })?;
+        .map_err(KeyError::from_transport)?;
 
     let status = resp.status().as_u16();
     let text = resp.text().await.unwrap_or_default();

--- a/src/search/byok/serper.rs
+++ b/src/search/byok/serper.rs
@@ -46,13 +46,7 @@ pub async fn search(
         .timeout(TIMEOUT)
         .send()
         .await
-        .map_err(|e| {
-            if e.is_timeout() {
-                KeyError::NetworkError
-            } else {
-                KeyError::UnknownError(format!("network: {e}"))
-            }
-        })?;
+        .map_err(KeyError::from_transport)?;
 
     let status = resp.status().as_u16();
     let text = resp.text().await.unwrap_or_default();

--- a/src/search/byok/tavily.rs
+++ b/src/search/byok/tavily.rs
@@ -45,13 +45,7 @@ pub async fn search(
         .timeout(TIMEOUT)
         .send()
         .await
-        .map_err(|e| {
-            if e.is_timeout() {
-                KeyError::NetworkError
-            } else {
-                KeyError::UnknownError(format!("network: {e}"))
-            }
-        })?;
+        .map_err(KeyError::from_transport)?;
 
     let status = resp.status().as_u16();
     let text = resp.text().await.unwrap_or_default();

--- a/src/search/byok/tinyfish.rs
+++ b/src/search/byok/tinyfish.rs
@@ -44,13 +44,7 @@ pub async fn search(
         .timeout(TIMEOUT)
         .send()
         .await
-        .map_err(|e| {
-            if e.is_timeout() {
-                KeyError::NetworkError
-            } else {
-                KeyError::UnknownError(format!("network: {e}"))
-            }
-        })?;
+        .map_err(KeyError::from_transport)?;
 
     let status = resp.status().as_u16();
     let text = resp.text().await.unwrap_or_default();


### PR DESCRIPTION
## What's broken

SerpApi's API takes the key as a query parameter, so `serpapi.rs` (my own adapter from #82, mirrored from `serper.rs`) sends `?api_key=<key>`. Every BYOK adapter mapped a transport failure with:

```rust
KeyError::UnknownError(format!("network: {e}"))
```

`reqwest::Error`'s Display includes the full request URL, query string and all — only `user:pass@` userinfo is redacted. Verified against the pinned `reqwest 0.12.28` on a refused connect:

```
error sending request for url (http://127.0.0.1:1/search?q=hello&api_key=SUPERSECRETKEY123)
```

So on any non-timeout transport failure (DNS error, connection refused, TLS error, captive portal) the SerpApi key went verbatim into `last_error` (`byok/mod.rs`) and from there into user-visible sinks:

- **local-first + BYOK-fallback mode**: `search_outcome`'s `cause = "local (…); byok (…)"` → the MCP search error's text content (i.e. the model's context), batch search's `searches[].error` / `_meta` diagnostics, the CLI's stderr and `--json` `error.message`.
- **every mode**: the `DONSEEK_DEBUG` line in `byok/mod.rs`, right after one that deliberately truncates the key to 8 chars.

Only SerpApi is affected today — the other eight providers send the key in a header. The serper.rs pattern I copied was safe only for that reason.

## Fix

Fixed at the shared boundary so a future query-param provider can't reintroduce it: one `KeyError::from_transport(reqwest::Error)` using `reqwest::Error::without_url()`, adopted by all nine adapters (each was the same 7-line closure; semantics otherwise unchanged — timeout → `NetworkError`, else `UnknownError("network: …")`). The URL carried no diagnostic value: the endpoint is a constant and the caller prepends the provider name. reqwest's `source()` chain only ever names the socket address, never the URL, and nothing in `src/` formats these errors with `{:?}` or walks `source()`.

## Test

`transport_errors_never_carry_the_request_url` drives a real refused-connect error (`no_proxy()`, so an `HTTP_PROXY` in the environment can't turn it into a 502 response) with the key in the query string, asserts the *unredacted* error does contain it (so the test is proving something), and that the mapped `KeyError` does not.

```
LIBCLANG_PATH=… cargo test --lib -- search::byok::tests   # 6 passed
cargo clippy --lib --tests -- -D warnings                 # clean
cargo fmt --check                                         # clean
```

- [x] Independent adversarial review: re-traced the leak from `serpapi.rs` through `mod.rs` into `mcp/server.rs` and `cli/tool.rs` per mode, verified `without_url()` on 0.12.28 (Display and Debug both drop the URL; source chain carries only the socket addr), checked every other `reqwest::Error` stringification site in `src/` for URL-borne credentials (none), confirmed no test/log parser matched the old message shape.

## Noted, not changed here

The generic non-2xx branches in the adapters echo the response body (`HTTP {status}: {text}`). A captive portal or proxy that reflects the request line into its 4xx body would put the query string back into the error. Lower likelihood; flagging in case you'd like a body-redaction follow-up.
