### PR TITLE
fix(search): clarify index-family labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to DonSeTch are documented here.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- Clarify compact search labels: counts describe search-index families that
+  returned a URL, not independent sources corroborating its claims. The weak
+  results message now refers to cross-index agreement. Ranking is unchanged.
+
 ## [3.6.7] - 2026-09-07
 
 ### Fixed

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -950,6 +950,8 @@ mod tests {
         ];
         // 5 engines, 3 families (bing family dedups to one opinion).
         assert_eq!(rank::family_count(&r), 3);
+        let markdown = render_compact_markdown(&outcome(vec![r]), "", None, &[]);
+        assert!(markdown.contains("3 index families"), "{markdown}");
     }
 
     #[test]
@@ -1253,12 +1255,13 @@ mod tests {
             &[Some("· ⚠ needs browser".into())],
         );
         assert!(
-            markdown
-                .contains("1. S1 · Tokio runtime guide : tokio.rs · ⚠ needs browser · 1 source"),
-            "corroboration rides the same line, after the route hint: {markdown}"
+            markdown.contains(
+                "1. S1 · Tokio runtime guide : tokio.rs · ⚠ needs browser · 1 index family"
+            ),
+            "index-family count follows the route hint: {markdown}"
         );
         assert!(markdown.contains("A focused explanation"));
-        assert!(markdown.contains("Weak results : low cross-source agreement."));
+        assert!(markdown.contains("Weak results : low cross-index agreement."));
         assert!(markdown.contains("Degraded retrieval : 1/2 backends available."));
         for diagnostic in [
             "engines:",

--- a/src/search/render.rs
+++ b/src/search/render.rs
@@ -235,20 +235,18 @@ pub fn render_compact_markdown(
             index + 1,
             result.title
         ));
-        // Corroboration on the model surface: how many independent
-        // index families agree determines how much a result can be
-        // trusted sight-unseen. Counting families (not engines) is
-        // the same math the ranking uses, so the number stays
-        // honest across correlated engines.
+        // Report how many search-index families returned this URL,
+        // using the same count as ranking. This is retrieval agreement,
+        // not independent corroboration of the page's claims.
         let families = rank::family_count(result);
         if let Some(hint) = hints.get(index).and_then(|hint| hint.as_deref()) {
             markdown.push(' ');
             markdown.push_str(hint);
         }
         markdown.push_str(&format!(
-            " · {} {}",
+            " · {} index {}",
             families,
-            if families == 1 { "source" } else { "sources" }
+            if families == 1 { "family" } else { "families" }
         ));
         markdown.push('\n');
         if !result.snippet.is_empty() {
@@ -261,7 +259,7 @@ pub fn render_compact_markdown(
     if out.results.is_empty() {
         markdown.push_str("No results. Retry once with a materially different formulation.\n");
     } else if out.weak {
-        markdown.push_str("Weak results : low cross-source agreement.\n");
+        markdown.push_str("Weak results : low cross-index agreement.\n");
     }
 
     let unavailable = out


### PR DESCRIPTION
Compact search results currently label the number of search-index families that returned a URL as "sources". This can be read as independent corroboration of the page's claims. This change uses "1 index family" / "N index families" and "low cross-index agreement" to describe the existing signal precisely. Counting, ranking, retrieval, and structured metadata remain unchanged.

This might help models interpret the signal more accurately, but I am not sure it improves their behavior: I have not run a behavioral evaluation. The concrete benefit is removing the ambiguity between multiple search indexes returning the same page and multiple independent sources corroborating its claims.

Would you consider this wording useful? I would appreciate your assessment of whether the clearer label is worth the small token increase, or whether you would prefer a different formulation.

### Validation

Using Rust 1.98, the locked dependencies, the `ci` profile, and `ocr,rerank,http`:

- `cargo test --locked --profile ci --lib search::tests --features ocr,rerank,http -- --test-threads=1`: 36 passed.
- `cargo test --locked --profile ci --lib mcp:: --features ocr,rerank,http -- --test-threads=1`: 55 passed.
- `cargo test --locked --profile ci --lib spec:: --features ocr,rerank,http -- --test-threads=1`: 4 passed.
- `cargo clippy --locked --profile ci --all-targets --features ocr,rerank,http -- -D warnings`: passed.
- `cargo fmt --all -- --check` and `git diff --check`: passed.

The existing tests now check the singular label, the weak-results wording, and that five engines sharing indexes render as three index families. This is targeted validation, not a claim that the full test suite ran.

Local build note: the default BoringSSL CMake configuration failed in its benchmark regex probe. Tests and Clippy used an existing local BoringSSL build through the supported `BORING_BSSL_PATH` / `BORING_BSSL_INCLUDE_PATH` overrides; its headers match the current dependency's patched headers. No dependency source or repository build configuration was changed.

With `o200k_base`, the isolated per-result label grows from 4 to 5 tokens (+1 per result); the weak-results sentence remains at 8 tokens. These are local tokenizer measurements, not a client billing measurement.

