### PR TITLE
fix(search): freshness test expires on 2026-09-16; future-dated items scored stale

### DIFF
--- a/src/search/authority.rs
+++ b/src/search/authority.rs
@@ -413,7 +413,11 @@ fn freshness_mult(published: &Option<String>) -> f64 {
         return 1.0;
     };
     match days_old {
-        0..=1 => 1.5,
+        // Negative = future-dated (a GMT pubDate ahead of a local
+        // clock near midnight): fresh, not stale. The lower-open arm
+        // is what makes iso_days_ago's "clamped to fresh" true; a
+        // `0..=1` arm sent every negative value to the stale 0.85.
+        ..=1 => 1.5,
         2..=3 => 1.3,
         4..=7 => 1.15,
         8..=30 => 1.0,
@@ -667,14 +671,38 @@ mod tests {
 
     #[test]
     fn freshness_tiers_parse_iso_prefix() {
-        // "2026-08-16" is a recent date → some freshness tier boost.
-        let f = freshness_mult(&Some("2026-08-16".into()));
-        assert!(
-            f >= 1.0,
-            "freshness should be >= 1.0 for a parseable date, got {f}"
-        );
+        // Relative to today: a literal date here silently walks out
+        // of the 30-day neutral tier and starts failing the build
+        // (the previous "2026-08-16" would have from 2026-09-16).
+        let now = epoch_days_now();
+        let tiers = [
+            (0, 1.5),
+            (1, 1.5),
+            (2, 1.3),
+            (3, 1.3),
+            (4, 1.15),
+            (7, 1.15),
+            (8, 1.0),
+            (30, 1.0),
+            (31, 0.85),
+            (400, 0.85),
+        ];
+        for (age, want) in tiers {
+            let iso = civil_from_days(now - age);
+            let got = freshness_mult(&Some(iso.clone()));
+            assert_eq!(got, want, "{age} days old ({iso})");
+        }
         // Unparseable → neutral.
         assert_eq!(freshness_mult(&Some("garbage".into())), 1.0);
+    }
+
+    #[test]
+    fn freshness_treats_future_dates_as_fresh() {
+        let now = epoch_days_now();
+        for ahead in [1, 2, 30] {
+            let iso = civil_from_days(now + ahead);
+            assert_eq!(freshness_mult(&Some(iso.clone())), 1.5, "{iso}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
Two small things in `authority.rs`'s News freshness multiplier, found in a read-through of the search core.

**1. A test expires in ten days.** `freshness_tiers_parse_iso_prefix` pins the literal date `"2026-08-16"` and asserts `>= 1.0`. The neutral tier is `8..=30` days, so from **2026-09-16** that date scores 0.85 and `cargo test --lib` fails repo-wide (verified with the module's own `days_from_civil`: 30 days on 09-15 passes, 31 on 09-16 fails). The sibling `freshness_prefers_recent` already uses the right shape (`civil_from_days(epoch_days_now() - N)`); the test now walks every tier boundary relative to today instead.

**2. Future-dated items scored stale.** `iso_days_ago`'s doc says "negative = future, clamped to fresh", but `freshness_mult`'s first arm was `0..=1 => 1.5`, so any negative `days_old` fell through to `_ => 0.85` — a GMT `pubDate` a few hours ahead of a local clock near midnight got the *stale* penalty. The arm is `..=1` now; a test covers −1/−2/−30 days.

```
LIBCLANG_PATH=… cargo test --lib -- search::authority   # 14 passed
cargo clippy --lib --tests -- -D warnings                # clean
cargo fmt --check                                        # clean
```
