### PR TITLE
fix(crawl): RSS </link> close tag matched case-sensitively

### DIFF
--- a/src/crawl/mod.rs
+++ b/src/crawl/mod.rs
@@ -1663,14 +1663,17 @@ fn parse_feed_urls(xml: &str, cap: usize) -> Vec<String> {
             break;
         };
         let after = open + 6;
-        let Some(close_rel) = xml[after..].find("</link>") else {
+        // Case-insensitive like the open-tag scan above : a
+        // case-sensitive close made "<LINK>u</LINK>" span to the
+        // next item's lowercase </link>.
+        let Some(close) = find_ascii_ci(xml, "</link>", after) else {
             break;
         };
-        let text = xml[after..after + close_rel].trim();
+        let text = xml[after..close].trim();
         if text.starts_with("http") {
             urls.push(text.to_string());
         }
-        pos = after + close_rel + 7;
+        pos = close + 7;
     }
     // Atom: <link href="URL" .../>
     if urls.len() < cap {

--- a/src/crawl/tests.rs
+++ b/src/crawl/tests.rs
@@ -1207,3 +1207,20 @@ fn feed_xml_folding_char_dropped_links_old_math() {
     let urls = got.expect("atom parse panicked");
     assert_eq!(urls, vec!["https://example.com/a/İtem"]);
 }
+
+#[test]
+fn rss_uppercase_link_tags_close_case_insensitively() {
+    // The open-tag scan matches "<LINK>" case-insensitively, so the
+    // close must too: with a case-sensitive close, an uppercase item
+    // "spans" to the NEXT item's lowercase </link> (one garbage URL
+    // swallowing the real one), and with no lowercase close left in
+    // the document every remaining RSS URL is dropped.
+    let xml = "<rss><channel>\
+               <item><LINK>https://example.com/1</LINK></item>\
+               <item><link>https://example.com/2</link></item>\
+               </channel></rss>";
+    assert_eq!(
+        super::parse_feed_urls(xml, 10),
+        vec!["https://example.com/1", "https://example.com/2"]
+    );
+}


### PR DESCRIPTION
## What

Follow-up to 0a4a7c3: `parse_feed_urls`'s RSS loop now finds the **open** tag case-insensitively (`find_ascii_ci(xml, "<link>", pos)`) but still finds the **close** with case-sensitive `str::find("</link>")`.

## Impact

For a feed with uppercase tags — `<LINK>https://example.com/1</LINK>` followed by a normal lowercase item:

- the item "closes" at the *next* item's lowercase `</link>`, producing one garbage URL spanning items (`https://example.com/1</LINK></item><item><link>https://example.com/2`) that swallows the real second URL;
- with no lowercase `</link>` anywhere later, the loop `break`s and every remaining RSS URL is dropped.

Before 0a4a7c3 the behavior was at least self-consistent (uppercase tags simply didn't match at all); this asymmetry is new. Uppercase RSS tags are malformed XML, but the open-tag scan deliberately chose to tolerate them — the close has to follow suit.

## Fix

Match the close with `find_ascii_ci` too (one call-site change; the helper already returns absolute offsets and, matching an ASCII needle, can only land on char boundaries).

## Testing

- New regression test `rss_uppercase_link_tags_close_case_insensitively` — fails on master with exactly the spanning garbage URL above, passes with the fix.
- Full crawl test module, `cargo clippy --all-targets`, `cargo fmt --check` all clean.

https://claude.ai/code/session_01Vg2CMnuvDevTxCpmJGbnRU