### PR TITLE
fix(crawl): a robots.txt "Crawl-delay: inf" aborted the crawl worker

### DIFF
--- a/src/crawl/governor.rs
+++ b/src/crawl/governor.rs
@@ -129,8 +129,13 @@ impl Governor {
             .crawl_delay
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // The setter is public: re-clamp here so no caller can
+        // hand `from_secs_f64` a value it panics on.
         match *cd {
-            Some(s) if s > 0.0 => Duration::from_secs_f64(s.max(BASE_DELAY.as_secs_f64())),
+            Some(s) if s.is_finite() && s > 0.0 => Duration::from_secs_f64(
+                s.min(super::sitemap::MAX_CRAWL_DELAY_SECS)
+                    .max(BASE_DELAY.as_secs_f64()),
+            ),
             _ => BASE_DELAY,
         }
     }
@@ -403,6 +408,20 @@ mod tests {
         let w = g.wait_for("ex.com", "lane0", 1);
         assert!(w > Duration::ZERO);
         assert!(w < Duration::from_secs(3));
+    }
+
+    // `Duration::from_secs_f64` panics on non-finite or > u64::MAX
+    // seconds; the governor must never trust the value it is
+    // handed that far.
+    #[test]
+    fn absurd_crawl_delay_never_panics_and_is_capped() {
+        for d in [f64::INFINITY, f64::NAN, 1e300, -1.0, 86400.0] {
+            let g = gov(&[LaneKind::Direct]);
+            g.set_crawl_delay(Some(d));
+            g.wait_for("ex.com", "lane0", 0);
+            let w = g.wait_for("ex.com", "lane0", 1);
+            assert!(w <= Duration::from_secs(90), "{d}: {w:?}");
+        }
     }
 
     #[test]

--- a/src/crawl/sitemap.rs
+++ b/src/crawl/sitemap.rs
@@ -19,9 +19,16 @@ pub struct Robots {
     pub disallow: Vec<String>,
     /// `Allow:` prefixes (override Disallow on longest match).
     pub allow: Vec<String>,
-    /// Site-declared request delay seconds, if any.
+    /// Site-declared request delay seconds, if any: finite,
+    /// non-negative, at most [`MAX_CRAWL_DELAY_SECS`].
     pub crawl_delay: Option<f64>,
 }
