### PR TITLE
fix(ghost): one non-UTF-8 Chrome stderr line failed the whole launch

### DIFF
--- a/src/ghost/mod.rs
+++ b/src/ghost/mod.rs
@@ -730,15 +730,11 @@ impl Ghost {
             .stderr
             .take()
             .ok_or_else(|| FetchError::ghost("no stderr pipe"))?;
-        let mut lines = BufReader::new(stderr).lines();
-        let ws_url = tokio::time::timeout(std::time::Duration::from_secs(15), async {
-            while let Ok(Some(line)) = lines.next_line().await {
-                if let Some(i) = line.find("ws://") {
-                    return Some(line[i..].trim().to_string());
-                }
-            }
-            None
-        })
+        let mut reader = BufReader::new(stderr);
+        let ws_url = tokio::time::timeout(
+            std::time::Duration::from_secs(15),
+            scan_for_ws_url(&mut reader),
+        )
         .await
         .map_err(|_| FetchError::ghost("devtools ws timeout"))?
         .ok_or_else(|| FetchError::ghost("no devtools ws line"))?;
@@ -1839,10 +1835,51 @@ fn b64decode(s: &[u8]) -> Vec<u8> {
     out
 }
 
+/// Scan Chrome's stderr for the "DevTools listening on ws://…"
+/// endpoint line. Lossy per line : Chrome's pre-DevTools chatter
+/// can carry raw non-UTF-8 bytes (fontconfig/library paths on odd
+/// locales), and `Lines::next_line()` returns Err on those, which
+/// used to end the scan and fail the launch with a misleading
+/// "no devtools ws line" while Chrome was actually up. The ws line
+/// itself is pure ASCII, so lossy decoding can never corrupt it.
+async fn scan_for_ws_url<R: tokio::io::AsyncBufRead + Unpin>(reader: &mut R) -> Option<String> {
+    let mut buf = Vec::new();
+    loop {
+        buf.clear();
+        match reader.read_until(b'\n', &mut buf).await {
+            Ok(0) | Err(_) => return None,
+            Ok(_) => {}
+        }
+        let line = String::from_utf8_lossy(&buf);
+        if let Some(i) = line.find("ws://") {
+            return Some(line[i..].trim().to_string());
+        }
+    }
+}
+
 #[cfg(test)]
 mod sandbox_tests {
     use super::*;
     use crate::profile::BrowserProfile;
+
+    // Chrome's pre-DevTools stderr chatter can carry raw non-UTF-8
+    // bytes (fontconfig/library paths on odd locales). Lines::
+    // next_line() returns Err on such a line, and the old
+    // `while let Ok(Some(..))` scan treated that as end-of-stream:
+    // the launch failed with a misleading "no devtools ws line"
+    // while Chrome was actually up. Same bug class as the fixed MCP
+    // stdio loop (#148); this is the only reader of Chrome's stderr.
+    #[tokio::test]
+    async fn ws_scan_survives_non_utf8_stderr_lines() {
+        let wire: &[u8] = b"Fontconfig warning: \xff\xfe/bad/path\n\
+                            DevTools listening on ws://127.0.0.1:9222/devtools/browser/abc\n";
+        let mut r = BufReader::new(wire);
+        assert_eq!(
+            scan_for_ws_url(&mut r).await.as_deref(),
+            Some("ws://127.0.0.1:9222/devtools/browser/abc"),
+            "a non-UTF-8 stderr line must not end the scan"
+        );
+    }
 
     #[test]
     fn default_args_do_not_contain_no_sandbox() {


### PR DESCRIPTION
## What

Follow-up to #148 (flagged in that PR's body at the time): `ghost/mod.rs`'s DevTools-ws wait loop had the same `while let Ok(Some(line)) = lines.next_line().await` shape as the fixed MCP stdio loop. tokio's `Lines` yields `Err` on an invalid-UTF-8 line, which this loop treats as end-of-stream.

## Impact

Chrome's pre-DevTools stderr chatter can carry raw non-UTF-8 bytes — fontconfig/library warnings embed filesystem paths verbatim on odd locales. One such line before `DevTools listening on ws://…` ends the scan early, and the launch fails with a misleading `no devtools ws line` while Chrome is actually up (it then gets killed via `kill_on_drop`). This loop is the **only** reader of Chrome's stderr, so nothing downstream recovers.

## Fix

`read_until(b'\n')` + `String::from_utf8_lossy` per line, extracted into `scan_for_ws_url(reader)` so the behavior is unit-testable without launching Chrome. The DevTools line itself is pure ASCII, so lossy decoding can never corrupt the endpoint URL; the `ws://` match index stays a valid char boundary either way.

## Testing

- New test `ws_scan_survives_non_utf8_stderr_lines` feeds a `\xff\xfe` line ahead of the DevTools line — fails against the old `Lines`-based scan (returns `None`, verified by implementing the extraction with the old semantics first), passes with the lossy scan.
- Full `cargo test --lib` (911 tests), `cargo clippy --all-targets`, `cargo fmt --check` all clean.

https://claude.ai/code/session_01Vg2CMnuvDevTxCpmJGbnRU