### PR TITLE
fix(cli): SIGPIPE default disposition killed the supervisor's crash recovery

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,20 +4,31 @@ use donsetch::mcp;
 
 #[tokio::main]
 async fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let cmd = args.get(1).map(|s| s.as_str()).unwrap_or("help");
+
     // CLI convention (rg, curl): a closed stdout pipe is normal,
     // not an error. Rust masks SIGPIPE by default, so every pipe-
     // tiled run (donsetch --help | head) turned the write into an
     // EPIPE panic with a full backtrace after head quit. Restoring
     // the default disposition makes the kill silent with exit 141,
-    // exactly what the shell expects. The MCP daemon inherits it
-    // too: when the transport pipe breaks, the client is gone and
-    // an instant exit beats a panic dump.
+    // exactly what the shell expects.
+    //
+    // NOT for `mcp`, though : SIG_DFL is process-wide, and in the
+    // daemon it turns every EPIPE into an instant kill. That
+    // bypasses stdio.rs's clean broken-transport shutdown (ghost
+    // cleanup included; macOS Chrome has no pdeathsig to fall
+    // back on), lets a BYOK plugin that exits without reading its
+    // stdin take the whole daemon down through the request write,
+    // and kills the supervisor exactly when its crashed child's
+    // stdin comes back EPIPE : the hold-restart-replay contract
+    // (supervisor.rs) depends on seeing that as an error.
     #[cfg(unix)]
