### PR TITLE
fix(crawl): ghost escalation budget could wrap to usize::MAX under concurrent workers

### DIFF
--- a/src/crawl/mod.rs
+++ b/src/crawl/mod.rs
@@ -271,6 +271,24 @@ impl ResumeFile {
     }
 }
 
+/// Tier-2 (real browser) escalations allowed per crawl: each one is
+/// a 20-40s headless-browser cycle, so the cap is the crawl's cost
+/// ceiling, not a tuning knob.
+const GHOST_BUDGET: usize = 3;
+
+/// Claim one ghost escalation from the shared budget. Atomic
+/// check-and-decrement: workers used to `load() > 0` then
+/// `fetch_sub(1)` as two steps, so two workers seeing budget == 1
+/// both passed the check, the second `fetch_sub` wrapped the counter
+/// to `usize::MAX`, and every later check passed for the rest of the
+/// crawl -- the cost cap gone. Only reachable with `concurrency > 1`
+/// (the default is 1), but that is a public `CrawlOptions` field.
+fn claim_ghost_slot(budget: &AtomicUsize) -> bool {
+    budget
+        .fetch_update(Ordering::SeqCst, Ordering::SeqCst, |n| n.checked_sub(1))
+        .is_ok()
+}
+
 pub struct Crawler {
     fetch: PageFetcher,
     governor: Arc<Governor>,
@@ -534,7 +552,7 @@ impl Crawler {
         let focus = Arc::new(opts.focus.clone());
 
         let workers = opts.concurrency.max(1);
-        let ghost_budget = Arc::new(AtomicUsize::new(3));
+        let ghost_budget = Arc::new(AtomicUsize::new(GHOST_BUDGET));
         let mut handles = Vec::new();
         for wid in 0..workers {
             let queue = Arc::clone(&sh_queue);
@@ -826,10 +844,7 @@ impl Crawler {
                         && let Some(ref ghost_hook) = ghost_hook
                     {
                         let remaining = deadline_at.saturating_duration_since(Instant::now());
-                        if remaining > Duration::from_secs(25)
-                            && ghost_budget.load(Ordering::SeqCst) > 0
-                        {
-                            ghost_budget.fetch_sub(1, Ordering::SeqCst);
+                        if remaining > Duration::from_secs(25) && claim_ghost_slot(&ghost_budget) {
                             match ghost_hook(item.url.clone()).await {
                                 Ok(gp) => ghost_html = Some(gp.html),
                                 Err(why) => {
@@ -992,10 +1007,7 @@ impl Crawler {
                         && let Some(ref ghost_hook) = ghost_hook
                     {
                         let remaining = deadline_at.saturating_duration_since(Instant::now());
-                        if remaining > Duration::from_secs(25)
-                            && ghost_budget.load(Ordering::SeqCst) > 0
-                        {
-                            ghost_budget.fetch_sub(1, Ordering::SeqCst);
+                        if remaining > Duration::from_secs(25) && claim_ghost_slot(&ghost_budget) {
                             match ghost_hook(item.url.clone()).await {
                                 Ok(gp) => {
                                     if let Ok(r2) = extract::extract(

--- a/src/crawl/tests.rs
+++ b/src/crawl/tests.rs
@@ -11,8 +11,44 @@ use std::time::Duration;
 use futures_util::FutureExt;
 
 use super::governor::{Governor, Lane, LaneKind};
-use super::{CrawlMode, CrawlOptions, Crawler, FetchedPage, PageFetcher, StopReason};
+use super::{
+    CrawlMode, CrawlOptions, Crawler, FetchedPage, GHOST_BUDGET, PageFetcher, StopReason,
+    claim_ghost_slot,
+};
 use crate::detect::walls::Verdict;
+
+// The escalation budget is shared by every worker. A load-then-
+// fetch_sub gate let two workers pass at budget == 1 and wrap the
+// counter to usize::MAX, after which every later check passed. The
+// atomic claim must hand out exactly GHOST_BUDGET slots however many
+// threads race for them, and the counter must end at 0, not wrap.
+#[test]
+fn ghost_budget_is_claimed_exactly_budget_times_under_contention() {
+    for _ in 0..20 {
+        let budget = Arc::new(AtomicUsize::new(GHOST_BUDGET));
+        let claimed = Arc::new(AtomicUsize::new(0));
+        let go = Arc::new(std::sync::Barrier::new(8));
+        let threads: Vec<_> = (0..8)
+            .map(|_| {
+                let (budget, claimed, go) = (budget.clone(), claimed.clone(), go.clone());
+                std::thread::spawn(move || {
+                    go.wait();
+                    for _ in 0..100 {
+                        if claim_ghost_slot(&budget) {
+                            claimed.fetch_add(1, Ordering::SeqCst);
+                        }
+                    }
+                })
+            })
+            .collect();
+        for t in threads {
+            t.join().unwrap();
+        }
+        assert_eq!(claimed.load(Ordering::SeqCst), GHOST_BUDGET);
+        assert_eq!(budget.load(Ordering::SeqCst), 0, "counter wrapped");
+        assert!(!claim_ghost_slot(&budget), "exhausted budget must refuse");
+    }
+}
 
 /// A scripted site: URL → (status, body). Missing URL = 404.
 struct MockSite {


### PR DESCRIPTION
## What's broken

Both tier-2 escalation sites in the crawl worker gate on the shared per-crawl budget with two separate atomic operations:

```rust
if remaining > Duration::from_secs(25) && ghost_budget.load(Ordering::SeqCst) > 0 {
    ghost_budget.fetch_sub(1, Ordering::SeqCst);
    match ghost_hook(item.url.clone()).await { … }
```

`ghost_budget` is an `Arc<AtomicUsize>` starting at 3, cloned into every worker (`opts.concurrency.max(1)` of them). With ≥2 workers, two can both observe `1`, both pass the check, and the second `fetch_sub` wraps the counter to `usize::MAX` — after which `load() > 0` holds for the rest of the crawl and the "at most 3 browser escalations per crawl" cost cap is gone: every later Challenge-verdict page can fire a 20–40 s headless-browser cycle, bounded only by the deadline. Even without hitting the wrap, the race over-spends the budget by up to `workers − 1`.

**Reachability:** `CrawlOptions::default()` is `concurrency: 1` and no shipped caller raises it, so the CLI/MCP crawl paths can't interleave today. It's a public field on the library API, and a future default bump would expose it — same shape as the Windows profile-lock race merged earlier (#97).

## Fix

One `fetch_update(SeqCst, SeqCst, |n| n.checked_sub(1)).is_ok()` as the gate (`claim_ghost_slot`), replacing the load + `fetch_sub` pair at both sites; the magic `3` becomes a named `GHOST_BUDGET`.

Test: 8 threads × 100 attempts × 20 rounds against a budget of 3 — exactly 3 claims succeed, the counter ends at 0 (no wrap), and the exhausted budget refuses.

```
LIBCLANG_PATH=… cargo test --lib -- crawl::tests   # 36 passed
cargo clippy --lib --tests -- -D warnings          # clean
cargo fmt --check                                  # clean
```
