### PR TITLE
fix(supervisor): responses in flight when the client closed stdin were dropped

### DIFF
--- a/src/mcp/supervisor.rs
+++ b/src/mcp/supervisor.rs
@@ -21,11 +21,21 @@
 use std::io::{Read, Write};
 use std::process::{Child, Command, Stdio};
 use std::sync::mpsc;
-use std::time::Duration;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 const MAX_RAPID_RESTARTS: u32 = 5;
 const BACKOFF_MS: u64 = 500;
 const POLL: Duration = Duration::from_millis(500);
+/// A child that served this long before dying was not part of a
+/// crash loop: the rapid-restart counter starts over. Without
+/// this the counter only ever grew, and a long-lived session gave
+/// up on its fifth crash in a month.
+const RAPID_WINDOW: Duration = Duration::from_secs(60);
+/// After our client closes stdin, how long the daemon gets to
+/// answer its in-flight requests and shut down cleanly before
+/// it is killed.
+const DRAIN_TIMEOUT: Duration = Duration::from_secs(30);
 
 enum In {
     Data(Vec<u8>),
@@ -34,17 +44,43 @@ enum In {
 
 pub fn run() -> std::io::Result<()> {
     let exe = std::env::current_exe()?;
+    run_with(
+        move || {
+            let mut c = Command::new(&exe);
+            c.arg("mcp");
+            c
+        },
+        std::io::stdin(),
+        std::io::stdout(),
+    )
+}
+
+/// The supervisor loop over an arbitrary child command, input and
+/// output (the real thing uses `donsetch mcp` and our own stdio).
+/// Returns once the client has closed `input` AND the daemon has
+/// finished: every response it produces on the way out reaches
+/// `output`.
+fn run_with<R, W>(
+    mut child_cmd: impl FnMut() -> Command,
+    input: R,
+    output: W,
+) -> std::io::Result<()>
+where
+    R: Read + Send + 'static,
+    W: Write + Send + 'static,
+{
     let mut restarts: u32 = 0;
     let mut pending: Vec<u8> = Vec::new();
+    let output = Arc::new(Mutex::new(output));
 
     // Drain OUR stdin from a thread so the main loop can also
     // watch for child death while the client is idle.
     let (tx, rx) = mpsc::channel::<In>();
     std::thread::spawn(move || {
-        let mut stdin = std::io::stdin().lock();
+        let mut input = input;
         let mut buf = [0u8; 16384];
         loop {
-            match stdin.read(&mut buf) {
+            match input.read(&mut buf) {
                 Ok(0) | Err(_) => {
                     let _ = tx.send(In::Eof);
                     return;
@@ -58,7 +94,7 @@ pub fn run() -> std::io::Result<()> {
         }
     });
 
-    let mut child: Option<(Child, std::process::ChildStdin)> = None;
+    let mut child: Option<(Child, std::process::ChildStdin, Instant)> = None;
     loop {
         // (Re)spawn if needed.
         if child.is_none() {
@@ -68,21 +104,23 @@ pub fn run() -> std::io::Result<()> {
                     pending.len()
                 );
             }
-            let mut c = Command::new(&exe)
-                .arg("mcp")
+            let mut c = child_cmd()
                 .stdin(Stdio::piped())
                 .stdout(Stdio::piped())
                 .stderr(Stdio::inherit())
                 .spawn()?;
             let mut stdin = c.stdin.take().expect("child stdin");
             let mut stdout = c.stdout.take().expect("child stdout");
+            let out = Arc::clone(&output);
             std::thread::spawn(move || {
-                let mut out = std::io::stdout();
                 let mut buf = [0u8; 16384];
                 loop {
                     match stdout.read(&mut buf) {
                         Ok(0) | Err(_) => break,
                         Ok(n) => {
+                            let mut out = out
+                                .lock()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner);
                             if out.write_all(&buf[..n]).is_err() {
                                 break; // our client is gone
                             }
@@ -97,10 +135,10 @@ pub fn run() -> std::io::Result<()> {
                 let _ = stdin.flush();
                 pending.clear();
             }
-            child = Some((c, stdin));
+            child = Some((c, stdin, Instant::now()));
         }
 
-        let (c, stdin) = child.as_mut().expect("child");
+        let (c, stdin, born) = child.as_mut().expect("child");
         // Multiplex: new input vs idle child death.
         match rx.recv_timeout(POLL) {
             Ok(In::Data(bytes)) => {
@@ -111,36 +149,69 @@ pub fn run() -> std::io::Result<()> {
                     // for its replacement, never drop them.
                     pending = bytes;
                     eprintln!("[supervisor] daemon died mid-write : holding request for restart");
-                    restart_child(c, &mut restarts);
+                    restart_child(c, &mut restarts, born.elapsed());
                     child = None;
                 }
             }
-            Ok(In::Eof) => {
-                // Our client closed stdin: signal EOF, let the
-                // daemon finish its in-flight work, clean exit.
-                drop(child.take());
+            // Our client closed stdin (or its reader thread died):
+            // pass the EOF on and let the daemon finish its
+            // in-flight work. Its answers travel through the
+            // forwarder thread, which only lives as long as this
+            // process : returning before the daemon exits would
+            // drop every response still on the way out (and cut
+            // its shutdown, browser cleanup included, short).
+            Ok(In::Eof) | Err(mpsc::RecvTimeoutError::Disconnected) => {
+                if let Some((c, stdin, _)) = child.take() {
+                    drop(stdin);
+                    drain(c);
+                }
                 return Ok(());
             }
             Err(mpsc::RecvTimeoutError::Timeout) => {
                 // Idle: is the child still alive?
                 if let Ok(Some(_status)) = c.try_wait() {
                     eprintln!("[supervisor] daemon died while idle : restarting");
-                    restart_child(c, &mut restarts);
+                    restart_child(c, &mut restarts, born.elapsed());
                     child = None;
                 }
-            }
-            Err(mpsc::RecvTimeoutError::Disconnected) => {
-                drop(child.take());
-                return Ok(());
             }
         }
     }
 }
 
-fn restart_child(c: &mut Child, restarts: &mut u32) {
+/// Wait for a child that has seen EOF to exit on its own, killing
+/// it only if it overstays `DRAIN_TIMEOUT`.
+fn drain(mut c: Child) {
+    let deadline = Instant::now() + DRAIN_TIMEOUT;
+    loop {
+        match c.try_wait() {
+            Ok(Some(_)) | Err(_) => return,
+            Ok(None) if Instant::now() >= deadline => {
+                eprintln!("[supervisor] daemon did not exit after stdin closed : killing it");
+                let _ = c.kill();
+                let _ = c.wait();
+                return;
+            }
+            Ok(None) => std::thread::sleep(Duration::from_millis(20)),
+        }
+    }
+}
+
+/// The restart count after a child that lived `lived` died: a
+/// crash loop counts up; a child that served a full
+/// `RAPID_WINDOW` first resets the count to one.
+fn next_restart_count(restarts: u32, lived: Duration) -> u32 {
+    if lived >= RAPID_WINDOW {
+        1
+    } else {
+        restarts + 1
+    }
+}
+
+fn restart_child(c: &mut Child, restarts: &mut u32, lived: Duration) {
     let _ = c.kill();
     let _ = c.wait();
-    *restarts += 1;
+    *restarts = next_restart_count(*restarts, lived);
     if *restarts >= MAX_RAPID_RESTARTS {
         eprintln!(
             "[supervisor] {MAX_RAPID_RESTARTS} rapid crashes : giving up (the daemon needs a look)"
@@ -148,4 +219,62 @@ fn restart_child(c: &mut Child, restarts: &mut u32) {
         std::process::exit(1);
     }
     std::thread::sleep(Duration::from_millis(BACKOFF_MS));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Shared sink the test can inspect after `run_with` returns.
+    /// (Unix-only with its test: the child is a `sh` one-liner.)
+    #[cfg(unix)]
+    #[derive(Clone, Default)]
+    struct Sink(Arc<Mutex<Vec<u8>>>);
+
+    #[cfg(unix)]
+    impl Write for Sink {
+        fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(b);
+            Ok(b.len())
+        }
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    // A client that writes its request and closes stdin at once
+    // (a one-shot script, `printf ... | donsetch mcp --supervised`)
+    // used to get nothing back: the supervisor returned on EOF
+    // and the process exit took the stdout forwarder with it
+    // before the daemon had answered. Reproduced with the real
+    // binary: `donsetch mcp` answered, `--supervised` did not.
+    #[cfg(unix)]
+    #[test]
+    fn responses_after_client_eof_still_reach_the_output() {
+        let sink = Sink::default();
+        let input = std::io::Cursor::new(b"hello\n".to_vec());
+        // A child that answers late: it echoes stdin only after
+        // the client has long since closed it.
+        run_with(
+            || {
+                let mut c = Command::new("sh");
+                c.args(["-c", "sleep 0.5; cat"]);
+                c
+            },
+            input,
+            sink.clone(),
+        )
+        .unwrap();
+        let got = sink.0.lock().unwrap().clone();
+        assert_eq!(String::from_utf8_lossy(&got), "hello\n");
+    }
+
+    #[test]
+    fn restart_counter_resets_after_a_long_lived_child() {
+        assert_eq!(next_restart_count(0, Duration::from_millis(10)), 1);
+        assert_eq!(next_restart_count(3, Duration::from_secs(5)), 4);
+        // Five crashes spread over a long session are not a loop.
+        assert_eq!(next_restart_count(4, RAPID_WINDOW), 1);
+        assert_eq!(next_restart_count(4, Duration::from_secs(3600)), 1);
+    }
 }


### PR DESCRIPTION
## What's broken

On our stdin EOF the supervisor does

```rust
Ok(In::Eof) => { drop(child.take()); return Ok(()); }
```

with the comment "let the daemon finish its in-flight work, clean exit". But the daemon's answers travel through the stdout-forwarder *thread*, which lives only as long as the supervisor process — so returning here drops every response the daemon is still producing, and cuts its shutdown (ghost-browser cleanup included) short when its next write hits a closed pipe.

Reproduced with the real binary, one `initialize` request then stdin closed:

```
printf '%s\n' "$REQ" | donsetch mcp               -> 1 response
printf '%s\n' "$REQ" | donsetch mcp --supervised  -> 0 responses   (parent)
printf '%s\n' "$REQ" | donsetch mcp --supervised  -> 1 response    (this branch)
```

`--supervised` is the argv `doctor` recommends to every client, so any one-shot script, probe, or client that closes stdin after its last request loses the tail of the session.

Second, smaller: `restarts` only ever increments, so the "5 rapid crashes → give up" check is really "5 crashes over the life of the session". A daemon that runs for a month and takes five unrelated hostile pages exits for good on the fifth, contradicting the module doc.

## Fix

- EOF (and the reader-thread-gone case): close the child's stdin, then **wait for it to exit** — `drain()` polls `try_wait` and only kills after `DRAIN_TIMEOUT` (30 s) so a wedged daemon can't hang the client forever.
- Restart counter: `next_restart_count(restarts, lived)` resets to 1 when the dying child had served ≥ `RAPID_WINDOW` (60 s); a genuine crash loop still counts to 5.
- `run()` now delegates to `run_with(child_cmd, input, output)` so the loop is testable in-process; the real entry point passes `donsetch mcp` and our own stdio. No behaviour change otherwise (same channel, same pending-replay, same poll).

## Tests

- `responses_after_client_eof_still_reach_the_output` (unix): input `"hello\n"` closed immediately, child `sh -c 'sleep 0.5; cat'`. Output after `run_with` returns must be `"hello\n"`. With the parent's EOF arm it is `""` (verified by temporarily restoring it).
- `restart_counter_resets_after_a_long_lived_child`: pure counter semantics.

```
LIBCLANG_PATH=… cargo test --lib -- mcp::supervisor   # 2 passed
cargo clippy --lib --tests -- -D warnings             # clean
cargo fmt --check                                     # clean
```
