### PR TITLE
fix(proxy): a password containing '@' split the proxy URL at the wrong '@'

### DIFF
--- a/src/transport/proxy.rs
+++ b/src/transport/proxy.rs
@@ -90,8 +90,10 @@ impl Proxy {
             (ProxyScheme::Http, s)
         };
 
-        // Split auth@addr : auth is optional.
-        let (user, pass, addr) = match rest.split_once('@') {
+        // Split auth@addr : auth is optional. The address (host:port)
+        // can never contain '@', so split at the LAST one: user and
+        // password both may.
+        let (user, pass, addr) = match rest.rsplit_once('@') {
             Some((auth, addr)) => {
                 let (u, p) = auth
                     .split_once(':')
@@ -685,6 +687,37 @@ mod tests {
         assert!(Proxy::parse("garbage").is_err());
         assert!(Proxy::parse("u:p@bad").is_err());
         assert!(Proxy::parse("u:p@host:99999").is_err());
+    }
+
+    // Auth was split from the address at the FIRST '@', so a
+    // password containing one ("p@ss") ended up as pass="p" and
+    // host="ss@1.2.3.4": accepted by `proxy add`, stored, and then
+    // unreachable. The address can never contain '@' (host:port),
+    // so the LAST '@' is the only correct split point.
+    #[test]
+    fn parse_password_containing_at() {
+        let p = Proxy::parse("socks5://alice:p@ss@1.2.3.4:1080").unwrap();
+        assert_eq!(p.user, "alice");
+        assert_eq!(p.pass, "p@ss");
+        assert_eq!(p.host, "1.2.3.4");
+        assert_eq!(p.port, 1080);
+        // Round trip through to_url keeps the password whole.
+        let p2 = Proxy::parse(&p.to_url()).unwrap();
+        assert_eq!(p2.pass, "p@ss");
+        assert_eq!(p2.host, "1.2.3.4");
+    }
+
+    #[test]
+    fn parse_user_and_password_containing_at_with_ipv6() {
+        let p = Proxy::parse("http://me@corp:p@ss:w0rd@[::1]:3128").unwrap();
+        assert_eq!(p.user, "me@corp");
+        assert_eq!(p.pass, "p@ss:w0rd");
+        assert_eq!(p.host, "::1");
+        assert_eq!(p.port, 3128);
+        let p2 = Proxy::parse(&p.to_url()).unwrap();
+        assert_eq!(p2.user, "me@corp");
+        assert_eq!(p2.pass, "p@ss:w0rd");
+        assert_eq!(p2.host, "::1");
     }
 
     #[test]


### PR DESCRIPTION
## What's broken

`Proxy::parse` separated auth from the address with `split_once('@')` — the **first** `@`:

```
socks5://alice:p@ss@1.2.3.4:1080
   → user = "alice", pass = "p", host = "ss@1.2.3.4"
```

That's accepted by `proxy add`, written to `proxies.txt`, and then permanently unreachable — `proxy check` just reports the garbled host as down. A username containing `@` (`me@corp`, common on corporate proxies) fails the same way. Every ingress goes through this one function: `proxy add`, `proxy import`, `proxies.txt`, `DONSEEK_PROXIES`.

## Fix

The address is always `host:port` and can never contain `@`, so the **last** `@` is the only correct split point: `rsplit_once`. `to_url()` already reconstructs `user:pass@host:port`, so it round-trips unchanged (both new tests assert that). The only other `@`-split in `src/` (`search/mod.rs`, an engine@egress label) is unrelated.

Two regression tests — password with `@`; user and password both with `@` plus an IPv6 host — fail on the previous code (`left: "p", right: "p@ss"`). All 28 `transport::proxy` tests pass.

```
LIBCLANG_PATH=… cargo test --lib -- transport::proxy::tests   # 28 passed
cargo clippy --lib --tests -- -D warnings                      # clean
cargo fmt --check                                              # clean
```

Not changed: the `bad addr`/`bad port` error strings still echo the raw input (`{s}`), which on a malformed line includes the password — worth a follow-up if you'd like those redacted.
