### PR TITLE
fix(extract): tables lost every <th scope="row"> label and mis-aligned the row

### DIFF
--- a/src/extract/blocks.rs
+++ b/src/extract/blocks.rs
@@ -558,18 +558,31 @@ fn table_block(el: ElementRef<'_>, headings: &[(u8, String)]) -> Option<Block> {
             truncated = true;
             break;
         }
-        let cells: Vec<String> = tr
-            .select(&scraper::Selector::parse("th").unwrap())
-            .map(|c| inline::plain(c).replace('|', "\\|"))
+        // One select over both cell kinds, in document order: a
+        // row's <th scope="row"> label has to stay in its column.
+        // Selecting <th> and <td> separately (the old shape) only
+        // ever used <th> for the header row, so every data row's
+        // label vanished and its remaining cells shifted left.
+        let cells: Vec<(bool, String)> = tr
+            .select(&scraper::Selector::parse("th, td").unwrap())
+            .map(|c| {
+                let is_th = c.value().name() == "th";
+                let t = inline::plain(c).replace('|', "\\|"); // unescaped pipes break md tables
+                (is_th, t)
+            })
             .collect();
-        if !cells.is_empty() && headers.is_empty() && rows.is_empty() {
-            headers = cells;
+        // The header row is the first row made only of <th>.
+        if headers.is_empty()
+            && rows.is_empty()
+            && !cells.is_empty()
+            && cells.iter().all(|(is_th, _)| *is_th)
+        {
+            headers = cells.into_iter().map(|(_, t)| t).collect();
             continue;
         }
-        let row: Vec<String> = tr
-            .select(&scraper::Selector::parse("td").unwrap())
-            .map(|c| {
-                let t = inline::plain(c).replace('|', "\\|"); // unescaped pipes break md tables
+        let row: Vec<String> = cells
+            .into_iter()
+            .map(|(_, t)| {
                 // Char-based truncation: byte-based cuts CJK at ~40
                 // chars (3 bytes/char). 120 chars is the real limit.
                 if t.chars().count() > 120 {

--- a/src/extract/tests.rs
+++ b/src/extract/tests.rs
@@ -1661,6 +1661,57 @@ fn table_without_th_promotes_first_row() {
 }
 
 // ════════════════════════════════════════════════════════════
+// 24b. TABLE ROW HEADERS (<th scope="row">) ARE KEPT
+// ════════════════════════════════════════════════════════════
+
+// The standard accessible markup for a data table labels each row
+// with a <th scope="row">. table_block collected <th> and <td> with
+// two separate selects and only ever used <th> cells for the single
+// header row, so every later row silently lost its label and its
+// remaining cells shifted one column left.
+#[test]
+fn table_row_header_cells_are_kept_in_data_rows() {
+    let html = r#"<html><body><article>
+<table>
+<tr><th></th><th>2022</th><th>2023</th></tr>
+<tr><th scope="row">Revenue</th><td>10</td><td>20</td></tr>
+<tr><th scope="row">Costs</th><td>7</td><td>9</td></tr>
+</table>
+</article></body></html>"#;
+    let r = extract_html(html);
+    assert!(
+        r.markdown.contains("| Revenue | 10 | 20 |"),
+        "row label dropped:\n{}",
+        r.markdown
+    );
+    assert!(r.markdown.contains("| Costs | 7 | 9 |"));
+}
+
+// A first row that mixes <th> and <td> is a data row, not a header
+// row; its <td> cells must not be thrown away.
+#[test]
+fn table_mixed_first_row_keeps_td_cells() {
+    let html = r#"<html><body><article>
+<table>
+<tr><th>Language</th><td>Rust</td></tr>
+<tr><th>License</th><td>MIT</td></tr>
+<tr><th>Since</th><td>2015</td></tr>
+</table>
+</article></body></html>"#;
+    let r = extract_html(html);
+    assert!(
+        r.markdown.contains("Rust") && r.markdown.contains("MIT") && r.markdown.contains("2015"),
+        "td cells dropped:\n{}",
+        r.markdown
+    );
+    assert!(
+        r.markdown.contains("| License | MIT |"),
+        "label/value pairing lost:\n{}",
+        r.markdown
+    );
+}
+
+// ════════════════════════════════════════════════════════════
 // 25. TABLE CELL TRUNCATION : CHAR-BASED (CJK)
 // ════════════════════════════════════════════════════════════
 


### PR DESCRIPTION
## What's broken

`table_block` collected a row's `<th>` cells and `<td>` cells with two separate selects, used the `<th>` set only for the single header row, and then discarded `<th>` on every later row. `<th scope="row">` is the standard accessible markup for labelling data rows (MDN's recommended form), so on any such table:

```html
<tr><th></th><th>2022</th><th>2023</th></tr>
<tr><th scope="row">Revenue</th><td>10</td><td>20</td></tr>
```

rendered as `| 10 | 20 |` — the label gone and every remaining cell shifted one column left under the wrong year. A `<th>`/`<td>` key-value table (`<tr><th>License</th><td>MIT</td></tr>`) lost all of its keys, and a first row that mixed `<th>` and `<td>` lost its `<td>` cells.

## Fix

One `th, td` select per `<tr>` in document order (scraper's `Select` is a pre-order tree walk filtered by the selector list — it never groups by alternative). The first row consisting only of `<th>` is the header row; every other row is a data row with all its cells in place.

Behaviour deltas beyond the bug, both trading silent data loss for visible content:
- A `<th>`-only row later in the table (a mid-table section label) used to become an empty row and be dropped; it's now kept as a data row.
- A key-value table with no all-`<th>` row now has its first pair promoted to headers by the existing "no `<th>` → promote first row" path (`| Language | Rust |`), instead of losing every key.

Nested-table cell duplication is pre-existing (the old descendant selects had it too) and unchanged in kind.

## Tests

Two regression tests; both fail on the parent (old output has no `Revenue` substring and drops `Rust` entirely). All 118 `extract::tests` pass.

```
LIBCLANG_PATH=… cargo test --lib -- extract::tests   # 118 passed
cargo clippy --lib --tests -- -D warnings            # clean
cargo fmt --check                                    # clean
```

- [x] Independent adversarial review: proved document-order iteration from the scraper 0.27 / ego-tree 0.11 sources, exercised caption/colgroup/nested-table/empty-`<th>` cases against a rebuilt binary, confirmed the only other `th`/`td`-splitting site (`adapters/wiki_infobox.rs`) is intentional key-value handling
