### PR TITLE
fix(extract): scripted MathML inside table cells serialized empty

### DIFF
--- a/src/extract/math.rs
+++ b/src/extract/math.rs
@@ -28,6 +28,29 @@ fn is_mathml_tag(name: &str) -> bool {
             | "maction"
             | "menclose"
             | "mphantom"
+            // Layout/script tags: each has its own serialize_at arm,
+            // but the child-recursion guard consults this list too :
+            // missing entries made e.g. an msub inside an mtd (both
+            // absent) invisible, so matrix cells serialized empty.
+            | "mfrac"
+            | "msqrt"
+            | "mroot"
+            | "msub"
+            | "msup"
+            | "msubsup"
+            | "munder"
+            | "mover"
+            | "munderover"
+            | "mmultiscripts"
+            | "mprescripts"
+            | "none"
+            | "mtable"
+            | "mtr"
+            | "mlabeledtr"
+            | "mtd"
+            | "merror"
+            | "mfenced"
+            | "mglyph"
     )
 }
 
@@ -325,6 +348,21 @@ mod tests {
         );
         let l = latex(el);
         assert!(l.contains("(1, 2; 3, 4)"), "{l}");
+    }
+
+    // The child-recursion guard only follows a child when the child
+    // OR its parent is a known MathML tag : with the layout/script
+    // tags (mtd, mfrac, msub, ...) missing from the list, a scripted
+    // construct inside a table cell was invisible on both sides of
+    // the check and every such cell serialized empty.
+    #[test]
+    fn serializes_scripted_constructs_inside_matrix_cells() {
+        let el = math_el(
+            r#"<math><mtable><mtr><mtd><msub><mi>a</mi><mn>1</mn></msub></mtd><mtd><mfrac><mn>1</mn><mn>2</mn></mfrac></mtd></mtr></mtable></math>"#,
+        );
+        let l = latex(el);
+        assert!(l.contains("a_{1}"), "msub cell dropped: {l}");
+        assert!(l.contains("(1)/(2)"), "mfrac cell dropped: {l}");
     }
 
     #[test]


### PR DESCRIPTION
## What

`extract/math.rs`'s `is_mathml_tag` list stopped at the token/container tags — every layout/script tag (`mfrac`, `msqrt`, `mroot`, `msub`/`msup`/`msubsup`, `munder`/`mover`/`munderover`, `mmultiscripts`, `mtable`/`mtr`/`mtd`, `merror`, `mfenced`, …) was missing.

## Why it matters

`serialize_at`'s default arm only recurses into an element child when `is_mathml_tag(child) || is_mathml_tag(parent)`. Each layout tag has its own dedicated `serialize_at` arm — but that arm is unreachable when **both** the parent and the child are missing from the list. The concrete everyday case is a matrix whose cells hold anything scripted:

```html
<math><mtable><mtr>
  <mtd><msub><mi>a</mi><mn>1</mn></msub></mtd>
  <mtd><mfrac><mn>1</mn><mn>2</mn></mfrac></mtd>
</mtr></mtable></math>
```

`mtd` is not in the list, `msub` is not in the list → the child is never followed, and the formula `(a_{1}, (1)/(2))` serializes as `(, )`. This hits any Wikipedia/paper page whose formulas ship matrices without `alttext` (the existing `serializes_matrix` test only used `<mn>` cells, which are in the list, so it never saw this).

## Fix

Add the missing MathML layout/script tags to `is_mathml_tag`. No serialization logic changes — the existing per-tag arms simply become reachable in nested positions.

## Testing

- New regression test `serializes_scripted_constructs_inside_matrix_cells` — fails on master with `msub cell dropped: (, )`, passes with the fix.
- Full `cargo test --lib` (911 tests), `cargo clippy --all-targets`, `cargo fmt --check` all clean.

(Follow-up candidate, not included: `mtable` row selection only looks for `mtr`, so a `mlabeledtr` row is still skipped as a row — rare enough that I left it out to keep this diff minimal; happy to add if you want it.)

https://claude.ai/code/session_01Vg2CMnuvDevTxCpmJGbnRU