+
+/// Longest `Crawl-delay` honoured. A page a minute is already a
+/// crawl that only the deadline ends; `86400` (real sites ship
+/// it) would be a day between pages, and `inf`/`1e300` parse as
+/// valid f64 but panic in `Duration::from_secs_f64`.
+pub const MAX_CRAWL_DELAY_SECS: f64 = 60.0;
 
 impl Robots {
     pub fn parse(body: &str, base_host: &str) -> Self {
@@ -53,7 +60,11 @@ impl Robots {
                     r.allow.push(v.to_string());
                 }
                 "crawl-delay" if in_star_group => {
-                    r.crawl_delay = v.parse::<f64>().ok();
+                    r.crawl_delay = v
+                        .parse::<f64>()
+                        .ok()
+                        .filter(|d| d.is_finite() && *d >= 0.0)
+                        .map(|d| d.min(MAX_CRAWL_DELAY_SECS));
                 }
                 "sitemap" => {
                     // Sitemap directives apply outside groups.

--- a/src/crawl/tests.rs
+++ b/src/crawl/tests.rs
@@ -450,6 +450,53 @@ async fn crawl_robots_disallow_respected() {
     assert!(!hits.iter().any(|h| h.contains("/private")));
 }
 
+// `Crawl-delay` was parsed with a bare `f64` parse and fed straight
+// to `Duration::from_secs_f64`, which panics on `inf`/huge values:
+// one hostile (or sloppy) robots.txt aborted the crawl worker, and
+// a finite `86400` was honoured verbatim (a day between pages).
+#[test]
+fn robots_crawl_delay_is_finite_and_clamped() {
+    use super::sitemap::Robots;
+    for bad in ["inf", "-inf", "nan", "-5", "abc"] {
+        let r = Robots::parse(&format!("User-agent: *\nCrawl-delay: {bad}\n"), "ex.com");
+        assert_eq!(r.crawl_delay, None, "{bad}");
+    }
+    let r = Robots::parse("User-agent: *\nCrawl-delay: 2.5\n", "ex.com");
+    assert_eq!(r.crawl_delay, Some(2.5));
+    for huge in ["86400", "1e300"] {
+        let r = Robots::parse(&format!("User-agent: *\nCrawl-delay: {huge}\n"), "ex.com");
+        assert_eq!(
+            r.crawl_delay,
+            Some(super::sitemap::MAX_CRAWL_DELAY_SECS),
+            "{huge}"
+        );
+    }
+}
+
+#[tokio::test]
+async fn crawl_survives_infinite_crawl_delay() {
+    let robots = "User-agent: *\nCrawl-delay: inf\n";
+    let seed = "<html><body><article><p>content words for extractor acceptance threshold pass yes yes yes</p><a href=\"/ok\">ok</a></article></body></html>";
+    let site = MockSite::new()
+        .page("https://ex.com/robots.txt", 200, robots)
+        .page("https://ex.com/", 200, seed)
+        .page("https://ex.com/ok", 200, &html("Ok", "ok"));
+    let (fetch, _hits) = site.fetcher();
+    let crawler = Crawler::new(fetch, gov());
+    let mut o = opts();
+    o.mode = CrawlMode::Content;
+    o.max_pages = 10;
+    o.respect_robots = true;
+    let r = tokio::time::timeout(
+        Duration::from_secs(20),
+        crawler.crawl("https://ex.com/", o, None),
+    )
+    .await
+    .expect("crawl must finish")
+    .unwrap();
+    assert!(r.pages.iter().any(|p| p.url.ends_with("/ok")));
+}
+
 #[tokio::test]
 async fn crawl_near_dupes_collapsed() {
     let body = html("Same", "identical body");


### PR DESCRIPTION
## What's broken

`Robots::parse` reads `Crawl-delay` with a bare `v.parse::<f64>()`, and `Governor::base` does

```rust
Some(s) if s > 0.0 => Duration::from_secs_f64(s.max(BASE_DELAY.as_secs_f64())),
```

`Duration::from_secs_f64` panics on a non-finite value or anything above `u64::MAX` seconds. Rust's `f64` parser accepts `inf`, `infinity`, `1e300`… so a robots.txt line

```
User-agent: *
Crawl-delay: inf
```

takes the crawl worker down on its first `wait_for` — with `respect_robots` on (the default) and `panic = "abort"` in release, that's the daemon. Finite silly values were honoured verbatim: `Crawl-delay: 86400` (some real sites ship it) meant a day between pages, i.e. a crawl that only the deadline ends.

## Fix

- `Robots::parse`: the delay must be finite and ≥ 0, and is capped at `MAX_CRAWL_DELAY_SECS = 60` (a page a minute is already deadline-bound).
- `Governor::base`: re-clamps (`is_finite`, `min(MAX)`) since `set_crawl_delay` is public.

## Tests

- `crawl::tests::robots_crawl_delay_is_finite_and_clamped` — `inf`/`-inf`/`nan`/`-5`/`abc` → `None`; `2.5` kept; `86400` and `1e300` → 60.
- `crawl::governor::tests::absurd_crawl_delay_never_panics_and_is_capped` — `set_crawl_delay` with `inf`/`nan`/`1e300`/`-1`/`86400`, two `wait_for`s each, wait ≤ 90 s.
- `crawl::tests::crawl_survives_infinite_crawl_delay` — end-to-end against the mock site with `Crawl-delay: inf`; on `master` it panics inside `from_secs_f64` (`core/src/time.rs:962`).

```
LIBCLANG_PATH=… cargo test --lib -- crawl::            # 83 passed
cargo clippy --lib --tests -- -D warnings              # clean
cargo fmt --check                                      # clean
```
