### PR TITLE
fix(keys, proxy): credential files were created world-readable, then chmod'ed

### DIFF
--- a/src/cli/keys.rs
+++ b/src/cli/keys.rs
@@ -649,13 +649,12 @@ fn cmd_export(args: &[String]) {
         }
         Some(path) => {
             let p = std::path::Path::new(path);
-            match std::fs::write(p, &json) {
+            // Owner-only from creation: this file holds every key.
+            // (Write-then-chmod left it world-readable until the
+            // chmod, and for good if the chmod failed -- while the
+            // line below still claimed 0600.)
+            match crate::config::write_private(p, json.as_bytes()) {
                 Ok(_) => {
-                    #[cfg(unix)]
-                    {
-                        use std::os::unix::fs::PermissionsExt;
-                        let _ = std::fs::set_permissions(p, std::fs::Permissions::from_mode(0o600));
-                    }
                     let n_providers = cfg.providers.len();
                     let n_keys: usize = cfg.providers.iter().map(|p| p.keys.len()).sum();
                     println!(

--- a/src/cli/proxy.rs
+++ b/src/cli/proxy.rs
@@ -555,7 +555,9 @@ async fn cmd_export(args: &[String]) {
             } else {
                 format!("{content}\n")
             };
-            match std::fs::write(path, &content) {
+            // Lines are `scheme://user:pass@host:port`: owner-only
+            // from creation, like the config file it came from.
+            match crate::config::write_private(std::path::Path::new(path), content.as_bytes()) {
                 Ok(()) => {
                     let n = proxies.len();
                     let word = if n == 1 { "proxy" } else { "proxies" };

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,38 @@ pub(crate) fn env_flag(name: &str) -> bool {
     env_flag_value(std::env::var_os(name).as_deref())
 }
 
+/// Write a file that holds credentials (API keys, proxy passwords)
+/// so that it is owner-only from the moment it exists.
+///
+/// `fs::write` followed by `set_permissions` creates the file at the
+/// umask default (0644 on most systems) and only tightens it after
+/// the secret has already landed: a world-readable window, and a
+/// world-readable file for good if anything fails in between. This
+/// opens with mode 0600 up front, then also re-applies 0600 for the
+/// case where the file already existed with looser permissions
+/// (`mode` on open only affects creation). Non-Unix: plain write.
+pub(crate) fn write_private(path: &std::path::Path, bytes: &[u8]) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::io::Write;
+        use std::os::unix::fs::OpenOptionsExt;
+        use std::os::unix::fs::PermissionsExt;
+        let mut f = std::fs::OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .mode(0o600)
+            .open(path)?;
+        f.set_permissions(std::fs::Permissions::from_mode(0o600))?;
+        f.write_all(bytes)?;
+        f.flush()
+    }
+    #[cfg(not(unix))]
+    {
+        std::fs::write(path, bytes)
+    }
+}
+
 fn env_flag_value(value: Option<&OsStr>) -> bool {
     value
         .and_then(OsStr::to_str)
@@ -58,5 +90,54 @@ mod tests {
         use std::os::unix::ffi::OsStrExt;
 
         assert!(!env_flag_value(Some(OsStr::from_bytes(b"true\xff"))));
+    }
+
+    #[cfg(unix)]
+    fn mode_of(p: &std::path::Path) -> u32 {
+        use std::os::unix::fs::PermissionsExt;
+        std::fs::metadata(p).unwrap().permissions().mode() & 0o777
+    }
+
+    // A fresh file must be 0600 from the moment it exists (not
+    // created at the umask default and chmod'ed afterwards, which
+    // leaves a world-readable window and a world-readable file on
+    // any crash in between).
+    #[cfg(unix)]
+    #[test]
+    fn write_private_creates_owner_only() {
+        let dir =
+            std::env::temp_dir().join(format!("donsetch-write-private-{}-new", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let p = dir.join("secret.json");
+
+        write_private(&p, b"{\"key\":\"s3cr3t\"}").unwrap();
+
+        assert_eq!(mode_of(&p), 0o600);
+        assert_eq!(std::fs::read(&p).unwrap(), b"{\"key\":\"s3cr3t\"}");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // An existing world-readable file (e.g. an export written by an
+    // older build) is tightened as well as truncated and rewritten.
+    #[cfg(unix)]
+    #[test]
+    fn write_private_tightens_an_existing_file() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = std::env::temp_dir().join(format!(
+            "donsetch-write-private-{}-existing",
+            std::process::id()
+        ));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).unwrap();
+        let p = dir.join("secret.json");
+        std::fs::write(&p, "old and longer content").unwrap();
+        std::fs::set_permissions(&p, std::fs::Permissions::from_mode(0o644)).unwrap();
+
+        write_private(&p, b"new").unwrap();
+
+        assert_eq!(mode_of(&p), 0o600);
+        assert_eq!(std::fs::read(&p).unwrap(), b"new");
+        let _ = std::fs::remove_dir_all(&dir);
     }
 }

--- a/src/transport/proxy.rs
+++ b/src/transport/proxy.rs
@@ -526,12 +526,10 @@ pub fn save_config(proxies: &[Proxy]) -> std::io::Result<()> {
         content.push('\n');
     }
     let tmp = path.with_extension("txt.tmp");
-    std::fs::write(&tmp, &content)?;
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::set_permissions(&tmp, std::fs::Permissions::from_mode(0o600))?;
-    }
+    // 0600 from creation: write-then-chmod left `proxies.txt.tmp`
+    // (passwords inside) world-readable between the two calls, and
+    // permanently on a crash in between.
+    crate::config::write_private(&tmp, content.as_bytes())?;
     std::fs::rename(&tmp, &path)?;
     Ok(())
 }


### PR DESCRIPTION
## What's broken

Three places wrote secrets with `fs::write` (umask default — 0644 on most systems) and tightened permissions afterwards, or not at all:

| Site | Contents | Old behaviour |
|---|---|---|
| `donsetch keys export <path>` | every API key | write, then `set_permissions(0600)` with the result discarded — then an unconditional "file permissions set to 0600 (owner-only)" line even when the chmod had failed |
| `donsetch proxy export <path>` | `scheme://user:pass@host:port` lines | plain `fs::write`, no permission handling |
| `transport/proxy.rs::save_config` (the live proxy store) | proxy passwords | `proxies.txt.tmp` written, *then* chmod'ed, then renamed — world-readable between the first two, and for good if the process died in between |

This is exactly the class `byok/store.rs::save` already fixed for the key store ("the old write-then-chmod path left a world-readable file behind on any crash").

## Fix

One helper, `config::write_private`: opens with `mode(0o600)` **before** any byte lands (`open(2)` applies `mode & ~umask`, so it can never come out more permissive), then `fchmod(0600)` on the open handle for the case where the file already existed with looser permissions (`mode` only affects creation), then writes. All three sites use it; `keys export` only prints the 0600 line when the write actually succeeded. `save_config` keeps its tmp→rename shape (rename preserves the inode's mode).

Tests: a fresh file is 0600 from creation; a pre-existing 0644 file is tightened as well as rewritten. The assertions hold under any umask (fchmod normalizes to exactly 0600) and POSIX default ACLs.

```
LIBCLANG_PATH=… cargo test --lib -- config::tests transport::proxy::tests   # 30 passed
cargo clippy --lib --tests -- -D warnings                                   # clean
cargo fmt --check                                                           # clean
```

- [x] Independent adversarial review: checked `mode`/umask/ACL semantics, the truncate-then-fchmod ordering (no exposure — old content is gone, new not yet written), symlink following (pre-existing, same as `fs::write`), and grepped every other secret-bearing write in `src/` — `auth.rs`, `ghost/cache.rs` vault, `byok/store.rs`, `byok/plugin.rs` all already do 0600-before-content; no remaining write-then-chmod site.

Optional follow-up: `auth.rs::save` and `ghost/cache.rs`'s vault save hand-roll the same pattern and could adopt the helper.