-    unsafe {
-        libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+    if cmd != "mcp" {
+        unsafe {
+            libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+        }
     }
-    let args: Vec<String> = std::env::args().collect();
-    let cmd = args.get(1).map(|s| s.as_str()).unwrap_or("help");
 
     match cmd {
         // ── Agent tools (spec-driven, shared core, clap-parsed) ──

--- a/src/mcp/supervisor.rs
+++ b/src/mcp/supervisor.rs
@@ -69,6 +69,18 @@ where
     R: Read + Send + 'static,
     W: Write + Send + 'static,
 {
+    // main() restores SIGPIPE's default disposition so piped CLI
+    // output dies quietly : this process must not. The crash
+    // contract below depends on a write to a dead child's stdin
+    // coming back as an EPIPE error (hold the bytes, restart,
+    // replay) rather than a signal that kills the supervisor; and
+    // a broken output pipe just means the client left (handled at
+    // the write). The child daemon is unaffected : it makes its
+    // own choice in its own main().
+    #[cfg(unix)]
+    unsafe {
+        libc::signal(libc::SIGPIPE, libc::SIG_IGN);
+    }
     let mut restarts: u32 = 0;
     let mut pending: Vec<u8> = Vec::new();
     let output = Arc::new(Mutex::new(output));
@@ -267,6 +279,67 @@ mod tests {
         .unwrap();
         let got = sink.0.lock().unwrap().clone();
         assert_eq!(String::from_utf8_lossy(&got), "hello\n");
+    }
+
+    /// A client that sends one request after a delay long enough
+    /// for the first child to have died, then EOF.
+    #[cfg(unix)]
+    struct DelayedOnce(&'static [u8], bool);
+
+    #[cfg(unix)]
+    impl Read for DelayedOnce {
+        fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+            if self.1 {
+                return Ok(0);
+            }
+            std::thread::sleep(Duration::from_millis(300));
+            self.1 = true;
+            buf[..self.0.len()].copy_from_slice(self.0);
+            Ok(self.0.len())
+        }
+    }
+
+    // main() restores SIGPIPE's default disposition for the CLI
+    // (quiet `donsetch --help | head` exits). The supervisor's
+    // whole crash contract, though, is built on the write to a
+    // dead child's stdin coming back as an EPIPE *error* (hold
+    // the bytes, restart, replay): under SIG_DFL that write is a
+    // SIGPIPE that kills the supervisor itself before write_all
+    // returns. run_with must pin SIG_IGN for its own process no
+    // matter what main() set. Without the fix this test does not
+    // fail an assert : the test process dies by signal 13.
+    #[cfg(unix)]
+    #[test]
+    fn crash_mid_write_restarts_even_with_cli_sigpipe_disposition() {
+        unsafe {
+            libc::signal(libc::SIGPIPE, libc::SIG_DFL);
+        }
+        let sink = Sink::default();
+        let spawns = Arc::new(Mutex::new(0u32));
+        let spawns2 = Arc::clone(&spawns);
+        run_with(
+            move || {
+                let mut n = spawns2.lock().unwrap();
+                *n += 1;
+                let mut c = Command::new("sh");
+                // First child dies instantly; its replacement serves.
+                c.args(["-c", if *n == 1 { "exit 0" } else { "cat" }]);
+                c
+            },
+            DelayedOnce(b"ping\n", false),
+            sink.clone(),
+        )
+        .unwrap();
+        assert!(
+            *spawns.lock().unwrap() >= 2,
+            "the dead child must have been replaced"
+        );
+        let got = sink.0.lock().unwrap().clone();
+        assert_eq!(
+            String::from_utf8_lossy(&got),
+            "ping\n",
+            "the held request must replay to the restarted child"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## What

Follow-up to d202703: `signal(SIGPIPE, SIG_DFL)` in `main()` is process-wide, and three daemon-side paths depend on a broken-pipe write coming back as an **EPIPE error**, not a killing signal:

1. **The supervisor's crash contract is dead code under SIG_DFL.** `supervisor.rs`'s recovery hinges on `stdin.write_all(&bytes)` to a dead child returning `Err` — "daemon died mid-write : holding request for restart". With SIG_DFL, that write delivers SIGPIPE and kills the supervisor itself, at exactly the moment it exists for (the daemon just crashed, a request is in hand). The client loses the whole session instead of a transparent restart+replay. CI never saw it because the disposition is set in `main()`, which unit tests don't run.
2. **`stdio.rs` already handles a broken transport gracefully** — "stdout write failed, shutting down" → clean shutdown, ghost cleanup included (relevant on macOS, where Chrome has no pdeathsig to fall back on). The instant SIG_DFL kill bypasses all of that. The pre-d202703 daemon didn't stack-dump on a broken pipe — it took this clean path.
3. **`byok/plugin.rs` writes the request to a plugin child's stdin** (`let _ = si.write_all(...)` — deliberately error-tolerant). A misbehaving plugin that exits without reading stdin would now take the whole daemon down through that write.

Mechanism proven in a scratch crate: child exits, parent writes to its stdin — `SIG_DFL` → silent death, exit 141, no output; `SIG_IGN` → `Err(BrokenPipe)` and the process continues. (TCP writes are unaffected either way — std sets `MSG_NOSIGNAL`/`SO_NOSIGPIPE` on sockets — so this is strictly about pipes.)

## Fix

- `main.rs`: set `SIG_DFL` for every command **except `mcp`** — the quiet `donsetch --help | head` / tool-pipe exit convention from d202703 is fully preserved (re-verified on the built binary: exit 141, zero stderr).
- `supervisor.rs::run_with`: pin `SIG_IGN` for the supervisor's own process, so the contract holds regardless of what `main()` chose. The child daemon re-decides in its own `main()` (`mcp` → keeps ignore, matching `stdio.rs`'s error-path design).

## Testing

- New test `crash_mid_write_restarts_even_with_cli_sigpipe_disposition`: sets the CLI disposition the way `main()` does, first child exits instantly, a request arrives after it's dead, a replacement child (`cat`) must receive the replayed bytes. On master, nextest reports it literally as **`SIGPIPE [0.31s] … (test aborted with signal 13: SIGPIPE)`** — the supervisor process dies; with the fix it passes, asserting both the respawn and the replay.
- Full `cargo nextest run` (954/954), `cargo clippy --all-targets`, `cargo fmt --check` all clean.

One residual trade-off, inherent to SIG_DFL on the tool commands and left as-is: `donsetch search` (CLI mode) with a BYOK *plugin* that crashes without reading stdin dies with exit 141 instead of reporting a plugin error — the daemon paths are what this PR protects. Flagging rather than fixing, since per-write SIGPIPE suppression on pipes isn't portably available.

https://claude.ai/code/session_01Vg2CMnuvDevTxCpmJGbnRU