### PR TITLE
fix(extract): must_contain excerpts pointed past the match on non-ASCII pages

### DIFF
--- a/src/extract/mod.rs
+++ b/src/extract/mod.rs
@@ -1083,61 +1083,97 @@ pub fn probe_render(text: &str, pattern: &str, is_regex: bool) -> String {
         }
     };
 
-    if is_regex {
-        match regex::RegexBuilder::new(pattern)
-            .case_insensitive(true)
-            .size_limit(1 << 20)
-            .build()
-        {
-            Ok(re) => {
-                let hits: Vec<(usize, usize)> = re
-                    .find_iter(text)
-                    .map(|m| (m.start(), m.end()))
-                    .take(50)
-                    .collect();
-                report(Some(hits))
-            }
-            Err(_) => report(None),
-        }
+    // Both modes go through one case-insensitive regex so every hit
+    // is a byte offset into `text` itself. The old substring path
+    // searched a separately lowercased copy, whose offsets drift
+    // from the real text as soon as case folding changes a byte
+    // length ('İ' -> "i̇"); and both paths then fed those BYTE
+    // offsets to a context window that treated them as CHAR indices,
+    // so on any page with non-ASCII text before the hit the excerpt
+    // landed after the match and did not contain it.
+    let source = if is_regex {
+        std::borrow::Cow::Borrowed(pattern)
     } else {
-        // Case-insensitive substring: lowercase both sides on
-        // ASCII (the dominant case) without allocating a regex.
-        let hay = text.to_lowercase();
-        let needle = pattern.to_lowercase();
-        let mut hits = Vec::new();
-        let mut from = 0;
-        while let Some(pos) = hay[from..].find(&needle) {
-            hits.push((from + pos, from + pos + needle.len()));
-            from += pos + needle.len().max(1);
-            if hits.len() >= 50 {
-                break;
-            }
+        std::borrow::Cow::Owned(regex::escape(pattern))
+    };
+    match regex::RegexBuilder::new(&source)
+        .case_insensitive(true)
+        .size_limit(1 << 20)
+        .build()
+    {
+        Ok(re) => {
+            let hits: Vec<(usize, usize)> = re
+                .find_iter(text)
+                .map(|m| (m.start(), m.end()))
+                .take(50)
+                .collect();
+            report(Some(hits))
         }
-        report(Some(hits))
+        // A literal can only fail to build by blowing the size
+        // limit (a multi-KB pattern under (?i) expands into Unicode
+        // classes); it is never "invalid", so search it as bytes
+        // instead. ASCII case-insensitive is the honest fallback:
+        // non-ASCII bytes must match exactly, which also keeps every
+        // hit on a char boundary.
+        Err(_) if !is_regex => report(Some(literal_hits(text, pattern))),
+        Err(_) => report(None),
     }
 }
 
-/// One-line context window around a match, ellipsized and
-/// whitespace-collapsed.
-fn context_around(text: &str, start: usize, end: usize, pad: usize) -> String {
-    let char_count = text.chars().count();
-    let lo = start.saturating_sub(pad);
-    let hi = (end + pad).min(char_count);
-    // Convert char indices to byte indices safely.
-    let byte_lo = char_to_byte(text, lo);
-    let byte_hi = char_to_byte(text, hi);
-    let window = &text[byte_lo..byte_hi];
-    let collapsed: String = window.split_whitespace().collect::<Vec<_>>().join(" ");
-    let prefix = if lo > 0 { "…" } else { "" };
-    let suffix = if hi < char_count { "…" } else { "" };
-    format!("{prefix}{collapsed}{suffix}")
+/// Byte-window search for a literal `needle` in `text`, ASCII
+/// case-insensitive. Non-ASCII bytes compare exactly, so a match
+/// start is always a char boundary (a UTF-8 lead byte or ASCII, never
+/// a continuation byte) and `start + needle.len()` is too.
+fn literal_hits(text: &str, needle: &str) -> Vec<(usize, usize)> {
+    let (hay, nb) = (text.as_bytes(), needle.as_bytes());
+    if nb.is_empty() || nb.len() > hay.len() {
+        return Vec::new();
+    }
+    let mut hits = Vec::new();
+    let mut from = 0;
+    while from + nb.len() <= hay.len() {
+        match hay[from..]
+            .windows(nb.len())
+            .position(|w| w.eq_ignore_ascii_case(nb))
+        {
+            Some(pos) => {
+                let start = from + pos;
+                hits.push((start, start + nb.len()));
+                from = start + nb.len();
+                if hits.len() >= 50 {
+                    break;
+                }
+            }
+            None => break,
+        }
+    }
+    hits
 }
 
-fn char_to_byte(text: &str, char_idx: usize) -> usize {
-    text.char_indices()
-        .nth(char_idx)
-        .map(|(b, _)| b)
-        .unwrap_or(text.len())
+/// One-line context window around a match, ellipsized and
+/// whitespace-collapsed. `start`/`end` are BYTE offsets into `text`
+/// (char boundaries, as regex matches are); `pad` is in chars.
+fn context_around(text: &str, start: usize, end: usize, pad: usize) -> String {
+    let byte_lo = if pad == 0 {
+        start
+    } else {
+        text[..start]
+            .char_indices()
+            .rev()
+            .nth(pad - 1)
+            .map(|(b, _)| b)
+            .unwrap_or(0)
+    };
+    let byte_hi = text[end..]
+        .char_indices()
+        .nth(pad)
+        .map(|(b, _)| end + b)
+        .unwrap_or(text.len());
+    let window = &text[byte_lo..byte_hi];
+    let collapsed: String = window.split_whitespace().collect::<Vec<_>>().join(" ");
+    let prefix = if byte_lo > 0 { "…" } else { "" };
+    let suffix = if byte_hi < text.len() { "…" } else { "" };
+    format!("{prefix}{collapsed}{suffix}")
 }
 
 /// One-line accounting of what the focus filter dropped: block

--- a/src/extract/tests.rs
+++ b/src/extract/tests.rs
@@ -2097,6 +2097,61 @@ fn must_contain_probe_applies_to_plain_text_passthrough() {
     assert!(out.markdown.len() < 400, "len {}", out.markdown.len());
 }
 
+// Hits were BYTE offsets (regex m.start(), or offsets into a
+// separately lowercased haystack), but context_around treated them
+// as CHAR indices. On any page with non-ASCII text before the match
+// the excerpt window landed after the real hit -- "MATCH: 1 hit"
+// followed by an excerpt that doesn't contain the pattern.
+fn probe_excerpt(text: &str, pattern: &str) -> String {
+    let opts = ExtractOptions {
+        must_contain: Some(pattern.into()),
+        ..Default::default()
+    };
+    let out = probe_render(text, opts.probe_pattern(), opts.probe_is_regex());
+    assert!(out.starts_with("probe: MATCH"), "{out}");
+    out.lines()
+        .find(|l| l.starts_with("[1]"))
+        .unwrap_or_else(|| panic!("no excerpt line:\n{out}"))
+        .to_string()
+}
+
+#[test]
+fn probe_excerpt_points_at_the_hit_on_non_ascii_pages() {
+    let prefix = "Асинхронная среда выполнения для языка Rust. ".repeat(6);
+    let text = format!("{prefix}The tokio runtime schedules tasks. {prefix}");
+    let sub = probe_excerpt(&text, "tokio runtime");
+    assert!(sub.contains("tokio runtime"), "substring excerpt: {sub}");
+    let re = probe_excerpt(&text, "/tokio\\s+runtime/");
+    assert!(re.contains("tokio runtime"), "regex excerpt: {re}");
+}
+
+#[test]
+fn probe_excerpt_survives_case_folding_that_changes_byte_length() {
+    // 'İ' (2 bytes) lowercases to "i̇" (3 bytes): the old lowercased
+    // haystack drifted further from the real text with every one.
+    let prefix = "İSTANBUL İZMİR İÇEL ".repeat(40);
+    let text = format!("{prefix}Needle here. {prefix}");
+    let sub = probe_excerpt(&text, "needle");
+    assert!(sub.contains("Needle"), "excerpt: {sub}");
+}
+
+// A multi-KB substring pattern expands past the regex size limit
+// under (?i); it must still be searched as a literal, not reported
+// as an "invalid regex".
+#[test]
+fn probe_substring_longer_than_the_regex_size_limit_still_matches() {
+    let needle = "проверка ".repeat(800); // ~14 KB, Cyrillic
+    let text = format!("intro {needle} outro");
+    let out = probe_render(&text, needle.trim_end(), false);
+    assert!(
+        out.starts_with("probe: MATCH : 1 hit"),
+        "{}",
+        &out[..out.len().min(120)]
+    );
+    let miss = probe_render("nothing here", needle.trim_end(), false);
+    assert!(miss.starts_with("probe: NO MATCH"), "{miss}");
+}
+
 /// Issue #49: links and formatting nested inside em/strong were
 /// flattened away by `plain()`. Nested inline markup must survive:
 /// `<em>A <strong><a>B</a></strong> C</em>` → `*A **[B](url)** C*`.


### PR DESCRIPTION
## What's broken

`probe_render` collected hits as **byte** offsets — regex `m.start()/m.end()`, or offsets into a separately lowercased copy of the text in substring mode — and `context_around` then treated them as **char** indices (`char_to_byte(text, start - pad)`). The two agree only while every char before the hit is one byte. On a Russian, German, CJK or emoji-bearing page the window landed after the real match:

```
probe: MATCH : 1 hit for "tokio runtime"
[1] …Rust. Асинхронная среда выполнения для языка Rust. Асинхронная среда …
```

— a MATCH whose excerpt doesn't contain the pattern. Substring mode drifted further still whenever case folding changes a byte length (`İ` → `i̇`), since the lowercased haystack's offsets never corresponded to the original text at all. The verdict and hit count were right; the "up to three excerpts" `spec.rs` promises were wrong, and those are what the agent reads.

## Fix

Both modes now run one case-insensitive regex (the substring pattern through `regex::escape`), so every hit is a byte offset into the real text, and `context_around` pads by chars *around* those byte offsets instead of reinterpreting them. If a multi-KB substring literal exceeds the regex size limit (under `(?i)` it expands into Unicode classes — ~5.5 K Cyrillic or ~13 K Latin chars), it falls back to a byte-window literal search rather than reporting a substring as an "invalid regex".

Substring mode's case handling moves from full lowercase mapping to Unicode simple case folding; the reviewer's exhaustive single-char scan found the only realistic visible difference is Greek final sigma now matching medial sigma (ß/İ/ı/Kelvin behave as before). It also removed a latent panic in the old substring loop on an empty pattern.

## Tests

Three new: a Cyrillic-prefixed page in both modes, an `İ`-heavy page, and a 14 KB literal. The first two report MATCH with an excerpt missing the pattern on the previous code. All 119 `extract::tests` and the offline `token_invariants` integration tests (which exercise `must_contain` end-to-end) pass.

```
LIBCLANG_PATH=… cargo test --lib -- extract::tests   # 119 passed
cargo clippy --lib --tests -- -D warnings            # clean
cargo fmt --check                                    # clean
```

- [x] Independent adversarial review: brute-forced the new window math against the old function fed *correct* char indices (byte-identical output across 7 strings incl. 4-byte emoji and combining marks, every boundary pair, pad 0..4), enumerated the case-folding delta over 3068 char pairs, measured the `size_limit` threshold (which prompted the literal fallback)
