### PR TITLE
fix(extract): a <pre> containing ``` closed its own code fence early

### DIFF
--- a/src/adapters/wiki_infobox.rs
+++ b/src/adapters/wiki_infobox.rs
@@ -221,7 +221,8 @@ fn render_blocks(root: ElementRef, url: &str, opts: &ExtractOptions) -> String {
             "pre" => {
                 let code = plain_text(el);
                 if !code.is_empty() {
-                    out.push_str(&format!("```\n{code}\n```\n\n"));
+                    let fence = crate::extract::render::code_fence(&code);
+                    out.push_str(&format!("{fence}\n{code}\n{fence}\n\n"));
                 }
             }
             "table" => {
@@ -331,5 +332,21 @@ mod tests {
         // No infobox → no adapter.
         let plain = "<html><body><div class='mw-parser-output'><p>text</p></div></body></html>";
         assert!(extract(plain, "https://en.wikipedia.org/wiki/Plain", &opts()).is_none());
+    }
+
+    #[test]
+    fn pre_containing_a_fence_gets_a_longer_fence() {
+        // e.g. the Markdown article's own syntax example.
+        let html = WIKI.replace(
+            "<h2>History</h2>",
+            "<pre>```python\nprint(1)\n```</pre><h2>History</h2>",
+        );
+        let ex = extract(&html, "https://en.wikipedia.org/wiki/Markdown", &opts()).unwrap();
+        assert!(
+            ex.markdown
+                .contains("````\n```python\nprint(1)\n```\n````\n"),
+            "{}",
+            ex.markdown
+        );
     }
 }

--- a/src/extract/reddit.rs
+++ b/src/extract/reddit.rs
@@ -382,7 +382,8 @@ fn render_md(el: ElementRef, url: &str, opts: &ExtractOptions) -> String {
                         let code: String = c.text().collect::<Vec<_>>().join("");
                         let code = code.trim_matches('\n');
                         if !code.is_empty() {
-                            out.push_str(&format!("```\n{code}\n```\n\n"));
+                            let fence = super::render::code_fence(code);
+                            out.push_str(&format!("{fence}\n{code}\n{fence}\n\n"));
                         }
                     }
                     "blockquote" => {

--- a/src/extract/render.rs
+++ b/src/extract/render.rs
@@ -169,10 +169,10 @@ pub fn render(meta: &Meta, url: &str, kept: &[&Block], opts: &super::ExtractOpti
                     &mut last_path,
                     &mut last_was_heading,
                 );
+                let fence = code_fence(code);
                 out.push_str(&format!(
-                    "```{}\n{}\n```\n\n",
-                    lang.as_deref().unwrap_or(""),
-                    code
+                    "{fence}{}\n{code}\n{fence}\n\n",
+                    lang.as_deref().unwrap_or("")
                 ));
             }
             Block::Quote { md, .. } => {
@@ -241,4 +241,39 @@ fn emit_path(
     }
     *last_path = path.to_vec();
     *last_was_heading = true;
+}
+
+/// Fence for a code block: one backtick longer than the longest
+/// backtick run inside it (min 3). A `<pre>` that itself shows a
+/// markdown fence -- every "how to write markdown" page, every
+/// README rendered by a docs site -- would otherwise close the
+/// block at its inner ``` and spill the rest as prose.
+pub(crate) fn code_fence(code: &str) -> String {
+    let mut longest = 0;
+    let mut run = 0;
+    for c in code.chars() {
+        if c == '`' {
+            run += 1;
+            longest = longest.max(run);
+        } else {
+            run = 0;
+        }
+    }
+    "`".repeat((longest + 1).max(3))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::code_fence;
+
+    #[test]
+    fn fence_is_one_longer_than_the_longest_backtick_run() {
+        assert_eq!(code_fence("fn main() {}"), "```");
+        assert_eq!(code_fence("a `b` c"), "```");
+        assert_eq!(code_fence("a ``b`` c"), "```");
+        assert_eq!(code_fence("```rust\nx\n```"), "````");
+        assert_eq!(code_fence("x\n````\ny"), "`````");
+        assert_eq!(code_fence("`````\n"), "``````");
+        assert_eq!(code_fence(""), "```");
+    }
 }

--- a/src/extract/tests.rs
+++ b/src/extract/tests.rs
@@ -502,6 +502,31 @@ fn block_code_pre() {
     assert!(r.markdown.contains("println!"));
 }
 
+// A <pre> that itself contains a markdown fence (every "how to
+// write markdown" page, every README rendered in a docs site)
+// used to be wrapped in a bare ``` fence: the inner ``` closed
+// the block early and the rest of the code spilled out as prose.
+#[test]
+fn block_code_containing_backtick_fence_is_wrapped_in_a_longer_fence() {
+    let html = "<html><body><article>
+<pre><code>Use a fence:
+
+```rust
+fn main() {}
+```
+
+Then prose.</code></pre>
+</article></body></html>";
+    let r = extract_html(html);
+    let md = &r.markdown;
+    let open = md.find("````\n").expect("longer opening fence");
+    let close = md.rfind("\n````\n").expect("longer closing fence");
+    assert!(open < close);
+    let inside = &md[open..close];
+    assert!(inside.contains("```rust\nfn main() {}\n```"), "{md}");
+    assert!(inside.contains("Then prose."), "{md}");
+}
+
 #[test]
 fn block_code_whitespace_preserved() {
     let html = r#"<html><body><article>


### PR DESCRIPTION
## What's broken

All three places that emit a code block — `extract/render.rs` (`Block::Code`), `extract/reddit.rs` (`<pre>` in a comment) and `adapters/wiki_infobox.rs` (`<pre>` in the article body) — wrap the text in a bare ` ``` ` fence. When the `<pre>` itself contains a markdown fence (every "how to write markdown" page, every README a docs site renders, the *Markdown* article on Wikipedia), the inner ` ``` ` closes the block early:

````
```
Use a fence:

```rust          ← closes the block; "rust" is now the info string of… nothing
fn main() {}     ← prose
```              ← opens a new, unterminated block
````

Everything after it in the document lands inside a code block or outside one, depending on parity.

## Fix

`render::code_fence(code)` returns a fence one backtick longer than the longest backtick run inside the block (min 3) — CommonMark's rule for nesting fences — and the three emitters use it for both the opening and closing fence. Output for code without a triple-backtick run is byte-identical to before.

## Tests

- `extract::tests::block_code_containing_backtick_fence_is_wrapped_in_a_longer_fence`: end-to-end through `extract`; the inner ` ```rust … ``` ` and the prose after it are both inside a ` ```` ` fence. Fails on `master` (no ` ```` ` fence emitted).
- `adapters::wiki_infobox::tests::pre_containing_a_fence_gets_a_longer_fence`: same through the Wikipedia adapter.
- `extract::render::tests::fence_is_one_longer_than_the_longest_backtick_run`: unit cases, including inline `` `x` `` (still ` ``` `) and a ` ```` ` run (→ ` ````` `).

```
LIBCLANG_PATH=… cargo test --lib -- extract adapters   # 313 passed
cargo clippy --lib --tests -- -D warnings              # clean
cargo fmt --check                                      # clean
```
