### PR TITLE
fix(mcp): requests with string JSON-RPC ids could never be cancelled

### DIFF
--- a/src/mcp/http.rs
+++ b/src/mcp/http.rs
@@ -55,7 +55,7 @@ use tower_http::{
     trace::TraceLayer,
 };
 
-use crate::mcp::server::{CancelMap, Daemon, handle};
+use crate::mcp::server::{CancelMap, Daemon, cancel_key, handle};
 
 /// Idle sessions are dropped after this long, so cancelled-tool
 /// registries cannot leak forever for clients that vanish mid-call.
@@ -437,7 +437,7 @@ async fn mcp_handler(State(state): State<HttpState>, headers: HeaderMap, body: B
     // Mirrors the stdio transport's inline handling.
     if is_notification && method == "notifications/cancelled" {
         let cancels = resolve_cancels(&state, sid_header.as_deref());
-        if let Some(rid) = req.pointer("/params/requestId").and_then(Value::as_i64)
+        if let Some(rid) = req.pointer("/params/requestId").and_then(cancel_key)
             && let Some(sender) = cancels
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -473,7 +473,7 @@ async fn mcp_handler(State(state): State<HttpState>, headers: HeaderMap, body: B
     // Writer sink for in-flight progress notifications. Each request
     // gets a fresh channel; nothing else consumes it.
     let (progress_tx, mut progress_rx) = mpsc::channel::<String>(256);
-    let request_id = req.get("id").and_then(Value::as_i64);
+    let request_id = req.get("id").and_then(cancel_key);
 
     let outcome = tokio::time::timeout(
         state.timeout,

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -254,8 +254,20 @@ where
     }
 }
 
+/// Cancellation registry: request-id key → cancel sender.
 pub type CancelMap =
-    Arc<std::sync::Mutex<std::collections::HashMap<i64, tokio::sync::watch::Sender<bool>>>>;
+    Arc<std::sync::Mutex<std::collections::HashMap<String, tokio::sync::watch::Sender<bool>>>>;
+
+/// Registry key for a JSON-RPC request id. Ids are numbers OR
+/// strings (uuids, "req-7"); keying on i64 meant a string-id client
+/// could never cancel anything. The JSON encoding keeps `7` and
+/// `"7"` distinct, as the spec requires.
+pub fn cancel_key(id: &Value) -> Option<String> {
+    match id {
+        Value::Number(_) | Value::String(_) => Some(id.to_string()),
+        _ => None,
+    }
+}
 
 /// Handle one line. Returns Some(response) for requests,
 /// None for notifications and cancelled requests (per MCP spec,
@@ -289,9 +301,9 @@ pub async fn handle(
 
     // tools/call gets the full context: cancel + progress.
     if method == "tools/call" {
-        let rid = id.as_i64();
+        let rid = cancel_key(&id);
         let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
-        if let Some(r) = rid {
+        if let Some(r) = rid.clone() {
             cancels
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)
@@ -4756,5 +4768,26 @@ mod initialize_tests {
                 json!(v)
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod cancel_key_tests {
+    use super::cancel_key;
+    use serde_json::json;
+
+    // JSON-RPC ids are numbers OR strings. The registry was keyed
+    // on i64, so a client using string ids ("req-7", uuids) could
+    // never cancel anything: its notifications/cancelled found no
+    // entry and the crawl ran to completion.
+    #[test]
+    fn string_and_number_ids_both_get_a_key() {
+        assert!(cancel_key(&json!("req-7")).is_some());
+        assert!(cancel_key(&json!(7)).is_some());
+        assert!(cancel_key(&json!(-1)).is_some());
+        assert_ne!(cancel_key(&json!("7")), cancel_key(&json!(7)));
+        assert_eq!(cancel_key(&json!("req-7")), cancel_key(&json!("req-7")));
+        assert!(cancel_key(&json!(null)).is_none());
+        assert!(cancel_key(&json!({"a": 1})).is_none());
     }
 }

--- a/src/mcp/stdio.rs
+++ b/src/mcp/stdio.rs
@@ -9,7 +9,7 @@ use tokio::sync::mpsc;
 
 use serde_json::Value;
 
-use crate::mcp::server::{CancelMap, Daemon, handle};
+use crate::mcp::server::{CancelMap, Daemon, cancel_key, handle};
 
 /// Run the stdio MCP daemon until stdin closes.
 /// Never returns Err on client garbage : only on fatal IO.
@@ -58,7 +58,7 @@ pub async fn run() -> Result<(), Box<dyn std::error::Error>> {
         if let Ok(v) = serde_json::from_str::<Value>(&line)
             && v.get("id").is_none()
             && v.get("method").and_then(Value::as_str) == Some("notifications/cancelled")
-            && let Some(rid) = v.pointer("/params/requestId").and_then(Value::as_i64)
+            && let Some(rid) = v.pointer("/params/requestId").and_then(cancel_key)
             && let Some(sender) = cancels
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner)


### PR DESCRIPTION
## What's broken

The cancellation registry (`CancelMap`) is keyed on `i64`. `handle()` registers a `tools/call` only when `id.as_i64()` is `Some`, and both transports look up `notifications/cancelled` with `requestId.as_i64()`:

```rust
let rid = id.as_i64();                                                   // server.rs
… v.pointer("/params/requestId").and_then(Value::as_i64)                // stdio.rs
… req.pointer("/params/requestId").and_then(Value::as_i64)              // http.rs (twice)
```

JSON-RPC ids are numbers **or strings**. A client that uses string ids (uuids, `"req-7"` — several MCP client libraries do) can never cancel anything: the tool call is never registered, the notification finds no entry, and a `web_crawl` or multi-URL `web_fetch` runs to completion while the client has already given up. The HTTP transport's timeout-cleanup path has the same `as_i64`, so a timed-out string-id request also leaked its watch sender.

## Fix

One `server::cancel_key(&Value) -> Option<String>`: numbers and strings map to their JSON encoding (`7` and `"7"` stay distinct, as the spec requires), anything else is unregisterable as before. `CancelMap` is keyed on that string, and `handle()`, the stdio loop, and both HTTP sites use the helper.

## Tests

`cancel_key_tests::string_and_number_ids_both_get_a_key` pins the contract (string ids get a key, `"7"` ≠ `7`, null/objects don't register). The registration/lookup sites are the same three lines with the helper substituted, so the behaviour follows from the key.

```
LIBCLANG_PATH=… cargo test --lib --features http -- cancel_key mcp::http   # 12 passed
cargo clippy --lib --tests --features http -- -D warnings                  # clean
cargo fmt --check                                                          # clean
```
