### PR TITLE
fix(extract): unbounded MathML recursion overflowed the stack (daemon abort)

### DIFF
--- a/src/extract/math.rs
+++ b/src/extract/math.rs
@@ -78,22 +78,42 @@ fn tex_annotation(el: ElementRef<'_>) -> Option<String> {
     None
 }
 
+/// Recursion cap. Every other DOM walker has one (blocks 300, inline
+/// 100, score 300); this one had none, and MathML nests as deep as a
+/// page cares to make it: a couple of thousand nested <mrow> in a
+/// release build (a 10-20 KB page; a few hundred in debug) overflowed
+/// the 2 MB tokio worker stack, which is a hard abort of the daemon,
+/// not a panic. Past the cap the subtree degrades to its plain text,
+/// an iterative tree walk. Legitimate MathML nests ~20-40 deep.
+const MAX_DEPTH: usize = 100;
+
 /// Compact linear serialization of a MathML subtree. Not full
 /// LaTeX : a token-efficient linearization an LLM reads natively:
 /// `W_Q^T`, `(Q K^T)/(sqrt(d_k))`, matrices as `(a, b; c, d)`.
 fn serialize(el: ElementRef<'_>) -> String {
+    serialize_at(el, 0)
+}
+
+fn serialize_at(el: ElementRef<'_>, depth: usize) -> String {
+    if depth > MAX_DEPTH {
+        return descendants_text(el);
+    }
     let name = el.value().name();
     match name {
         // Scripted constructs: gather children positionally.
         "msup" | "msub" | "msubsup" | "munder" | "mover" | "munderover" | "mroot"
-        | "mmultiscripts" => serialize_scripted(el, name),
+        | "mmultiscripts" => serialize_scripted(el, name, depth),
         "mfrac" => {
             let kids = element_children(el);
             if kids.len() == 2 {
-                format!("({})/({})", serialize(kids[0]), serialize(kids[1]))
+                format!(
+                    "({})/({})",
+                    serialize_at(kids[0], depth + 1),
+                    serialize_at(kids[1], depth + 1)
+                )
             } else {
                 kids.iter()
-                    .map(|k| serialize(*k))
+                    .map(|k| serialize_at(*k, depth + 1))
                     .collect::<Vec<_>>()
                     .join(" ")
             }
@@ -101,7 +121,7 @@ fn serialize(el: ElementRef<'_>) -> String {
         "msqrt" => {
             let inner: String = element_children(el)
                 .iter()
-                .map(|k| serialize(*k))
+                .map(|k| serialize_at(*k, depth + 1))
                 .collect::<Vec<_>>()
                 .join("");
             format!("sqrt({inner})")
@@ -116,7 +136,7 @@ fn serialize(el: ElementRef<'_>) -> String {
                 let cells: Vec<String> = tr
                     .select(&scraper::Selector::parse("mtd").unwrap())
                     .take(12)
-                    .map(serialize_inline_of)
+                    .map(|c| serialize_at(c, depth + 1))
                     .collect();
                 if !cells.is_empty() {
                     rows.push(cells.join(", "));
@@ -146,7 +166,7 @@ fn serialize(el: ElementRef<'_>) -> String {
                         if let Some(c) = ElementRef::wrap(child) {
                             let cname = c.value().name();
                             if is_mathml_tag(cname) || is_mathml_tag(name) {
-                                out.push_str(&serialize(c));
+                                out.push_str(&serialize_at(c, depth + 1));
                             }
                         }
                     }
@@ -158,25 +178,19 @@ fn serialize(el: ElementRef<'_>) -> String {
     }
 }
 
-fn serialize_inline_of(el: ElementRef<'_>) -> String {
-    serialize(el)
-}
-
 /// Serialize msup/msub/msubsup/munder/mover/munderover/mroot with
 /// positional children: base, sub, sup.
-fn serialize_scripted(el: ElementRef<'_>, name: &str) -> String {
+fn serialize_scripted(el: ElementRef<'_>, name: &str, depth: usize) -> String {
     let kids = element_children(el);
-    let base = kids.first().map(|k| serialize(*k)).unwrap_or_default();
+    let kid = |i: usize| kids.get(i).map(|k| serialize_at(*k, depth + 1));
+    let base = kid(0).unwrap_or_default();
     let (sub, sup) = match name {
-        "msub" => (kids.get(1).map(|k| serialize(*k)), None),
-        "msup" => (None, kids.get(1).map(|k| serialize(*k))),
-        "msubsup" | "munderover" => (
-            kids.get(1).map(|k| serialize(*k)),
-            kids.get(2).map(|k| serialize(*k)),
-        ),
-        "munder" => (kids.get(1).map(|k| serialize(*k)), None),
-        "mover" => (None, kids.get(1).map(|k| serialize(*k))),
-        "mroot" => (None, kids.get(1).map(|k| serialize(*k))), // base^(index)
+        "msub" => (kid(1), None),
+        "msup" => (None, kid(1)),
+        "msubsup" | "munderover" => (kid(1), kid(2)),
+        "munder" => (kid(1), None),
+        "mover" => (None, kid(1)),
+        "mroot" => (None, kid(1)), // base^(index)
         _ => (None, None),
     };
     let mut out = base;
@@ -214,6 +228,41 @@ mod tests {
         doc.select(&scraper::Selector::parse("math").unwrap())
             .next()
             .expect("math element")
+    }
+
+    // Unbounded recursion over page-controlled nesting is a stack
+    // overflow -- a hard abort of the daemon, not a panic -- and
+    // html5ever happily builds a 20000-deep <mrow> tree from a
+    // ~250 KB page. Run on a deliberately small stack: this only
+    // passes when the walk is depth-capped (100 frames fit in 2 MiB
+    // with room to spare; 20000 do not on any build profile).
+    #[test]
+    fn deeply_nested_mathml_does_not_overflow_the_stack() {
+        const DEPTH: usize = 20_000;
+        let html = format!(
+            "<math>{}<mi>x</mi>{}</math>",
+            "<mrow>".repeat(DEPTH),
+            "</mrow>".repeat(DEPTH)
+        );
+        let out = std::thread::Builder::new()
+            .stack_size(2 * 1024 * 1024)
+            .spawn(move || latex(math_el(&html)))
+            .expect("spawn")
+            .join()
+            .expect("serialize must not overflow");
+        assert!(out.contains('x'), "{out}");
+    }
+
+    // The cap degrades to plain text, it does not drop content.
+    #[test]
+    fn past_the_depth_cap_content_is_kept_as_text() {
+        let depth = MAX_DEPTH + 50;
+        let html = format!(
+            "<math>{}<mi>deep</mi>{}</math>",
+            "<mrow>".repeat(depth),
+            "</mrow>".repeat(depth)
+        );
+        assert!(latex(math_el(&html)).contains("deep"));
     }
 
     #[test]


### PR DESCRIPTION
## What's broken

`extract/math.rs::serialize` recurses once per MathML child with no depth guard. Every other DOM walker in the extractor has one (`blocks` 300, `inline` 100, `score` 300); this one had none, and html5ever builds a nested `<mrow>` tree as deep as the page makes it.

A stack overflow isn't a panic — it's `fatal runtime error: stack overflow, aborting` — so `panic = "abort"` vs unwind is irrelevant: the MCP daemon dies mid-fetch. Reproduced in a scratch crate with the same `scraper 0.27`: the parent commit aborts at **~250 levels on a 1 MiB debug stack** and **~1.6–2k levels on a 2 MiB release stack** — i.e. a 10–20 KB page of `<math><mrow><mrow>…`. Reachable from both the block-level and inline `"math"` branches on any fetched page. The `extract` fuzz target's 4 KB default input caps nesting near 680, which is why it never surfaced.

## Fix

`serialize` now threads a depth (`serialize_at`), and past `MAX_DEPTH = 100` (matching `inline.rs`; legitimate MathML nests ~20–40, and MediaWiki/arXiv/KaTeX pages never reach `serialize` at all thanks to `alttext` / `<annotation x-tex>`) returns the subtree's plain text via `descendants_text` — an iterative ego-tree walk. The `serialize_scripted` children go through one `kid(i)` closure so no call site can reset the depth.

Output below the cap is unchanged: the reviewer diffed the parent and new serializers over 26 hand-written cases (every scripted arm, `mfrac` with 1/2/3 kids, nested/empty `mtable`, `semantics`, `annotation`, `mspace`, foreign children) plus 62 000 randomized trees — zero mismatches.

## Tests

- `deeply_nested_mathml_does_not_overflow_the_stack`: a 20 000-deep tree serialized on a 2 MiB thread stack — aborts on the parent commit in both debug and release; the capped walk needs ~460 KB in debug.
- `past_the_depth_cap_content_is_kept_as_text`: content beyond the cap survives as text rather than being dropped.

```
LIBCLANG_PATH=… cargo test --lib -- extract::math    # 9 passed
LIBCLANG_PATH=… cargo test --lib -- extract::tests   # 121 passed
cargo clippy --lib --tests -- -D warnings            # clean
cargo fmt --check                                    # clean
```

- [x] Independent adversarial review: confirmed no remaining uncapped recursion in the module (`el.text()`/`select()`/`children()` are all ego-tree iterative; html5ever's tree builder parses 20 000 nesting on a 64 KB stack), measured the parent's actual overflow thresholds, and randomized-diffed output equivalence.

## Noted, not changed here

`is_mathml_tag` doesn't list `mtable`/`mtd`/`mfrac`/`msup`/…, so a matrix cell containing a fraction or a power (`<mtd><mfrac>…</mfrac></mtd>`) serializes to an empty cell. Pre-existing and separate; I'll send it as its own PR.
