### PR TITLE
fix(fetch): raw plaintext proxy hop sent no Proxy-Authorization; SOCKS5 tunnels carried absolute-form to the origin

### DIFF
--- a/src/fetch/client.rs
+++ b/src/fetch/client.rs
@@ -557,13 +557,32 @@ impl Fetcher {
         // no session resumption, no ALPN.
         if !is_https {
             let mut stream = tcp;
-            // Proxied plaintext http:// uses absolute-form request
-            // targets (RFC 9112 3.2.2): the proxy needs the full
-            // origin in the request line to route it.
-            let target = if proxy.is_some() {
+            // Plaintext http:// through a raw HTTP-proxy hop uses
+            // absolute-form request targets (RFC 9112 3.2.2): the
+            // proxy needs the full origin in the request line to
+            // route it. ONLY that hop : a SOCKS5 tunnel is
+            // transparent, so the ORIGIN reads this line, and no
+            // browser sends an origin absolute-form (fingerprint;
+            // same condition as the dial above).
+            let raw_http_proxy = proxy.filter(|p| p.is_http_connect());
+            let target = if raw_http_proxy.is_some() {
                 url_of("http", authority, path)
             } else {
                 path.to_string()
+            };
+            // The raw hop has no CONNECT to carry credentials : a
+            // credentialed proxy needs Proxy-Authorization on the
+            // request itself (consumed by the proxy, never
+            // forwarded to the origin).
+            let with_auth: Vec<(String, String)>;
+            let req_headers = match raw_http_proxy.and_then(|p| p.proxy_authorization()) {
+                Some(auth) => {
+                    let mut h = req_headers.to_vec();
+                    h.push(("proxy-authorization".to_string(), auth));
+                    with_auth = h;
+                    &with_auth[..]
+                }
+                None => req_headers,
             };
             let resp =
                 tokio::time::timeout(RESPONSE_TIMEOUT, h1::get(&mut stream, &target, req_headers))

--- a/src/transport/proxy.rs
+++ b/src/transport/proxy.rs
@@ -177,6 +177,20 @@ impl Proxy {
         Ok(stream)
     }
 
+    /// `Proxy-Authorization` value for this proxy, if credentialed.
+    /// CONNECT tunnels and SOCKS5 authenticate in-protocol, but the
+    /// raw absolute-form plaintext hop has no tunnel setup to carry
+    /// credentials : each request must send this header itself.
+    pub fn proxy_authorization(&self) -> Option<String> {
+        if self.user.is_empty() {
+            return None;
+        }
+        Some(format!(
+            "Basic {}",
+            base64(&format!("{}:{}", self.user, self.pass))
+        ))
+    }
+
     // ── HTTP CONNECT (RFC 7231 §4.3.6) ──
 
     async fn http_connect(
@@ -185,20 +199,18 @@ impl Proxy {
         target_host: &str,
         target_port: u16,
     ) -> Result<(), FetchError> {
-        let req = if self.user.is_empty() {
-            format!(
+        let req = match self.proxy_authorization() {
+            None => format!(
                 "CONNECT {target_host}:{target_port} HTTP/1.1\r\n\
                  Host: {target_host}:{target_port}\r\n\
                  Proxy-Connection: keep-alive\r\n\r\n"
-            )
-        } else {
-            let auth = base64(&format!("{}:{}", self.user, self.pass));
-            format!(
+            ),
+            Some(auth) => format!(
                 "CONNECT {target_host}:{target_port} HTTP/1.1\r\n\
                  Host: {target_host}:{target_port}\r\n\
-                 Proxy-Authorization: Basic {auth}\r\n\
+                 Proxy-Authorization: {auth}\r\n\
                  Proxy-Connection: keep-alive\r\n\r\n"
-            )
+            ),
         };
         tokio::time::timeout(PROXY_TIMEOUT, stream.write_all(req.as_bytes()))
             .await

--- a/tests/egress_proxy.rs
+++ b/tests/egress_proxy.rs
@@ -246,3 +246,149 @@ async fn plaintext_http_through_env_proxy_uses_absolute_form() {
         "expected absolute-form GET, saw: {seen:?}"
     );
 }
+
+// The raw absolute-form hop has no CONNECT to carry credentials:
+// the request itself must send Proxy-Authorization, exactly like
+// curl does for plaintext http:// through an authenticated proxy.
+// Without it, every credentialed HTTP proxy (residential lanes are
+// essentially always credentialed) answers 407.
+#[tokio::test(flavor = "multi_thread")]
+#[allow(clippy::await_holding_lock)]
+async fn plaintext_http_through_credentialed_proxy_sends_proxy_authorization() {
+    let _env = ENV_LOCK.lock().unwrap();
+    let mitm = spawn_mitm().await;
+    // SAFETY: process-scoped, single-threaded with respect to env.
+    unsafe {
+        std::env::set_var("HTTP_PROXY", format!("http://u:p@{}", mitm.addr));
+        std::env::set_var("ALL_PROXY", format!("http://u:p@{}", mitm.addr));
+        std::env::set_var("DONSETCH_ALLOW_PRIVATE_EGRESS", "1");
+    }
+
+    let fetcher = Fetcher::new(BrowserProfile::chrome_150(
+        donsetch::profile::Platform::Linux,
+    ))
+    .expect("fetcher builds");
+    let out = fetcher
+        .fetch("http://console.example/plain")
+        .await
+        .expect("plaintext through credentialed proxy");
+    assert_eq!(String::from_utf8_lossy(&out.body), "plain-http");
+    let seen = mitm.seen.lock().unwrap();
+    let head = seen
+        .iter()
+        .find(|h| h.starts_with("GET http://console.example/plain "))
+        .expect("absolute-form GET reached the proxy");
+    // base64("u:p") = "dTpw"
+    assert!(
+        head.to_lowercase()
+            .contains("proxy-authorization: basic dtpw"),
+        "credentialed hop must authenticate per-request, head was: {head}"
+    );
+}
+
+/// Minimal in-process SOCKS5 "proxy": accepts the no-auth handshake
+/// and then plays the ORIGIN itself (reads the HTTP head off the
+/// tunnel, records it, answers 200). What it records is exactly what
+/// the origin server would see arrive through a real tunnel.
+async fn spawn_socks5() -> (SocketAddr, Arc<std::sync::Mutex<Vec<String>>>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let seen: Arc<std::sync::Mutex<Vec<String>>> = Arc::new(std::sync::Mutex::new(Vec::new()));
+    let seen2 = seen.clone();
+    tokio::spawn(async move {
+        loop {
+            let Ok((mut tcp, _)) = listener.accept().await else {
+                continue;
+            };
+            let seen = seen2.clone();
+            tokio::spawn(async move {
+                // Greeting: VER NMETHODS METHODS... -> pick no-auth.
+                let mut hdr = [0u8; 2];
+                if tcp.read_exact(&mut hdr).await.is_err() || hdr[0] != 0x05 {
+                    return;
+                }
+                let mut methods = vec![0u8; hdr[1] as usize];
+                if tcp.read_exact(&mut methods).await.is_err() {
+                    return;
+                }
+                if tcp.write_all(&[0x05, 0x00]).await.is_err() {
+                    return;
+                }
+                // CONNECT request: VER CMD RSV ATYP DST PORT.
+                let mut req = [0u8; 4];
+                if tcp.read_exact(&mut req).await.is_err() || req[3] != 0x03 {
+                    return;
+                }
+                let mut len = [0u8; 1];
+                if tcp.read_exact(&mut len).await.is_err() {
+                    return;
+                }
+                let mut dst = vec![0u8; len[0] as usize + 2];
+                if tcp.read_exact(&mut dst).await.is_err() {
+                    return;
+                }
+                if tcp
+                    .write_all(&[0x05, 0x00, 0x00, 0x01, 0, 0, 0, 0, 0, 0])
+                    .await
+                    .is_err()
+                {
+                    return;
+                }
+                // Tunnel established: now be the origin.
+                let mut head = Vec::new();
+                let mut byte = [0u8; 1];
+                while !head.ends_with(b"\r\n\r\n") {
+                    match tcp.read(&mut byte).await {
+                        Ok(0) | Err(_) => return,
+                        Ok(_) => head.push(byte[0]),
+                    }
+                    if head.len() > 8192 {
+                        return;
+                    }
+                }
+                seen.lock()
+                    .unwrap()
+                    .push(String::from_utf8_lossy(&head).to_string());
+                tcp.write_all(
+                    b"HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: 11\r\nConnection: close\r\n\r\nsocks-plain",
+                )
+                .await
+                .ok();
+            });
+        }
+    });
+    (addr, seen)
+}
+
+// A SOCKS5 hop is a transparent tunnel to the ORIGIN: the request
+// line the origin sees must be origin-form ("GET /plain"), like
+// every browser sends. Absolute-form belongs only on the raw
+// HTTP-proxy hop; leaking it through the tunnel is a fingerprint
+// (and picky origins/CDNs reject it).
+#[tokio::test(flavor = "multi_thread")]
+#[allow(clippy::await_holding_lock)]
+async fn plaintext_http_through_socks5_uses_origin_form() {
+    let _env = ENV_LOCK.lock().unwrap();
+    let (addr, seen) = spawn_socks5().await;
+    // SAFETY: process-scoped, single-threaded with respect to env.
+    unsafe {
+        std::env::set_var("HTTP_PROXY", format!("socks5://{addr}"));
+        std::env::set_var("ALL_PROXY", format!("socks5://{addr}"));
+        std::env::set_var("DONSETCH_ALLOW_PRIVATE_EGRESS", "1");
+    }
+
+    let fetcher = Fetcher::new(BrowserProfile::chrome_150(
+        donsetch::profile::Platform::Linux,
+    ))
+    .expect("fetcher builds");
+    let out = fetcher
+        .fetch("http://console.example/plain")
+        .await
+        .expect("plaintext through socks5");
+    assert_eq!(String::from_utf8_lossy(&out.body), "socks-plain");
+    let seen = seen.lock().unwrap();
+    assert!(
+        seen.iter().any(|h| h.starts_with("GET /plain ")),
+        "origin-form GET expected through the tunnel, saw: {seen:?}"
+    );
+}


### PR DESCRIPTION
## What

Two follow-up bugs in 9d02afa's (#154) new plaintext-via-proxy path in `fetch/client.rs::fresh_request`:

**1. The raw absolute-form hop never authenticates.** `http://` through an HTTP proxy now goes raw (`connect_tcp` + absolute-form) — correctly, since CONNECT is for https. But unlike the CONNECT path (which sends `Proxy-Authorization` during tunnel setup, `proxy.rs`), nothing added the header to the raw request: `req_headers` is profile+cookies+referer only. A credentialed HTTP proxy — residential lanes essentially always are — answers **407 on every plaintext fetch**. The existing E2E test used an unauthenticated proxy, so it couldn't see this.

**2. SOCKS5 tunnels delivered absolute-form request lines to the origin.** The dial arm keys on `p.is_http_connect()`, but the request-target arm keyed on bare `proxy.is_some()`. A SOCKS5 proxy is a transparent tunnel to the **origin**, which then reads `GET http://host/path HTTP/1.1`. Spec-legal for servers to accept, but no browser sends absolute-form to an origin — a bot fingerprint in a Chrome-true client, and it contradicts the adjacent comment ("plaintext http:// through an HTTP proxy goes RAW…").

## Fix

- New `Proxy::proxy_authorization()` builds the `Basic …` value; the CONNECT path is refactored onto it (byte-identical request), and the raw hop appends it per-request. The header is injected only inside the raw-HTTP-proxy branch, whose dial predicate is literally the same — the stream endpoint is always the proxy when the header exists, so credentials can never reach an origin. The base64 alphabet also guarantees the value passes h1's CR/LF/NUL header guard regardless of env-URL contents.
- Both arms now share one `raw_http_proxy` binding, so target form and dial can't diverge again.

## Testing (tests/egress_proxy.rs)

- `plaintext_http_through_credentialed_proxy_sends_proxy_authorization`: credentialed env proxy → asserts the recorded head carries `proxy-authorization: Basic dTpw`. Fails on master (head has no such header, the real proxy would 407), passes with the fix.
- `plaintext_http_through_socks5_uses_origin_form`: new in-process SOCKS5 server (no-auth handshake, then plays the origin) → asserts the origin sees `GET /plain `. Fails on master with the absolute-form line captured verbatim, passes with the fix.
- Full `cargo nextest run --test egress_proxy` (5/5 incl. the three pre-existing MITM tests), `cargo test --lib` (910), clippy, fmt all clean.

Adversarially reviewed (credential-leak trace across the retry loop, pooled-h2 and redirect paths; `http_connect` refactor byte-compared). One pre-existing gap noted, not touched here: `Proxy::parse` does no percent-decoding of userinfo, so `u%40x` stays literal — shared with the CONNECT path since before this change.

https://claude.ai/code/session_01Vg2CMnuvDevTxCpmJGbnRU