### PR TITLE
fix(mcp): every egress handshake failure classified as tls.verify — the tls.egress arm was dead code

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -4289,19 +4289,21 @@ fn verdict_kind(v: Verdict, status: u16) -> &'static str {
 fn fetch_error_kind(e: &FetchError) -> &'static str {
     match e {
         FetchError::Timeout | FetchError::Io(_) => "transient",
+        // Match on the classifier's own leading sentences, never on
+        // hint text : "SSL_CERT_FILE" appears in BOTH hints, and
+        // with it in the verify arm (checked first) every egress
+        // failure classified as tls.verify; the egress arm was dead.
         FetchError::Tls(msg)
-            if msg.contains("certificate verification failed")
-                || msg.contains("trusted root")
-                || msg.contains("SSL_CERT_FILE") =>
-        {
-            "tls.verify"
-        }
-        FetchError::Tls(msg)
-            if msg.contains("egress path")
-                || msg.contains("TLS handshake aborted")
-                || msg.contains("cut short") =>
+            if msg.starts_with("TLS handshake aborted")
+                || msg.starts_with("TLS handshake cut short") =>
         {
             "tls.egress"
+        }
+        FetchError::Tls(msg)
+            if msg.starts_with("TLS certificate verification failed")
+                || msg.contains("trusted root") =>
+        {
+            "tls.verify"
         }
         _ => "permanent",
     }
@@ -4310,6 +4312,48 @@ fn fetch_error_kind(e: &FetchError) -> &'static str {
 #[cfg(test)]
 mod stitch_tests {
     use super::*;
+
+    // fetch_error_kind's tls.verify arm matched on "SSL_CERT_FILE" :
+    // text that also appears in the egress hint appended to every
+    // aborted/cut-short handshake message, so ALL egress failures
+    // classified as tls.verify and the tls.egress arm was dead code
+    // (wrong next_action: "export SSL_CERT_FILE" instead of the
+    // proxy-routing hint the interception fix exists to give).
+    // Classify against the REAL classifier output, not hand-written
+    // strings, so the two files cannot drift apart again.
+    #[test]
+    fn tls_error_kinds_match_the_real_classifier_output() {
+        #[derive(Debug)]
+        struct E(&'static str);
+        impl std::fmt::Display for E {
+            fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+                f.write_str(self.0)
+            }
+        }
+        impl std::error::Error for E {}
+        let classified = |raw: &'static str| {
+            FetchError::Tls(crate::transport::tls::classify_handshake_error(&E(raw)))
+        };
+        // Middlebox kills the handshake: reset / early EOF.
+        assert_eq!(
+            fetch_error_kind(&classified("connection reset by peer")),
+            "tls.egress"
+        );
+        assert_eq!(
+            fetch_error_kind(&classified("unexpected EOF during handshake")),
+            "tls.egress"
+        );
+        // Re-signed cert from an untrusted interception CA.
+        assert_eq!(
+            fetch_error_kind(&classified("certificate verify failed: unknown ca")),
+            "tls.verify"
+        );
+        // Unclassified boring text stays permanent.
+        assert_eq!(
+            fetch_error_kind(&classified("some exotic library error")),
+            "permanent"
+        );
+    }
 
     // search_error used to hardcode errorKind: "transient" for every
     // failure, including validate_query rejections (empty/oversized


### PR DESCRIPTION
## What

Follow-up to 9d02afa (#154): `fetch_error_kind` in `mcp/server.rs` checks its `tls.verify` patterns before `tls.egress`, and one of them is `msg.contains("SSL_CERT_FILE")`. But `EGRESS_HINT` in `transport/tls.rs` — appended by `classify_handshake_error` to **every** aborted/cut-short handshake message — contains that literal ("point SSL_CERT_FILE at the interception CA bundle"). So:

- every egress-interception failure (reset / early EOF mid-handshake) classified as `errorKind: "tls.verify"`;
- `next_action` gave the wrong recipe ("export SSL_CERT_FILE…") instead of the proxy-routing hint that the interception fix exists to give;
- the `tls.egress` arm was unreachable — its own patterns ("egress path", "TLS handshake aborted", "cut short") only occur in messages that already contain "SSL_CERT_FILE";
- and `error_code()` (which classifies the same failure from the friendly text) got it right, so the two classifiers disagreed with each other — the same split-condition drift shape as #124.

## Fix

Match on the classifier's own leading sentences, never on hint text, egress checked first:

- `tls.egress`: `starts_with("TLS handshake aborted")` / `starts_with("TLS handshake cut short")`
- `tls.verify`: `starts_with("TLS certificate verification failed")` (plus the existing "trusted root" fallback)

## Testing

- New test `tls_error_kinds_match_the_real_classifier_output` builds its inputs by running the **real** `classify_handshake_error` over raw boring-style errors — not hand-written strings — so `server.rs` and `tls.rs` can't silently drift apart again. Fails on master with `left: "tls.verify", right: "tls.egress"`, passes with the fix.
- Full `cargo test --lib` (912 tests), `cargo clippy --all-targets`, `cargo fmt --check` all clean.

https://claude.ai/code/session_01Vg2CMnuvDevTxCpmJGbnRU