### PR TITLE
fix(extract): every nested list item was emitted twice

### DIFF
--- a/src/adapters/docs_outline.rs
+++ b/src/adapters/docs_outline.rs
@@ -82,12 +82,29 @@ pub fn extract(html: &str, url: &str, opts: &ExtractOptions) -> Option<Extracted
     let mut body = String::new();
     let block_sel = Selector::parse("h1, h2, h3, h4, p, ul, ol, pre, table, blockquote").unwrap();
     for el in root.select(&block_sel) {
+        // Descendant select: a <p> inside a <li> or <blockquote>,
+        // a nested <ul>, would be emitted as part of its parent
+        // AND again on its own. Outermost matches only.
+        let nested = el
+            .ancestors()
+            .take_while(|a| a.id() != root.id())
+            .filter_map(ElementRef::wrap)
+            .any(|a| block_sel.matches(&a));
+        if nested {
+            continue;
+        }
         match el.value().name() {
             "h1" | "h2" | "h3" | "h4" => {
                 let t = text_of(el);
                 if !t.is_empty() {
                     let level = el.value().name().as_bytes()[1] - b'0';
                     body.push_str(&format!("{} {}\n\n", "#".repeat(level as usize), t));
+                }
+            }
+            "ul" | "ol" => {
+                let (items, _) = crate::extract::blocks::list_items(el, url, &body_opts, 0);
+                if !items.is_empty() {
+                    crate::extract::render::push_list(&mut body, &items, el.value().name() == "ol");
                 }
             }
             _ => {
@@ -262,5 +279,27 @@ mod tests {
           <body><nav><a class="md-nav__link" href="/a/">A</a><a class="md-nav__link" href="/b/">B</a></nav>
           <main><p>hi</p></main></body></html>"#;
         assert!(extract(thin, "https://docs.example.com/", &opts()).is_none());
+    }
+
+    // The block selector matched descendants, so a <p> inside a
+    // <li> or <blockquote>, and a nested <ul>, were emitted once
+    // as part of their parent and again on their own.
+    #[test]
+    fn nested_blocks_are_emitted_once() {
+        let html = MKDOCS.replace(
+            "<pre>code sample</pre>",
+            "<ul><li><p>Step one</p><ul><li>Detail a</li></ul></li><li>Step two</li></ul>\
+             <blockquote><p>Quoted note</p></blockquote>\
+             <pre>code sample</pre>",
+        );
+        let ex = extract(&html, "https://docs.example.com/guide/", &opts()).unwrap();
+        let md = &ex.markdown;
+        assert_eq!(md.matches("Step one").count(), 1, "{md}");
+        assert_eq!(md.matches("Detail a").count(), 1, "{md}");
+        assert_eq!(md.matches("Quoted note").count(), 1, "{md}");
+        assert!(
+            md.contains("- Step one\n  - Detail a\n- Step two\n"),
+            "{md}"
+        );
     }
 }

--- a/src/adapters/wiki_infobox.rs
+++ b/src/adapters/wiki_infobox.rs
@@ -204,19 +204,10 @@ fn render_blocks(root: ElementRef, url: &str, opts: &ExtractOptions) -> String {
                 }
             }
             "ul" | "ol" => {
-                let li_sel = Selector::parse("li").unwrap();
-                for (i, li) in el.select(&li_sel).enumerate() {
-                    let (m, _) = crate::extract::inline::markdown(li, url, &opts);
-                    if !m.trim().is_empty() {
-                        let bullet = if el.value().name() == "ol" {
-                            format!("{}. ", i + 1)
-                        } else {
-                            "- ".to_string()
-                        };
-                        out.push_str(&format!("{bullet}{}\n", m.trim()));
-                    }
+                let (items, _) = crate::extract::blocks::list_items(el, url, &opts, 0);
+                if !items.is_empty() {
+                    crate::extract::render::push_list(&mut out, &items, el.value().name() == "ol");
                 }
-                out.push('\n');
             }
             "pre" => {
                 let code = plain_text(el);
@@ -348,5 +339,25 @@ mod tests {
             "{}",
             ex.markdown
         );
+    }
+
+    // `el.select("li")` matched nested items too, so each one
+    // appeared fused into its parent's line and again as its own
+    // top-level bullet (and nested numbering restarted the count).
+    #[test]
+    fn nested_list_items_are_indented_not_duplicated() {
+        let html = WIKI.replace(
+            "<h2>History</h2>",
+            "<ul><li>Outer one<ul><li>Inner a</li><li>Inner b</li></ul></li><li>Outer two</li></ul>\
+             <ol><li>First<ol><li>Sub</li></ol></li><li>Second</li></ol><h2>History</h2>",
+        );
+        let ex = extract(&html, "https://en.wikipedia.org/wiki/Lists", &opts()).unwrap();
+        let md = &ex.markdown;
+        assert_eq!(md.matches("Inner a").count(), 1, "{md}");
+        assert!(
+            md.contains("- Outer one\n  - Inner a\n  - Inner b\n- Outer two\n"),
+            "{md}"
+        );
+        assert!(md.contains("1. First\n  - Sub\n2. Second\n"), "{md}");
     }
 }

--- a/src/extract/blocks.rs
+++ b/src/extract/blocks.rs
@@ -428,7 +428,11 @@ fn contains_block(el: ElementRef<'_>) -> bool {
     false
 }
 
-fn list_items(
+/// Items of a `<ul>`/`<ol>`, nested lists flattened to indented
+/// entries ("  " per level, up to 4 deep). Shared with the docs
+/// and Wikipedia adapters so nested lists render the same way
+/// everywhere.
+pub(crate) fn list_items(
     list: ElementRef<'_>,
     base: &str,
     opts: &super::ExtractOptions,
@@ -444,7 +448,15 @@ fn list_items(
         if li.value().name() != "li" || crate::extract::junk::skip(li) {
             continue;
         }
-        let (md, ld) = inline::markdown(li, base, opts);
+        // Below the cap the nested lists are rendered as indented
+        // items (so the item's own line must not include them); at
+        // the cap they are flattened into the line instead, never
+        // dropped.
+        let (md, ld) = if depth < 4 {
+            inline::item_markdown(li, base, opts)
+        } else {
+            inline::markdown(li, base, opts)
+        };
         let md = md.trim().to_string();
         if !md.is_empty() {
             items.push(format!("{}{}", "  ".repeat(depth as usize), md));

--- a/src/extract/inline.rs
+++ b/src/extract/inline.rs
@@ -8,10 +8,34 @@ const MAX_DEPTH: usize = 100;
 /// Render an element's inline content as markdown.
 /// Returns (markdown, link_density 0..1).
 pub fn markdown(el: ElementRef<'_>, base: &str, opts: &super::ExtractOptions) -> (String, f32) {
+    markdown_impl(el, base, opts, false)
+}
+
+/// `markdown` for a list item: its own content only. Nested
+/// `<ul>`/`<ol>` children are the caller's (rendered as indented
+/// items), not flattened into this item's line -- which had every
+/// nested item appearing twice, fused into its parent and again
+/// on its own line.
+pub fn item_markdown(
+    li: ElementRef<'_>,
+    base: &str,
+    opts: &super::ExtractOptions,
+) -> (String, f32) {
+    markdown_impl(li, base, opts, true)
+}
+
+fn markdown_impl(
+    el: ElementRef<'_>,
+    base: &str,
+    opts: &super::ExtractOptions,
+    skip_lists: bool,
+) -> (String, f32) {
     let mut buf = String::new();
     let mut total = 0usize;
     let mut link = 0usize;
-    render(el, base, opts, &mut buf, &mut total, &mut link, 0);
+    render(
+        el, base, opts, &mut buf, &mut total, &mut link, 0, skip_lists,
+    );
     let collapsed = collapse(&buf);
     // Restore <br> sentinels as newlines after whitespace collapse.
     let collapsed = collapsed.replace('\u{0}', "\n");
@@ -35,6 +59,7 @@ pub fn plain(el: ElementRef<'_>) -> String {
     collapse(&buf)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn render(
     el: ElementRef<'_>,
     base: &str,
@@ -43,6 +68,7 @@ fn render(
     total: &mut usize,
     link: &mut usize,
     depth: usize,
+    skip_lists: bool,
 ) {
     if depth > MAX_DEPTH {
         return;
@@ -61,6 +87,14 @@ fn render(
                     continue;
                 };
                 let name = c.value().name();
+                if skip_lists && matches!(name, "ul" | "ol") {
+                    // Block boundary: text before and after the
+                    // nested list must not fuse ("BeforeAfter").
+                    if !buf.is_empty() && !buf.ends_with(' ') {
+                        buf.push(' ');
+                    }
+                    continue;
+                }
                 match name {
                     "a" => {
                         // Render children recursively so nested
@@ -148,13 +182,13 @@ fn render(
                         if !buf.is_empty() && !buf.ends_with(' ') {
                             buf.push(' ');
                         }
-                        render(c, base, opts, buf, total, link, depth + 1);
+                        render(c, base, opts, buf, total, link, depth + 1, false);
                     }
                     _ => {
                         if crate::extract::junk::skip(c) {
                             continue;
                         }
-                        render(c, base, opts, buf, total, link, depth + 1);
+                        render(c, base, opts, buf, total, link, depth + 1, false);
                     }
                 }
             }
@@ -175,7 +209,16 @@ impl RenderInner {
         let mut t = String::new();
         let mut total = 0usize;
         let mut link = 0usize;
-        render(c, base, opts, &mut t, &mut total, &mut link, depth + 1);
+        render(
+            c,
+            base,
+            opts,
+            &mut t,
+            &mut total,
+            &mut link,
+            depth + 1,
+            false,
+        );
         t
     }
 }

--- a/src/extract/render.rs
+++ b/src/extract/render.rs
@@ -117,18 +117,7 @@ pub fn render(meta: &Meta, url: &str, kept: &[&Block], opts: &super::ExtractOpti
                     &mut last_path,
                     &mut last_was_heading,
                 );
-                for (i, item) in items.iter().enumerate() {
-                    let indent: String = item.chars().take_while(|c| *c == ' ').collect();
-                    let body = item.trim_start();
-                    let depth = indent.len() / 2;
-                    let bullet = if *ordered && depth == 0 {
-                        format!("{}. ", i + 1)
-                    } else {
-                        "- ".to_string()
-                    };
-                    out.push_str(&format!("{indent}{bullet}{body}\n"));
-                }
-                out.push('\n');
+                push_list(&mut out, items, *ordered);
             }
             Block::Table {
                 headers,
@@ -210,6 +199,27 @@ pub fn render(meta: &Meta, url: &str, kept: &[&Block], opts: &super::ExtractOpti
     }
     out.push('\n');
     out
+}
+
+/// Emit `list_items` output as markdown: "  " indentation per
+/// nesting level is already in each item; top-level items of an
+/// ordered list are numbered (nested ones get "-"), and the
+/// number counts top-level items only -- nested entries used to
+/// advance it, so "1. First / - Sub / 3. Second".
+pub(crate) fn push_list(out: &mut String, items: &[String], ordered: bool) {
+    let mut n = 0;
+    for item in items {
+        let indent: String = item.chars().take_while(|c| *c == ' ').collect();
+        let body = item.trim_start();
+        let bullet = if ordered && indent.is_empty() {
+            n += 1;
+            format!("{n}. ")
+        } else {
+            "- ".to_string()
+        };
+        out.push_str(&format!("{indent}{bullet}{body}\n"));
+    }
+    out.push('\n');
 }
 
 fn normalize(s: &str) -> String {

--- a/src/extract/tests.rs
+++ b/src/extract/tests.rs
@@ -595,6 +595,53 @@ fn block_nested_list() {
     assert!(r.markdown.contains("Nested item"));
 }
 
+// The outer <li>'s inline render used to descend into the nested
+// <ul> as well, so every nested item appeared twice: fused into
+// its parent's line ("Has nested Nested item") and again as its
+// own indented bullet.
+#[test]
+fn block_nested_list_items_are_not_duplicated() {
+    let html = r#"<html><body><article>
+<p>Intro paragraph long enough to keep the article.</p>
+<ul>
+<li>Top level</li>
+<li>Has nested
+  <ul>
+    <li>Nested item</li>
+    <li>Second nested</li>
+  </ul>
+</li>
+<li>Last</li>
+</ul>
+</article></body></html>"#;
+    let r = extract_html(html);
+    let md = &r.markdown;
+    assert_eq!(md.matches("Nested item").count(), 1, "{md}");
+    assert_eq!(md.matches("Second nested").count(), 1, "{md}");
+    assert!(
+        md.contains("- Has nested\n  - Nested item\n  - Second nested\n- Last"),
+        "{md}"
+    );
+}
+
+// Past the indentation cap the nested list is flattened into its
+// parent's line (as before), never dropped; and text on either
+// side of a nested list keeps its word boundary.
+#[test]
+fn block_nested_list_deep_levels_and_trailing_text_survive() {
+    let html = r#"<html><body><article>
+<p>Intro paragraph long enough to keep the article.</p>
+<ul><li>L0<ul><li>L1<ul><li>L2<ul><li>L3<ul><li>L4<ul><li>L5 deep text<ul><li>L6 deeper</li></ul></li></ul></li></ul></li></ul></li></ul></li></ul></li>
+<li>Before<ul><li>Inner</li></ul>After text</li>
+</ul>
+</article></body></html>"#;
+    let r = extract_html(html);
+    let md = &r.markdown;
+    assert!(md.contains("        - L4 L5 deep text L6 deeper\n"), "{md}");
+    assert_eq!(md.matches("deep text").count(), 1, "{md}");
+    assert!(md.contains("- Before After text\n  - Inner\n"), "{md}");
+}
+
 #[test]
 fn block_definition_list() {
     let html = r#"<html><body><article>


### PR DESCRIPTION
## What's broken

`blocks::list_items` renders each `<li>` with `inline::markdown`, which recurses into the item's nested `<ul>`/`<ol>` too — and then `list_items` renders that nested list *again* as indented items. On `master`:

```html
<ul>
<li>Top level</li>
<li>Has nested<ul><li>Nested item</li><li>Second nested</li></ul></li>
<li>Last</li>
</ul>
```
```
- Top level
- Has nested Nested item Second nested
  - Nested item
  - Second nested
- Last
```

Every nested list on every page — docs, READMEs, Wikipedia, HN/Reddit comment bodies — pays for its nested items twice, and the parent line is fused with all of them. The existing `block_nested_list` test only asserted `contains`, so it never saw it. Ordered numbering also counted nested entries: `1. First / - Sub / 3. Second`.

The two adapters had their own versions of the same thing: `wiki_infobox.rs` selected every descendant `<li>` (duplication plus restarted numbering), and `docs_outline.rs` selected descendant blocks, so a `<p>` inside a `<li>` or `<blockquote>` and a nested `<ul>` were emitted once inside the parent and once on their own (Docusaurus wraps every list item in `<p>`).

## Fix

- `inline::item_markdown(li)` — `markdown` for a list item: its own content only, direct `<ul>`/`<ol>` children left to the caller. Everything else about `inline::markdown` is unchanged (a `<blockquote>` or `<td>` containing a list still flattens it, as before).
- `render::push_list(out, items, ordered)` — the list emitter, numbering top-level items only.
- `blocks::list_items` is `pub(crate)` and both adapters use it with `push_list`, so nested lists render identically everywhere. `docs_outline` additionally skips any block match that has a matching ancestor below the content root.

## Tests

- `extract::tests::block_nested_list_items_are_not_duplicated` — end-to-end: each nested item exactly once, exact `- Has nested\n  - Nested item\n  - Second nested\n- Last` shape. Fails on `master` (count 2).
- `adapters::wiki_infobox::tests::nested_list_items_are_indented_not_duplicated` — nested `<ul>` and `<ol>`, `1. First / - Sub / 2. Second`.
- `adapters::docs_outline::tests::nested_blocks_are_emitted_once` — `<li><p>`, nested `<ul>`, `<blockquote><p>`.
- `extract::tests::block_nested_list_deep_levels_and_trailing_text_survive` — past `list_items`' 4-level indentation cap the nested list is flattened into the parent line as before (never dropped), and `Before<ul>…</ul>After` keeps its word boundary. Both were regressions in the first draft of this branch, caught by an old-vs-new output diff over 23 list shapes; for everything without a directly nested list the generic output is byte-identical to `master`.

- [x] Independent adversarial review: diffed old vs new `extract()` over plain/ordered/link/`<li><p>`/`<li><div>`/`<br>`/`<dl>`/list-in-table/list-in-blockquote/`<li><div><ul>` shapes — no differences except the intended dedup and numbering; confirmed `ancestors()` excludes self in ego-tree 0.11.

```
LIBCLANG_PATH=… cargo test --lib -- extract adapters   # 314 passed
LIBCLANG_PATH=… cargo test --lib                       # 884 passed (1 pre-existing Xvfb-concurrency flake, passes on rerun)
cargo clippy --lib --tests -- -D warnings              # clean
cargo fmt --check                                      # clean
```
