### PR TITLE
fix(doctor, xvfb): two more char-boundary slice panics on text the code doesn't control

### DIFF
--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -844,14 +844,27 @@ fn check_plugins() -> CheckResult {
     }
 }
 
+/// Display form of a key: enough to recognize it, never enough to
+/// use it. Char-based throughout -- the old byte slices panicked on
+/// a key with a multibyte char in the cut position (`parse_key` /
+/// `keys import` never reject non-ASCII), and showed 7 of 8 chars of
+/// a short key.
 fn mask_key(k: &str) -> String {
     let start = k.split_once("::").map(|(t, _)| t).unwrap_or(k);
-    let b = start.as_bytes();
-    if b.len() <= 8 {
-        return format!("{}***", &start[..start.len().saturating_sub(1)]);
+    let n = start.chars().count();
+    if n <= 8 {
+        let shown: String = start.chars().take(n.saturating_sub(1).min(2)).collect();
+        return format!("{shown}***");
     }
-    let head = std::str::from_utf8(&b[..6]).unwrap_or("");
-    let tail = std::str::from_utf8(&b[b.len() - 4..]).unwrap_or("");
+    let head: String = start.chars().take(6).collect();
+    let tail: String = start
+        .chars()
+        .rev()
+        .take(4)
+        .collect::<Vec<_>>()
+        .into_iter()
+        .rev()
+        .collect();
     format!("{head}...{tail}")
 }
 
@@ -1211,4 +1224,30 @@ async fn apply_fixes(collected: &mut [(String, String, String, String)]) -> Resu
         cli::bold("done")
     );
     Ok(())
+}
+
+#[cfg(test)]
+mod mask_tests {
+    use super::mask_key;
+
+    #[test]
+    fn mask_key_is_char_safe_and_never_shows_most_of_a_short_key() {
+        // 8 bytes, 7 chars, last char multibyte: `&start[..7]` panicked.
+        assert_eq!(mask_key("abcdefé"), "ab***");
+        // All-multibyte short key.
+        assert_eq!(mask_key("密钥测试"), "密钥***");
+        // Degenerate lengths.
+        assert_eq!(mask_key(""), "***");
+        assert_eq!(mask_key("a"), "***");
+        assert_eq!(mask_key("ab"), "a***");
+        // A real-length key keeps the recognizable head...tail shape.
+        assert_eq!(
+            mask_key("sk-abcdefghijklmnopqrstuvwxyz0123"),
+            "sk-abc...0123"
+        );
+        // Multibyte at both cut positions.
+        assert_eq!(mask_key("ключключключключ"), "ключкл...ключ");
+        // Bright Data `token::zone` keys mask the token only.
+        assert_eq!(mask_key("0123456789abcdef::my_zone"), "012345...cdef");
+    }
 }

--- a/src/ghost/xvfb.rs
+++ b/src/ghost/xvfb.rs
@@ -334,13 +334,23 @@ mod linux {
         if read.is_err() && total.is_empty() {
             return None;
         }
-        let text = String::from_utf8_lossy(&total);
+        tail_line(&String::from_utf8_lossy(&total))
+    }
+
+    /// Last non-blank line of `text`, trimmed, cut to ~300 bytes.
+    /// The cut is pulled back onto a char boundary: Xvfb's stderr is
+    /// lossy-decoded bytes, and `&line[..297]` inside a multibyte
+    /// char (a localized X error, or the U+FFFD replacement the
+    /// lossy decode itself inserts) was a str-slice panic on the
+    /// one path that only runs when the display already failed.
+    pub(super) fn tail_line(text: &str) -> Option<String> {
         let line = text
             .lines()
             .rfind(|l| !l.trim().is_empty())
             .map(|l| l.trim().to_string())?;
         if line.len() > 300 {
-            Some(format!("{}…", &line[..297]))
+            let cut = line.floor_char_boundary(297);
+            Some(format!("{}…", &line[..cut]))
         } else {
             Some(line)
         }
@@ -418,6 +428,27 @@ mod tests {
     /// Serialize them within this binary (nextest runs one process).
     static SYNC_SERIAL: Mutex<()> = Mutex::new(());
     static SERIAL: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    // A long final stderr line of multibyte chars must be cut on a
+    // char boundary, not sliced at byte 297 (a panic on the failure
+    // path, i.e. exactly when the diagnostic is needed).
+    #[test]
+    fn stderr_tail_cuts_long_multibyte_line_on_a_char_boundary() {
+        // 3-byte chars: byte 297 is a boundary (297 = 3*99), so
+        // shift by one ASCII byte to land inside a char.
+        let long = format!("x{}", "終".repeat(150));
+        let text = format!("first line\n\n{long}\n   \n");
+        let tail = x::tail_line(&text).expect("a non-blank line");
+        assert!(tail.ends_with('…'), "{tail}");
+        assert!(tail.len() <= 297 + '…'.len_utf8());
+        assert!(tail.starts_with("x終"));
+        // Short lines pass through trimmed and untouched.
+        assert_eq!(
+            x::tail_line("a\n  cannot open display :99  \n").as_deref(),
+            Some("cannot open display :99")
+        );
+        assert_eq!(x::tail_line("\n  \n"), None);
+    }
 
     #[test]
     fn gate_conflicts_and_recovers() {


### PR DESCRIPTION
Same class as #133, two sites found in the same audit pass:

**`cli/doctor.rs::mask_key`** — `&start[..len-1]` on a key of ≤ 8 bytes panics when the last char is multibyte (`"abcdefé"` → "byte index 7 is not a char boundary"); `parse_key` / `keys import` never reject non-ASCII, so a stray Unicode char in a pasted key aborts `doctor`. The same branch also displayed 7 of 8 chars of a short key, which isn't masking. Now char-based: short keys show at most 2 chars + `***`, long keys keep the recognizable `6...4` shape, multibyte at either cut is fine.

**`ghost/xvfb.rs::read_stderr_tail`** — `&line[..297]` on Xvfb's lossy-decoded stderr panics when byte 297 falls inside a multibyte char (a localized X error message, or the U+FFFD that `from_utf8_lossy` itself inserts for a bad byte). It's the path that only runs *after* the display failed to start — i.e. exactly when the diagnostic is wanted. Extracted into a pure `tail_line()` using `floor_char_boundary`.

Both have tests that panic on the previous code.

```
LIBCLANG_PATH=… cargo test --lib -- cli::doctor::mask_tests ghost::xvfb::tests::stderr_tail   # 2 passed
cargo clippy --lib --tests -- -D warnings   # clean
cargo fmt --check                           # clean
```

Small enough that I didn't run a separate review pass on this one; the `floor_char_boundary` semantics were exhaustively checked in #133's review.
