### PR TITLE
fix(mcp): one non-UTF-8 byte on stdin shut the whole daemon down

### DIFF
--- a/src/mcp/stdio.rs
+++ b/src/mcp/stdio.rs
@@ -11,6 +11,47 @@ use serde_json::Value;
 
 use crate::mcp::server::{CancelMap, Daemon, handle};
 
+/// One stdin line, classified.
+enum Incoming {
+    /// A line to hand to the JSON-RPC dispatcher.
+    Request(String),
+    /// A line that is not UTF-8: the client is still there, so
+    /// this is not EOF. Reason text for the error response.
+    Malformed(String),
+    /// stdin closed, or a real read error.
+    Eof,
+}
+
+/// `Lines::next_line` reports a line that isn't UTF-8 as
+/// `Err(InvalidData)` -- after consuming it, so the reader is
+/// positioned at the next line. Treating that Err as EOF (the old
+/// `while let Ok(Some(..))`) shut the whole daemon down on one bad
+/// byte from the client, mid-session, with every in-flight tool
+/// call orphaned. Only a real read error or EOF ends the loop.
+async fn next_incoming<R: tokio::io::AsyncBufRead + Unpin>(
+    lines: &mut tokio::io::Lines<R>,
+) -> Incoming {
+    match lines.next_line().await {
+        Ok(Some(l)) => Incoming::Request(l),
+        Ok(None) => Incoming::Eof,
+        Err(e) if e.kind() == std::io::ErrorKind::InvalidData => Incoming::Malformed(e.to_string()),
+        Err(e) => {
+            eprintln!("[mcp] stdin read failed, shutting down: {e}");
+            Incoming::Eof
+        }
+    }
+}
+
+/// JSON-RPC parse error for a line the dispatcher never saw
+/// (same shape `handle` emits for unparseable JSON).
+fn parse_error(reason: &str) -> String {
+    serde_json::json!({
+        "jsonrpc": "2.0", "id": null,
+        "error": { "code": -32700, "message": format!("parse error: {reason}") }
+    })
+    .to_string()
+}
+
 /// Run the stdio MCP daemon until stdin closes.
 /// Never returns Err on client garbage : only on fatal IO.
 pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
@@ -48,7 +89,15 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     let cancels: CancelMap = Arc::new(Mutex::new(std::collections::HashMap::new()));
 
     let mut lines = BufReader::new(tokio::io::stdin()).lines();
-    while let Ok(Some(line)) = lines.next_line().await {
+    loop {
+        let line = match next_incoming(&mut lines).await {
+            Incoming::Request(l) => l,
+            Incoming::Malformed(reason) => {
+                let _ = tx.send(parse_error(&reason)).await;
+                continue;
+            }
+            Incoming::Eof => break,
+        };
         let line = line.trim().to_string();
         if line.is_empty() {
             continue;
@@ -82,4 +131,42 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
     daemon.shutdown().await;
     let _ = writer.await;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // `Lines::next_line` yields Err(InvalidData) for a line that
+    // isn't UTF-8. The loop used to treat any Err as EOF, so one
+    // stray byte from the client (a pasted path in a legacy
+    // codepage, a truncated multibyte char) shut the daemon down
+    // mid-session. The bad line must be answered and skipped;
+    // the request after it must still be served.
+    #[tokio::test]
+    async fn invalid_utf8_line_is_skipped_not_eof() {
+        let input: &[u8] = b"{\"a\":1}\n\xff\xfe garbage\n{\"b\":2}\n";
+        let mut lines = BufReader::new(input).lines();
+        assert!(
+            matches!(next_incoming(&mut lines).await, Incoming::Request(l) if l == "{\"a\":1}")
+        );
+        assert!(matches!(
+            next_incoming(&mut lines).await,
+            Incoming::Malformed(_)
+        ));
+        assert!(
+            matches!(next_incoming(&mut lines).await, Incoming::Request(l) if l == "{\"b\":2}")
+        );
+        assert!(matches!(next_incoming(&mut lines).await, Incoming::Eof));
+    }
+
+    #[test]
+    fn malformed_line_gets_a_jsonrpc_parse_error() {
+        let v: Value = serde_json::from_str(&parse_error("stream did not contain valid UTF-8"))
+            .expect("valid json");
+        assert_eq!(v["jsonrpc"], "2.0");
+        assert!(v["id"].is_null());
+        assert_eq!(v["error"]["code"], -32700);
+        assert!(v["error"]["message"].as_str().unwrap().contains("UTF-8"));
+    }
 }


### PR DESCRIPTION
## What's broken

`mcp/stdio.rs` reads requests with

```rust
while let Ok(Some(line)) = lines.next_line().await {
```

tokio's `Lines::next_line` reports a line that isn't valid UTF-8 as `Err(InvalidData)` — after consuming it, so the reader is already positioned at the next line. The loop treated that `Err` exactly like EOF: fall through to `drop(tx)`, `daemon.shutdown()`, and every in-flight tool call is orphaned. One stray byte from the client (a pasted path in a legacy codepage, a truncated multibyte character, a client bug) ends the whole session — and it looks like a clean shutdown, not an error.

## Fix

Reads go through a small classifier:

- `Ok(Some)` → dispatch as before
- `Err(InvalidData)` → answer with the same JSON-RPC `-32700` parse error `handle` already emits for unparseable JSON, and keep reading
- `Ok(None)` → EOF as before; any other `Err` → logged to stderr, then shutdown (previously it was silently indistinguishable from EOF)

## Tests

- `invalid_utf8_line_is_skipped_not_eof`: `{"a":1}\n\xff\xfe garbage\n{"b":2}\n` yields Request, Malformed, Request, Eof — the request after the bad line is still served. Fails on `master`'s semantics (the second read was Eof).
- `malformed_line_gets_a_jsonrpc_parse_error`: pins the error shape (`id: null`, code `-32700`).

```
LIBCLANG_PATH=… cargo test --lib -- mcp::stdio       # 2 passed
cargo clippy --lib --tests -- -D warnings            # clean
cargo fmt --check                                    # clean
```

## Noted, not changed here

`ghost/mod.rs:735` reads Chrome's stderr with the same `while let Ok(Some(..))` shape while looking for the `DevTools listening on ws://` line. A non-UTF-8 line before it would surface as `no devtools ws line`. Much less likely in practice (Chrome logs UTF-8), so left alone.
