### PR TITLE
feat(search): bring back fast, keyless Google search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ channel until the v4.0.0 release train.
 
 ### Added
 
+- Native keyless Google search via the legacy mobile endpoint, using
+  DonShadow without a browser or paid API. Seven selectable Nokia
+  profiles (`DONSETCH_GOOGLE_PROFILE`, default `6230-03.15`), observed
+  working in local tests; availability is not guaranteed. An explicit
+  CAPTCHA permits one next-profile attempt in the existing thin-merge
+  retry wave; successful profiles remain preferred per egress in
+  memory, with circular advancement on CAPTCHA and no profile cooldowns.
+  Profile selection resets on restart. HTTP 429 and other walls do
+  not rotate. Native and
+  browser Google share one ranking family but keep separate health.
 - Route memory: fetches learn route health per tier (EWMA latency by
   route, failure classes, LRU-bounded store). Tier 1 rides healthy
   routes only; persistent failures quarantine and a background probe
@@ -78,6 +88,14 @@ channel until the v4.0.0 release train.
 
 ### Fixed
 
+- Search pacing uses cancellation-safe per-engine/egress admission;
+  waiting is included in attempt deadlines and cancelled waiters
+  leave no future-slot debt. Google HTTP health is isolated from
+  legacy browser health; Google follows common failure and quarantine rules.
+- Search retries retain completed peers when another retry times out
+  and report retry timeouts explicitly, with the attempted Google
+  profile when available. At most one retry per engine per search. Ordinary
+  retries, including Google, keep a three-second budget including pacing.
 - **#164 audit wave (S1-S6 in the search/fetch stack):**
   S1: version matching is boundary-aware; "5.2" no longer matches
   "15.2" or "5.20" but still matches "5.2.1" and "v5.2".

--- a/README.md
+++ b/README.md
@@ -547,16 +547,24 @@ Disable with `DONSEEK_NO_DISK_STATE=1`.
 
 ## 🔎 Keyless search
 
-No API key, no account. 5 keyless engines across 4 independent index
+No API key, no account. 6 keyless engines across 4 independent index
 families + 8 official verticals run in parallel on your machine, merged,
 deduped, ranked.
 
-- **Backends:** Bing-family (Bing, DuckDuckGo, Yahoo), Brave, Mojeek
+- **Backends:** Bing-family (Bing, DuckDuckGo, Yahoo), Brave, Mojeek, Google
   + keyless verticals (GitHub, Wikipedia, HN, Semantic Scholar, arXiv,
   StackExchange, MDN, Google News).
+- **Native Google:** browser-free HTTP via the legacy mobile endpoint, using
+  the existing Rust transport. Seven selectable, experimentally verified Nokia
+  profiles; the default is `6230-03.15`. No paid API or CAPTCHA solver.
+  Successful profiles remain preferred per egress in memory; CAPTCHA advances
+  circularly through the profiles. Retry, pacing and quarantine use the same
+  policy as other engines, with no per-profile cooldowns. Selection resets on
+  restart. Rate limits do not advance the profile cursor.
+  Availability depends on Google and the network; see [configuration and limits](docs/google-wml.md).
 - **Ghost SERP cascade lane:** if the plain fan-out and its retry wave
-  leave the merge thin (<3 lanes or <15 hits), one headless render
-  unlocks Google's 2026 JS-shell SERP as a 4th consensus family. Costs
+  leave the merge thin (<3 lanes or <15 hits) and native Google failed,
+  one headless render can recover Google's desktop SERP. Costs
   nothing when healthy (only fires under underdelivery); reports itself
   honestly as `google_ghost`.
 - **Semantic reranking**: local ONNX cross-encoder

--- a/docs/google-wml.md
+++ b/docs/google-wml.md
@@ -1,0 +1,70 @@
+# Native Google search
+
+Google participates in the default keyless search through DonShadow HTTP.
+No browser, paid API, CSE dependency or interactive CAPTCHA solver is required
+for this lane. The unofficial mobile endpoint can change or stop working;
+local successes do not establish long-term availability or browser-equivalent results.
+
+## Configuration and lifecycle
+
+`DONSETCH_GOOGLE_PROFILE` selects the initial profile (default `6230-03.15`).
+Valid IDs, in rotation order: `6230-03.15`, `6230-05.50`, `6230-04.44`, `6230i-03.80`,
+`6280-03.60`, `7610-5.0509.0`, `7610-7.0642.0`.
+Set it before startup; unknown/empty values fail only the Google lane.
+
+- Preference is **in memory, per egress**; restart resets it. There are no
+  per-profile cooldowns or suspensions: CAPTCHA advances A → B → … → A.
+- A valid parsed success retains the profile. The common thin-merge retry wave
+  decides whether to make one extra attempt and chooses its egress normally.
+  On an untouched egress, a CAPTCHA retry selects the profile after the failed
+  one. An evolved egress cursor takes precedence over old retry evidence,
+  including after wraparound. Other failures do not advance the cursor.
+- Generation checks prevent stale outcomes undoing a new preference;
+  success on the unchanged profile does not invalidate other in-flight outcomes.
+- Pacing admission is FIFO and cancellation-safe, with no future-slot debt.
+  Admission and I/O share an eight-second budget for initial engine attempts;
+  all retries retain the common three-second budget. Synchronous
+  parsing is not preemptible. Retry timeouts remain visible in reports.
+- All Google failures, including CAPTCHA, follow normal engine/egress health,
+  quarantine and direct-fallback rules. A circular cursor cannot override them.
+  `google_http_v1` isolates native health from legacy browser records.
+  Browser health stays `google_ghost`; both count as one Google ranking family.
+- Reports optionally expose the attempted `profile`. Cached IDs are historical
+  evidence, never restored profile preferences. Old cache records remain readable.
+  Native success suppresses the automatic browser cascade unless explicitly forced.
+
+## Code ownership
+
+`engines/google_wml.rs` owns URLs, parsing and the process-local profile selector.
+The searcher owns the adapter state; the generic egress pool knows no profiles.
+`egress.rs` owns pacing/egress health, `tasks.rs` bounds one attempt, and
+`search/mod.rs` owns retry scheduling. The existing fetcher supplies request-local,
+cookie-less headers, URL guards, TLS validation and body limits.
+Unavailable egress skips only that engine. DDG endpoint aliases share the pool's
+health key for selection and reporting, not the broader ranking index family.
+No Chrome persona is replaced with a Nokia identity; this is header compatibility,
+not Nokia TLS emulation. CLI/MCP still share their dispatcher and ranking pipeline.
+
+## Verification
+
+Offline tests cover parsing, header isolation, circular profile advancement,
+stale outcomes, cancellation, deadlines and legacy report loading. Explicit live
+probe (one to five public queries; uses the configured initial identity, not the
+full search scheduler):
+
+```sh
+cargo run --profile ci --example google_wml_probe -- 'rust programming language'
+donsetch search 'rust programming language' --json
+```
+
+Seven profiles returned results in a limited local sample; some were checked on
+only one query. Live CAPTCHA recovery and sustained/cross-region reliability
+remain unverified. Full CI is required before merge.
+
+Protocol references, not runtime dependencies:
+[SearXNG](https://github.com/searxng/searxng/blob/master/searx/engines/google.py),
+[DDGS](https://github.com/deedy5/ddgs/blob/main/ddgs/engines/google.py).
+Additional profile strings were located in
+[WAP-Browser-data](https://github.com/bevelgacom/WAP-Browser-data) and
+[Wordlist-Collection](https://github.com/gurkylee/Wordlist-Collection/blob/main/user_agents/software_name/nokia_browser.txt);
+a listed User-Agent is not proof of an authenticated physical device.

--- a/examples/google_wml_probe.rs
+++ b/examples/google_wml_probe.rs
@@ -1,0 +1,97 @@
+//! Explicit live probe: cargo run --profile ci --example google_wml_probe -- "rust programming language"
+//! One direct HTTP request per query, no browser, proxy, API key or persisted search state.
+//! Optional GOOGLE_PROBE_BASELINE=1 also tests the ordinary desktop endpoint.
+//! GOOGLE_PROBE_USER_AGENT overrides only this experiment's WML identity.
+use donsetch::{fetch::client::Fetcher, profile::BrowserProfile, search::engines};
+use std::time::{Duration, Instant};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let queries: Vec<_> = std::env::args().skip(1).collect();
+    if queries.is_empty() || queries.len() > 5 {
+        return Err("provide 1–5 public, non-sensitive queries".into());
+    }
+    let fetcher = Fetcher::new(BrowserProfile::host_default())?;
+    let user_agent = match std::env::var("GOOGLE_PROBE_USER_AGENT") {
+        Ok(ua) => ua,
+        Err(_) => engines::google_wml::configured_user_agent()
+            .ok_or("invalid DONSETCH_GOOGLE_PROFILE")?
+            .to_owned(),
+    };
+    let mut failed = false;
+    for query in queries {
+        let modes = if std::env::var_os("GOOGLE_PROBE_BASELINE").is_some() {
+            vec!["google", "google_ghost"]
+        } else {
+            vec!["google"]
+        };
+        for mode in modes {
+            let started = Instant::now();
+            let url = engines::serp_url(mode, &query).unwrap();
+            let response = tokio::time::timeout(Duration::from_secs(8), async {
+                if mode == "google" {
+                    fetcher
+                        .fetch_once_via_user_agent(&url, None, &user_agent)
+                        .await
+                } else {
+                    // Desktop endpoint over HTTP only; no ghost browser is started.
+                    fetcher.fetch_once_via(&url, &[], None, false, None).await
+                }
+            })
+            .await;
+            match response {
+                Ok(Ok(out)) => {
+                    let content_type = out
+                        .headers
+                        .iter()
+                        .find(|(n, _)| n.eq_ignore_ascii_case("content-type"))
+                        .map(|(_, v)| v.as_str())
+                        .unwrap_or("");
+                    let html = donsetch::extract::charset::decode(&out.body, content_type);
+                    let error =
+                        engines::google_wml::response_error(out.status, &out.headers, &html);
+                    let hits = engines::parse(mode, &html);
+                    let ok = out.status == 200
+                        && out.verdict == donsetch::detect::walls::Verdict::ContentOk
+                        && error.is_none()
+                        && hits.len() >= 3;
+                    failed |= mode == "google" && !ok;
+                    println!(
+                        "{}",
+                        serde_json::json!({
+                            "query":query, "mode":mode, "browser":false, "status":out.status,
+                            "user_agent":if mode == "google" { &user_agent } else { &fetcher.profile().user_agent },
+                            "alpn":out.alpn, "bytes":out.body.len(), "ms":started.elapsed().as_millis(),
+                            "verdict":format!("{:?}",out.verdict), "error":error,
+                            "hits":hits.len(), "ok":ok,
+                            "results":hits.iter().take(5).map(|h| serde_json::json!({"title":h.title,"url":h.url,"snippet":h.snippet})).collect::<Vec<_>>()
+                        })
+                    );
+                    if out.status != 200
+                        || out.verdict != donsetch::detect::walls::Verdict::ContentOk
+                        || error.is_some()
+                    {
+                        // No retry/UA rotation to hammer a blocked endpoint.
+                        return Err("Google blocked or redirected the probe; stopping".into());
+                    }
+                }
+                other => {
+                    eprintln!(
+                        "query={query:?} mode={mode}: {}",
+                        match other {
+                            Ok(Err(e)) => e.to_string(),
+                            Err(_) => "timeout".into(),
+                            _ => unreachable!(),
+                        }
+                    );
+                    return Err("native HTTP probe failed".into());
+                }
+            }
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        }
+    }
+    if failed {
+        return Err("one or more WML queries produced no usable results".into());
+    }
+    Ok(())
+}

--- a/src/fetch/client.rs
+++ b/src/fetch/client.rs
@@ -43,6 +43,11 @@ pub struct FetchOutcome {
     pub elapsed: Duration,
 }
 
+struct RequestIdentity<'a> {
+    class: RequestClass,
+    legacy_user_agent: Option<&'a str>,
+}
+
 pub struct Fetcher {
     profile: BrowserProfile,
     connector: boring::ssl::SslConnector,
@@ -428,6 +433,62 @@ impl Fetcher {
         referer: Option<&str>,
         class: RequestClass,
     ) -> Result<FetchOutcome, FetchError> {
+        self.fetch_once_via_identity(
+            url_str,
+            conditional,
+            proxy,
+            use_jar,
+            referer,
+            RequestIdentity {
+                class,
+                legacy_user_agent: None,
+            },
+        )
+        .await
+    }
+
+    /// One cookie-less hop with a request-local legacy User-Agent.
+    /// Reuses TLS, connection pooling and URL guards; does not mutate the
+    /// shared browser profile or follow redirects with this identity.
+    pub async fn fetch_once_via_user_agent(
+        &self,
+        url_str: &str,
+        proxy: Option<&proxy::Proxy>,
+        user_agent: &str,
+    ) -> Result<FetchOutcome, FetchError> {
+        if user_agent.is_empty()
+            || !user_agent.is_ascii()
+            || user_agent.bytes().any(|b| b.is_ascii_control())
+        {
+            return Err(FetchError::Http("invalid User-Agent".into()));
+        }
+        self.fetch_once_via_identity(
+            url_str,
+            &[],
+            proxy,
+            false,
+            None,
+            RequestIdentity {
+                class: RequestClass::Navigation,
+                legacy_user_agent: Some(user_agent),
+            },
+        )
+        .await
+    }
+
+    async fn fetch_once_via_identity(
+        &self,
+        url_str: &str,
+        conditional: &[(String, String)],
+        proxy: Option<&proxy::Proxy>,
+        use_jar: bool,
+        referer: Option<&str>,
+        identity: RequestIdentity<'_>,
+    ) -> Result<FetchOutcome, FetchError> {
+        let RequestIdentity {
+            class,
+            legacy_user_agent: user_agent,
+        } = identity;
         // Centralized gate ensures credentials/host checks even for
         // direct fetch_once calls (e.g. tests, internal callers).
         // Includes DNS resolution : every target, including proxy
@@ -463,6 +524,19 @@ impl Fetcher {
 
         // Header set from profile (Chrome order, coherence) + cookie + conditionals.
         let mut req_headers = self.profile.h1_headers_for_class(&authority, &path, class);
+        if let Some(ua) = user_agent {
+            // These browser metadata headers do not describe a legacy client.
+            req_headers.retain(|(n, _)| {
+                !n.starts_with("sec-ch-ua")
+                    && !n.starts_with("sec-fetch-")
+                    && n != "upgrade-insecure-requests"
+            });
+            for (name, value) in &mut req_headers {
+                if name == "user-agent" {
+                    *value = ua.to_owned();
+                }
+            }
+        }
         if use_jar {
             let jar = self
                 .jar

--- a/src/search/byok/mod.rs
+++ b/src/search/byok/mod.rs
@@ -248,6 +248,7 @@ impl ByokSearcher {
                     let results = to_merged(outcome.hits, &provider, max);
                     let report = vec![EngineReport {
                         engine: provider.clone(),
+                        profile: None,
                         status: if outcome.degraded {
                             "degraded".into()
                         } else {

--- a/src/search/egress.rs
+++ b/src/search/egress.rs
@@ -17,7 +17,8 @@
 //!   startup and never assigned mid-query.
 
 use std::collections::HashMap;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
+type PaceGate = Arc<tokio::sync::Mutex<Option<Instant>>>;
 use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::{Duration, Instant};
 
@@ -37,6 +38,15 @@ const DIRECT_JITTER_MS: u64 = 2000;
 /// because our residential IP isn't on blocklists.
 const PROXY_AVERSE: &[&str] = &["brave", "ddg"];
 
+/// Health is shared by DDG's primary and alternate endpoints. This is not
+/// ranking's index-family map: Bing and Yahoo keep their own egress health.
+pub(super) fn health_key(engine: &str) -> &str {
+    match engine {
+        "ddg_lite" | "ddg_html" => "ddg",
+        other => other,
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Health {
     Healthy,
@@ -54,11 +64,11 @@ pub struct Egress {
 struct PairState {
     health: Health,
     burned_until: Option<Instant>,
-    last_used: Option<Instant>,
 }
 
 pub struct EgressPool {
     egresses: Vec<Egress>,
+    pacing: Mutex<HashMap<(String, String), PaceGate>>,
     /// (engine, egress_id) -> state
     pairs: Mutex<HashMap<(String, String), PairState>>,
     /// Global proxy liveness (connect failures burn a proxy
@@ -94,6 +104,7 @@ impl EgressPool {
         }
         Self {
             egresses,
+            pacing: Mutex::new(HashMap::new()),
             pairs: Mutex::new(HashMap::new()),
             dead: Mutex::new(HashMap::new()),
             stress_ok: AtomicU32::new(2000), // seed optimistic
@@ -152,6 +163,7 @@ impl EgressPool {
     /// - everyone else rides proxies first; direct only as
     ///   last resort (protect the home IP)
     pub fn pick(&self, engine: &str, exclude: &[String], direct_available: bool) -> Option<Egress> {
+        let engine = health_key(engine);
         let pairs = self
             .pairs
             .lock()
@@ -226,6 +238,7 @@ impl EgressPool {
 
     /// Record a successful engine call through this egress.
     pub fn report_ok(&self, engine: &str, egress_id: &str) {
+        let engine = health_key(engine);
         self.stress_record(true);
         let mut pairs = self
             .pairs
@@ -236,16 +249,15 @@ impl EgressPool {
             .or_insert(PairState {
                 health: Health::Suspect,
                 burned_until: None,
-                last_used: None,
             });
         s.health = Health::Healthy;
         s.burned_until = None;
-        s.last_used = Some(Instant::now());
     }
 
     /// Engine rejected us (429 / challenge / empty parse):
     /// burn the pair, not the engine.
     pub fn report_blocked(&self, engine: &str, egress_id: &str) {
+        let engine = health_key(engine);
         self.stress_record(false);
         let mut pairs = self
             .pairs
@@ -256,7 +268,6 @@ impl EgressPool {
             .or_insert(PairState {
                 health: Health::Suspect,
                 burned_until: None,
-                last_used: None,
             });
         s.health = match s.health {
             Health::Healthy => Health::Suspect,
@@ -265,7 +276,6 @@ impl EgressPool {
                 Health::Burned
             }
         };
-        s.last_used = Some(Instant::now());
     }
 
     /// The egress line itself is dead (connect failure).
@@ -316,19 +326,79 @@ impl EgressPool {
             (MIN_INTERVAL, JITTER_MS)
         };
         let interval = base + Duration::from_millis(jitter(jit));
-        let wait = {
-            let pairs = self
-                .pairs
+        let gate = {
+            let mut gates = self
+                .pacing
                 .lock()
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
-            pairs
-                .get(&(engine.to_string(), egress_id.to_string()))
-                .and_then(|s| s.last_used)
-                .map(|t| interval.saturating_sub(t.elapsed()))
-                .unwrap_or(Duration::ZERO)
+            gates
+                .entry((engine.into(), egress_id.into()))
+                .or_insert_with(|| Arc::new(tokio::sync::Mutex::new(None)))
+                .clone()
         };
-        if !wait.is_zero() {
-            tokio::time::sleep(wait).await;
+        // FIFO, cancellation-safe admission. Waiters reserve no future slots.
+        // Cancellation drops the guard without changing the last admission.
+        let mut last = gate.lock().await;
+        if let Some(at) = *last {
+            tokio::time::sleep(interval.saturating_sub(at.elapsed())).await;
+        }
+        *last = Some(Instant::now());
+    }
+}
+
+#[cfg(test)]
+mod pacing_tests {
+    use super::*;
+
+    #[test]
+    fn regression_ddg_fallback_updates_the_selected_egress_health() {
+        let proxy = Proxy::parse("http://127.0.0.1:12345").unwrap();
+        let id = proxy.id();
+        let pool = EgressPool::new(vec![proxy]);
+        pool.report_blocked("ddg", &id);
+        pool.report_ok("ddg_html", &id);
+        assert_eq!(pool.pick("ddg", &[], false).map(|e| e.id), Some(id.clone()));
+        pool.report_blocked("ddg_html", &id);
+        pool.report_blocked("ddg_html", &id);
+        pool.report_ok("yahoo", &id);
+        assert!(pool.pick("ddg", &[], false).is_none());
+        assert!(pool.pick("ddg_html", &[], false).is_none());
+        assert!(pool.pick("yahoo", &[], false).is_some());
+        pool.report_ok("ddg_lite", &id);
+        assert!(pool.pick("ddg_html", &[], false).is_some());
+    }
+
+    #[tokio::test]
+    async fn cancelled_waiters_do_not_reserve_future_slots() {
+        let pool = EgressPool::new(Vec::new());
+        pool.pace("google", "direct").await;
+        let key = ("google".to_string(), "direct".to_string());
+        let gate = pool.pacing.lock().unwrap()[&key].clone();
+        let first = *gate.lock().await;
+        for _ in 0..20 {
+            assert!(
+                tokio::time::timeout(Duration::from_millis(1), pool.pace("google", "direct"))
+                    .await
+                    .is_err()
+            );
+        }
+        assert_eq!(*gate.lock().await, first);
+        pool.report_ok("google", "direct");
+        pool.report_blocked("google", "direct");
+        assert_eq!(*gate.lock().await, first);
+        assert!(
+            tokio::time::timeout(Duration::from_millis(20), pool.pace("bing", "direct"))
+                .await
+                .is_ok()
+        );
+    }
+
+    #[test]
+    fn direct_last_resort_is_the_same_for_all_engines() {
+        let pool = EgressPool::new(Vec::new());
+        for engine in ["google", "bing", "ddg", "brave"] {
+            pool.report_blocked(engine, "direct");
+            assert_eq!(pool.pick(engine, &[], true).unwrap().id, "direct");
         }
     }
 }

--- a/src/search/engines.rs
+++ b/src/search/engines.rs
@@ -4,6 +4,8 @@
 
 use scraper::{Html, Selector};
 
+pub mod google_wml;
+
 /// One raw hit from one engine.
 #[derive(Debug, Clone)]
 pub struct Hit {
@@ -149,7 +151,8 @@ pub fn parse(engine: &str, html: &str) -> Vec<Hit> {
     let doc = Html::parse_document(html);
     let mut hits = match engine {
         "brave" => parse_brave(&doc),
-        "google" => parse_google(&doc),
+        "google" => google_wml::parse(&doc),
+        "google_ghost" => parse_google(&doc),
         "bing" => parse_bing(&doc),
         // DDG primary is now lite : the html endpoint serves a
         // CAPTCHA challenge to proxy IPs.  parse_ddg (html parser)
@@ -569,7 +572,8 @@ fn parse_yahoo(doc: &Html) -> Vec<Hit> {
 pub fn serp_url(engine: &str, query: &str) -> Option<String> {
     let q = url::form_urlencoded::byte_serialize(query.as_bytes()).collect::<String>();
     match engine {
-        "google" => Some(format!(
+        "google" => Some(google_wml::url(query)),
+        "google_ghost" => Some(format!(
             "https://www.google.com/search?q={q}&hl=en&gl=us&num=15&ie=utf-8&oe=utf-8"
         )),
         "brave" => Some(format!("https://search.brave.com/search?q={q}")),
@@ -587,6 +591,20 @@ pub fn serp_url(engine: &str, query: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn google_http_and_browser_keep_distinct_endpoints_and_parsers() {
+        assert!(serp_url("google", "rust").unwrap().contains("/wml/search?"));
+        assert!(
+            serp_url("google_ghost", "rust")
+                .unwrap()
+                .contains("/search?")
+        );
+        assert!(!serp_url("google_ghost", "rust").unwrap().contains("/wml/"));
+        let desktop = r#"<div class="g"><a href="https://example.org/"><h3>Title</h3></a><div class="VwiEFb">Snippet</div></div>"#;
+        assert_eq!(parse("google_ghost", desktop).len(), 1);
+        assert!(parse("google", desktop).is_empty());
+    }
 
     #[test]
     fn serp_url_detection() {

--- a/src/search/engines/google_wml.rs
+++ b/src/search/engines/google_wml.rs
@@ -1,0 +1,580 @@
+//! Google's no-JavaScript mobile endpoint. Protocol references (not dependencies):
+//! searxng/searxng: searx/engines/google.py; deedy5/ddgs: ddgs/engines/google.py.
+//! Uses DonShadow's existing TLS/HTTP stack, not a Nokia TLS emulation or browser.
+
+use scraper::{ElementRef, Html};
+
+use super::{Hit, sel, text};
+
+/// Observed working identities, not an availability guarantee. Profile fallback
+/// is bounded by the search retry wave, never an internal request loop.
+pub const PROFILES: &[(&str, &str)] = &[
+    (
+        "6230-03.15",
+        "Nokia6230/2.0 (03.15) Profile/MIDP-2.0 Configuration/CLDC-1.1",
+    ),
+    (
+        "6230-05.50",
+        "Nokia6230/2.0 (05.50) Profile/MIDP-2.0 Configuration/CLDC-1.1",
+    ),
+    (
+        "6230-04.44",
+        "Nokia6230/2.0 (04.44) Profile/MIDP-2.0 Configuration/CLDC-1.1",
+    ),
+    (
+        "6230i-03.80",
+        "Nokia6230i/2.0 (03.80) Profile/MIDP-2.0 Configuration/CLDC-1.1",
+    ),
+    (
+        "6280-03.60",
+        "Nokia6280/2.0 (03.60) Profile/MIDP-2.0 Configuration/CLDC-1.1",
+    ),
+    (
+        "7610-5.0509.0",
+        "Nokia7610/2.0 (5.0509.0) SymbianOS/7.0s Series60/2.1 Profile/MIDP-2.0 Configuration/CLDC-1.0",
+    ),
+    (
+        "7610-7.0642.0",
+        "Nokia7610/2.0 (7.0642.0) SymbianOS/7.0s Series60/2.1 Profile/MIDP-2.0 Configuration/CLDC-1.0",
+    ),
+];
+
+pub const USER_AGENT: &str = PROFILES[0].1;
+
+pub fn profile_user_agent(id: Option<&str>) -> Option<&'static str> {
+    match id {
+        None => Some(USER_AGENT),
+        Some(id) => PROFILES
+            .iter()
+            .find(|(name, _)| *name == id)
+            .map(|(_, ua)| *ua),
+    }
+}
+
+pub fn configured_user_agent() -> Option<&'static str> {
+    match std::env::var("DONSETCH_GOOGLE_PROFILE") {
+        Ok(id) => profile_user_agent(Some(&id)),
+        Err(std::env::VarError::NotPresent) => profile_user_agent(None),
+        Err(_) => None,
+    }
+}
+
+/// Adapter-local identity selection, not a health or retry scheduler.
+/// Egress eligibility, deadlines and quarantine belong to the search core.
+pub(crate) struct ProfileSelector {
+    initial: Option<usize>,
+    cursors: std::sync::Mutex<std::collections::HashMap<String, Cursor>>,
+}
+
+struct Cursor {
+    index: usize,
+    generation: u64,
+}
+
+pub(crate) struct ProfileLease {
+    egress: String,
+    index: usize,
+    generation: u64,
+}
+
+impl ProfileLease {
+    pub fn user_agent(&self) -> &'static str {
+        PROFILES[self.index].1
+    }
+    pub fn label(&self) -> String {
+        format!("google@{}", PROFILES[self.index].0)
+    }
+}
+
+impl ProfileSelector {
+    pub fn from_env() -> Self {
+        let initial = configured_user_agent()
+            .and_then(|ua| PROFILES.iter().position(|(_, candidate)| *candidate == ua));
+        Self {
+            initial,
+            cursors: std::sync::Mutex::new(std::collections::HashMap::new()),
+        }
+    }
+
+    /// A retry carries the previous failure as generic attempt evidence. Only
+    /// this adapter interprets a Google CAPTCHA as an identity change on an
+    /// untouched egress. An evolved cursor takes precedence over old evidence.
+    pub fn select(
+        &self,
+        egress: &str,
+        previous: Option<(&str, &str)>,
+    ) -> Result<ProfileLease, &'static str> {
+        let initial = self.initial.ok_or("invalid-config")?;
+        let mut cursors = self
+            .cursors
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let cursor = cursors.entry(egress.into()).or_insert(Cursor {
+            index: initial,
+            generation: 0,
+        });
+        let alternative = previous.and_then(|(label, status)| {
+            if status != "blocked:captcha" || cursor.generation != 0 {
+                return None;
+            }
+            let id = label.strip_prefix("google@")?;
+            PROFILES
+                .iter()
+                .position(|(name, _)| *name == id)
+                .map(|index| (index + 1) % PROFILES.len())
+        });
+        Ok(ProfileLease {
+            egress: egress.into(),
+            index: alternative.unwrap_or(cursor.index),
+            generation: cursor.generation,
+        })
+    }
+
+    pub fn finish(&self, lease: &ProfileLease, status: &str) {
+        if !matches!(status, "ok" | "blocked:captcha") {
+            return;
+        }
+        let mut cursors = self
+            .cursors
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let Some(cursor) = cursors.get_mut(&lease.egress) else {
+            return;
+        };
+        if cursor.generation != lease.generation {
+            return;
+        }
+        let next = if status == "blocked:captcha" {
+            (lease.index + 1) % PROFILES.len()
+        } else {
+            lease.index
+        };
+        if status == "blocked:captcha" || cursor.index != next {
+            cursor.generation = cursor.generation.wrapping_add(1);
+        }
+        cursor.index = next;
+    }
+}
+
+pub fn url(query: &str) -> String {
+    let mut url = url::Url::parse("https://www.google.com/wml/search").unwrap();
+    url.query_pairs_mut().extend_pairs([
+        ("q", query),
+        ("sca_esv", "1"),
+        ("hl", "en"),
+        ("ie", "utf-8"),
+        ("oe", "utf-8"),
+    ]);
+    url.into()
+}
+
+/// Do not follow consent/CAPTCHA redirects or mistake an HTTP-200 wall for hits.
+pub fn response_error(
+    status: u16,
+    headers: &[(String, String)],
+    html: &str,
+) -> Option<&'static str> {
+    // Rate limiting takes precedence even if the body contains a CAPTCHA.
+    if status == 429 {
+        return Some("blocked:http-status");
+    }
+    let location = headers
+        .iter()
+        .find(|(n, _)| n.eq_ignore_ascii_case("location"))
+        .map(|(_, v)| v.as_str())
+        .unwrap_or("");
+    if location.contains("/sorry")
+        || location.contains("sorry.google.com")
+        || (html.len() < 2000 && html.contains("/sorry/"))
+        || html.contains("id=\"captcha-form\"")
+        || html.contains("id='captcha-form'")
+    {
+        return Some("blocked:captcha");
+    }
+    if location.contains("consent.google.") {
+        return Some("blocked:consent");
+    }
+    if (300..400).contains(&status) {
+        return Some("blocked:redirect");
+    }
+    if status != 200 {
+        return Some("blocked:http-status");
+    }
+    if html.contains("Your browser isn't supported any more") {
+        return Some("blocked:unsupported-browser");
+    }
+    None
+}
+
+fn target(href: &str) -> Option<String> {
+    if !(href.starts_with("https://") || href.starts_with("http://") || href.starts_with("/url?")) {
+        return None;
+    }
+    let base = url::Url::parse("https://www.google.com").unwrap();
+    let wrapped = base.join(href).ok()?;
+    let target = if matches!(wrapped.host_str(), Some("google.com" | "www.google.com"))
+        && wrapped.path() == "/url"
+    {
+        let (_, value) = wrapped
+            .query_pairs()
+            .find(|(key, _)| key == "q" || key == "url")?;
+        url::Url::parse(&value).ok()?
+    } else {
+        wrapped
+    };
+    if !matches!(target.scheme(), "http" | "https")
+        || target.host_str().is_none()
+        || !target.username().is_empty()
+        || target.password().is_some()
+    {
+        return None;
+    }
+    if matches!(target.host_str(), Some("google.com" | "www.google.com"))
+        && matches!(
+            target.path(),
+            "/search" | "/wml/search" | "/url" | "/preferences" | "/sorry" | "/sorry/"
+        )
+    {
+        return None;
+    }
+    Some(target.into())
+}
+
+pub fn parse(doc: &Html) -> Vec<Hit> {
+    let mut hits = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    let link = sel("a.fuLhoc[href]");
+    let title = sel("span.CVA68e");
+    let snippet = sel("div.taTFJ span.FrIlee");
+    for block in doc.select(&sel("div.zMzFAb")) {
+        let Some(a) = block.select(&link).next() else {
+            continue;
+        };
+        let Some(t) = a.select(&title).next() else {
+            continue;
+        };
+        let body = block
+            .select(&snippet)
+            .map(text)
+            .collect::<Vec<_>>()
+            .join(" ");
+        push(&mut hits, &mut seen, a, text(t), body);
+    }
+    // Structural fallback used by DDGS: title div followed by a table-bearing
+    // snippet div. Do not fall back to all anchors (navigation is not a result).
+    let span = sel("span");
+    let table = sel("table");
+    for block in doc.select(&sel("div")) {
+        let children: Vec<_> = block.children().filter_map(ElementRef::wrap).collect();
+        if children.len() < 2
+            || children[0].value().name() != "div"
+            || children[1].value().name() != "div"
+            || children[1].select(&table).next().is_none()
+        {
+            continue;
+        }
+        let Some(a) = children[0]
+            .children()
+            .filter_map(ElementRef::wrap)
+            .find(|el| el.value().name() == "a" && el.value().attr("href").is_some())
+        else {
+            continue;
+        };
+        // Keep the title inside the result anchor, not a neighbouring UI label.
+        let Some(t) = a.select(&span).next() else {
+            continue;
+        };
+        push(&mut hits, &mut seen, a, text(t), text(children[1]));
+    }
+    hits
+}
+
+fn push(
+    hits: &mut Vec<Hit>,
+    seen: &mut std::collections::HashSet<String>,
+    a: ElementRef<'_>,
+    title: String,
+    snippet: String,
+) {
+    let Some(url) = a.value().attr("href").and_then(target) else {
+        return;
+    };
+    if title.is_empty() || !seen.insert(url.clone()) {
+        return;
+    }
+    hits.push(Hit {
+        title,
+        url,
+        snippet,
+        rank: hits.len(),
+        published: None,
+    });
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn selector() -> ProfileSelector {
+        ProfileSelector {
+            initial: Some(0),
+            cursors: Default::default(),
+        }
+    }
+
+    #[test]
+    fn selector_wraps_without_cooldowns_and_restart_resets() {
+        let profiles = selector();
+        for _ in 0..2 {
+            for index in 0..PROFILES.len() {
+                let lease = profiles.select("direct", None).unwrap();
+                assert_eq!(lease.index, index);
+                profiles.finish(&lease, "blocked:captcha");
+            }
+        }
+        let a = profiles.select("direct", None).unwrap();
+        profiles.finish(&a, "blocked:captcha");
+        let b = profiles.select("direct", None).unwrap();
+        profiles.finish(&b, "ok");
+        assert_eq!(profiles.select("direct", None).unwrap().index, 1);
+        assert_eq!(selector().select("direct", None).unwrap().index, 0);
+    }
+
+    #[test]
+    fn retry_can_change_egress_and_identity_without_rotating_other_errors() {
+        let profiles = selector();
+        let a = profiles.select("proxy-a", None).unwrap();
+        profiles.finish(&a, "blocked:captcha");
+        let label = a.label();
+        let b = profiles
+            .select("proxy-b", Some((&label, "blocked:captcha")))
+            .unwrap();
+        assert_eq!(b.index, 1);
+        profiles.finish(&b, "ok");
+        assert_eq!(profiles.select("proxy-b", None).unwrap().index, 1);
+        assert_eq!(profiles.select("proxy-c", None).unwrap().index, 0);
+        for status in [
+            "blocked:http-status",
+            "blocked:429",
+            "blocked:consent",
+            "timeout",
+            "net",
+        ] {
+            let lease = profiles.select("proxy-c", Some((&label, status))).unwrap();
+            assert_eq!(lease.index, 0);
+            profiles.finish(&lease, status);
+            assert_eq!(profiles.select("proxy-c", None).unwrap().index, 0);
+        }
+    }
+
+    #[test]
+    fn delayed_retry_respects_evolved_cursors_including_wraparound() {
+        let profiles = selector();
+        let a = profiles.select("direct", None).unwrap();
+        profiles.finish(&a, "blocked:captcha");
+        let b = profiles.select("direct", None).unwrap();
+        profiles.finish(&b, "blocked:captcha");
+        let label = a.label();
+        let retry = profiles
+            .select("direct", Some((&label, "blocked:captcha")))
+            .unwrap();
+        assert_eq!(retry.index, 2);
+        profiles.finish(&retry, "ok");
+        assert_eq!(profiles.select("direct", None).unwrap().index, 2);
+
+        // Returning to A after a full cycle is not an untouched cursor.
+        for _ in 2..PROFILES.len() {
+            let lease = profiles.select("direct", None).unwrap();
+            profiles.finish(&lease, "blocked:captcha");
+        }
+        let retry = profiles
+            .select("direct", Some((&label, "blocked:captcha")))
+            .unwrap();
+        assert_eq!(retry.index, 0);
+    }
+
+    #[test]
+    fn cross_egress_retry_preserves_existing_preference() {
+        let profiles = selector();
+        let a = profiles.select("proxy-a", None).unwrap();
+        profiles.finish(&a, "blocked:captcha");
+        for _ in 0..2 {
+            let lease = profiles.select("proxy-b", None).unwrap();
+            profiles.finish(&lease, "blocked:captcha");
+        }
+        let label = a.label();
+        let retry = profiles
+            .select("proxy-b", Some((&label, "blocked:captcha")))
+            .unwrap();
+        assert_eq!(retry.index, 2);
+        profiles.finish(&retry, "ok");
+        assert_eq!(profiles.select("proxy-b", None).unwrap().index, 2);
+    }
+
+    #[test]
+    fn unchanged_success_does_not_hide_captcha_but_stale_outcomes_cannot_rewind() {
+        let profiles = selector();
+        let a = profiles.select("direct", None).unwrap();
+        let concurrent_a = profiles.select("direct", None).unwrap();
+        profiles.finish(&a, "ok");
+        profiles.finish(&concurrent_a, "blocked:captcha");
+        let b = profiles.select("direct", None).unwrap();
+        assert_eq!(b.index, 1);
+        profiles.finish(&b, "ok");
+        profiles.finish(&a, "ok");
+        profiles.finish(&a, "blocked:captcha");
+        assert_eq!(profiles.select("direct", None).unwrap().index, 1);
+    }
+
+    #[test]
+    fn invalid_configuration_fails_without_selecting_a_profile() {
+        let profiles = ProfileSelector {
+            initial: None,
+            cursors: Default::default(),
+        };
+        assert_eq!(
+            profiles.select("direct", None).err(),
+            Some("invalid-config")
+        );
+    }
+
+    #[test]
+    fn rate_limiting_takes_precedence_over_captcha_markup() {
+        assert_eq!(
+            response_error(429, &[], "<form id='captcha-form'>"),
+            Some("blocked:http-status")
+        );
+    }
+
+    #[test]
+    fn profiles_are_unique_valid_and_reject_unknown_ids() {
+        assert_eq!(PROFILES.len(), 7);
+        assert_eq!(
+            PROFILES.iter().map(|(id, _)| *id).collect::<Vec<_>>(),
+            [
+                "6230-03.15",
+                "6230-05.50",
+                "6230-04.44",
+                "6230i-03.80",
+                "6280-03.60",
+                "7610-5.0509.0",
+                "7610-7.0642.0"
+            ]
+        );
+        let mut ids = std::collections::HashSet::new();
+        let mut user_agents = std::collections::HashSet::new();
+        for (id, ua) in PROFILES {
+            assert!(ids.insert(id));
+            assert!(user_agents.insert(ua));
+            assert!(ua.starts_with("Nokia"));
+            assert_eq!(profile_user_agent(Some(id)), Some(*ua));
+            assert!(ua.is_ascii() && !ua.bytes().any(|b| b.is_ascii_control()));
+        }
+        assert_eq!(profile_user_agent(None), Some(USER_AGENT));
+        assert_eq!(
+            profile_user_agent(None),
+            profile_user_agent(Some("6230-03.15"))
+        );
+        assert_eq!(profile_user_agent(Some("unknown")), None);
+        assert_eq!(profile_user_agent(Some("")), None);
+    }
+
+    #[test]
+    fn walls_and_http_errors_are_not_successful_pages() {
+        assert_eq!(
+            response_error(200, &[], "Your browser isn't supported any more"),
+            Some("blocked:unsupported-browser")
+        );
+        for status in [403, 429, 500, 503] {
+            assert_eq!(response_error(status, &[], ""), Some("blocked:http-status"));
+        }
+    }
+
+    #[test]
+    fn query_round_trips_without_parameter_injection() {
+        let query = "caffè Rust & C++ #東京";
+        let u = url::Url::parse(&url(query)).unwrap();
+        assert_eq!(u.path(), "/wml/search");
+        assert_eq!(u.query_pairs().find(|(k, _)| k == "q").unwrap().1, query);
+        assert_eq!(u.query_pairs().count(), 5);
+    }
+
+    #[test]
+    fn redirects_preserve_complete_target_query_and_fragment() {
+        assert_eq!(
+            target("/url?sa=U&q=https%3A%2F%2Fexample.org%2Fp%3Fa%3D1%26b%3D2%23part").unwrap(),
+            "https://example.org/p?a=1&b=2#part"
+        );
+        assert_eq!(
+            target("https://example.org/?q=a+b").unwrap(),
+            "https://example.org/?q=a+b"
+        );
+        for bad in [
+            "javascript:alert(1)",
+            "/url?q=javascript%3Aalert(1)",
+            "/url?sa=U",
+            "/wml/search?q=x",
+            "https://user:pass@example.org/",
+        ] {
+            assert!(target(bad).is_none(), "{bad}");
+        }
+    }
+
+    #[test]
+    fn parses_xml_layout_and_deduplicates_without_truncating_urls() {
+        let html = r#"<?xml version="1.0" encoding="UTF-8"?>
+        <div class="zMzFAb"><a class="fuLhoc" href="/url?q=https%3A%2F%2Fexample.org%2F%3Fa%3D1%26b%3D2&amp;sa=U"><span class="CVA68e">Rust &amp; TLS</span></a><div class="taTFJ"><span class="FrIlee">Native <b>HTTP</b></span></div></div>
+        <div class="zMzFAb"><a class="fuLhoc" href="https://example.org/?a=1&amp;b=2"><span class="CVA68e">Duplicate</span></a></div>
+        <div class="zMzFAb"><a class="fuLhoc" href="https://example.org/?a=1&amp;b=3"><span class="CVA68e">Distinct</span></a></div>"#;
+        let hits = parse(&Html::parse_document(html));
+        assert_eq!(hits.len(), 2);
+        assert_eq!(hits[0].title, "Rust & TLS");
+        assert_eq!(hits[0].snippet, "Native HTTP");
+        assert_eq!(hits[0].url, "https://example.org/?a=1&b=2");
+        assert_eq!(hits[1].rank, 1);
+    }
+
+    #[test]
+    fn structural_fallback_and_navigation_exclusion() {
+        let html = r#"<div><div><a href="https://example.org/"><span>Title</span></a></div><div><table><tr><td>Snippet</td></tr></table></div></div>
+        <a href="https://google.com/preferences">Settings</a><script>enableJavascript()</script>"#;
+        let hits = parse(&Html::parse_document(html));
+        assert_eq!(hits.len(), 1);
+        assert_eq!(hits[0].snippet, "Snippet");
+        assert!(
+            parse(&Html::parse_document(
+                "<a href='https://example.org'>Navigation</a>"
+            ))
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn block_redirects_are_not_results() {
+        assert_eq!(
+            response_error(
+                302,
+                &[(
+                    "Location".into(),
+                    "https://www.google.com/sorry/index".into()
+                )],
+                ""
+            ),
+            Some("blocked:captcha")
+        );
+        assert_eq!(
+            response_error(
+                302,
+                &[("location".into(), "https://consent.google.com/m".into())],
+                ""
+            ),
+            Some("blocked:consent")
+        );
+        assert_eq!(
+            response_error(200, &[], "<form id='captcha-form'>"),
+            Some("blocked:captcha")
+        );
+        assert_eq!(response_error(302, &[], ""), Some("blocked:redirect"));
+        assert_eq!(response_error(200, &[], "ordinary results"), None);
+    }
+}

--- a/src/search/intent.rs
+++ b/src/search/intent.rs
@@ -218,16 +218,16 @@ pub fn detect(query: &str) -> Intent {
 
 /// Engines to fan out per intent. Order = trust prior.
 /// Bing family (bing/ddg/yahoo) + independent indexes
-/// (mojeek/brave) for consensus diversity.
+/// (mojeek/brave/google) for consensus diversity.
 /// DDG and Brave are PROXY_AVERSE : they prefer the direct
 /// lane because proxy IPs get CAPTCHA'd/429'd.
 pub fn engines_for(intent: Intent) -> &'static [&'static str] {
     match intent {
-        // 5 engines, 3 index families (bing, mojeek, brave).
+        // 6 engines, 4 index families (bing, mojeek, brave, google).
         Intent::Web | Intent::Code | Intent::News | Intent::Entity => {
-            &["bing", "ddg", "mojeek", "yahoo", "brave"]
+            &["bing", "ddg", "mojeek", "yahoo", "brave", "google"]
         }
-        Intent::Paper => &["bing", "ddg", "mojeek"],
+        Intent::Paper => &["bing", "ddg", "mojeek", "google"],
     }
 }
 

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -37,6 +37,7 @@ use intent::Intent;
 use rank::Merged;
 
 const ENGINE_TIMEOUT: Duration = Duration::from_secs(8);
+const RETRY_TIMEOUT: Duration = Duration::from_secs(3);
 
 /// Chronic-failure bench time. A walled engine stops wasting a
 /// fan-out slot for this long after 3 consecutive strikes.
@@ -122,12 +123,17 @@ fn norm_query(q: &str) -> String {
 /// A single predicate so quarantine and trust tracking can't drift
 /// out of sync with each other again.
 fn is_engine_fault(status: &str) -> bool {
-    !status.starts_with("dead") && status != "auth-fail" && status != "no-results"
+    !status.starts_with("dead")
+        && status != "auth-fail"
+        && status != "no-results"
+        && status != "invalid-config"
+        && status != "pacing-timeout"
 }
 
 pub struct Searcher {
     fetcher: Fetcher,
     pool: EgressPool,
+    google: engines::google_wml::ProfileSelector,
     /// engine -> trust EWMA (1.0 seed; 0.2..2.0 clamp).
     /// Persisted to disk: an engine that learned "this walled me"
     /// keeps that memory across daemon restarts instead of
@@ -190,6 +196,8 @@ where
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct EngineReport {
     pub engine: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub profile: Option<String>,
     pub status: String,
     pub hits: usize,
     pub ms: u64,
@@ -218,6 +226,7 @@ impl Searcher {
         Self {
             fetcher,
             pool,
+            google: engines::google_wml::ProfileSelector::from_env(),
             trust: Mutex::new(trust),
             health_dirty: std::sync::atomic::AtomicBool::new(false),
             cache: Mutex::new(load_cache_disk()),
@@ -417,7 +426,7 @@ impl Searcher {
         // goes only to the first two engines (top trust).
         let mut live: Vec<&str> = engines
             .iter()
-            .filter(|e| !self.quarantined(e))
+            .filter(|e| !self.quarantined(engine_health_key(e)))
             .copied()
             .collect();
         // Rank engines by learned trust so width cuts drop
@@ -429,10 +438,10 @@ impl Searcher {
                 .unwrap_or_else(std::sync::PoisonError::into_inner);
             live.sort_by(|a, b| {
                 trust
-                    .get(*b)
+                    .get(engine_health_key(b))
                     .copied()
                     .unwrap_or(1.0)
-                    .total_cmp(&trust.get(*a).copied().unwrap_or(1.0))
+                    .total_cmp(&trust.get(engine_health_key(a)).copied().unwrap_or(1.0))
             });
         }
         // ── Adaptive fan-out width: the governor. Under
@@ -462,25 +471,13 @@ impl Searcher {
         //
         // We only exclude proxy egresses from reuse : direct
         // is shared, not exclusive.
-        let has_proxies = self.pool.has_proxies();
-        for (engine, q) in assignments {
-            let Some(eg) = self.pool.pick(&engine, &used_egresses, true) else {
-                break;
-            };
-            // Exclude proxy egresses (spread across proxies)
-            // but NOT direct (multiple PROXY_AVERSE engines
-            // share the direct lane with pacing).
-            if has_proxies && eg.proxy.is_some() {
-                used_egresses.push(eg.id.clone());
-            }
-            futures.push(Box::pin(engine_task(
-                engine,
-                q,
-                eg.id,
-                eg.proxy,
-                &self.fetcher,
-                &self.pool,
-            )));
+        let context = tasks::EngineContext {
+            fetcher: &self.fetcher,
+            pool: &self.pool,
+            google: &self.google,
+        };
+        for (engine, q, eg) in assign_egresses(&self.pool, assignments, &mut used_egresses) {
+            futures.push(Box::pin(engine_task(engine, q, eg.id, eg.proxy, context)));
         }
         // Verticals: direct, friendly APIs.
         let verticals: Vec<&&str> = verticals.iter().filter(|v| !self.quarantined(v)).collect();
@@ -509,14 +506,24 @@ impl Searcher {
         let failed: Vec<String> = if merge_thin {
             outcomes
                 .iter()
-                .filter(|(_, r)| matches!(r, Err((s, _, _)) if s != "no-results"))
+                .filter(|(_, r)| matches!(r, Err((s, _, _)) if retry_engine_failure(s)))
                 .map(|(e, _)| e.split('@').next().unwrap_or(e).to_string())
                 .collect()
         } else {
             Vec::new()
         };
         let mut retry_futures: Vec<TaskFut> = Vec::new();
+        let mut retried = std::collections::HashSet::new();
         for engine in &failed {
+            if !retried.insert(engine) {
+                continue;
+            }
+            if outcomes
+                .iter()
+                .any(|(label, outcome)| engine_name(label) == engine && outcome.is_ok())
+            {
+                continue;
+            }
             let is_vertical = matches!(
                 engine.as_str(),
                 "github"
@@ -534,11 +541,18 @@ impl Searcher {
                 let Some(eg) = self.pool.pick("github", &[], false) else {
                     continue;
                 };
-                retry_futures.push(Box::pin(vertical_task(
+                let task = Box::pin(vertical_task(
                     engine.clone(),
                     query.to_string(),
                     &self.fetcher,
                     eg.proxy,
+                ));
+                retry_futures.push(Box::pin(bounded_retry(
+                    task,
+                    engine.clone(),
+                    eg.id,
+                    false,
+                    RETRY_TIMEOUT,
                 )));
                 continue;
             }
@@ -547,30 +561,30 @@ impl Searcher {
             let Some(eg) = self.pool.pick(engine, &used_egresses, true) else {
                 continue;
             };
-            retry_futures.push(Box::pin(engine_task(
+            let previous = outcomes.iter().find_map(|(label, result)| {
+                if engine_name(label) == engine
+                    && let Err((status, _, _)) = result
+                {
+                    Some((label.as_str(), status.as_str()))
+                } else {
+                    None
+                }
+            });
+            retry_futures.push(Box::pin(tasks::engine_task_with_budget(
                 retry_engine.to_string(),
                 query.to_string(),
                 eg.id,
                 eg.proxy,
-                &self.fetcher,
-                &self.pool,
+                context,
+                RETRY_TIMEOUT,
+                previous,
             )));
         }
-        let retry_outcomes = if retry_futures.is_empty() {
-            Vec::new()
-        } else {
-            tokio::time::timeout(
-                Duration::from_secs(3),
-                futures_util::future::join_all(retry_futures),
-            )
-            .await
-            .unwrap_or_default()
-        };
+        let retry_outcomes = futures_util::future::join_all(retry_futures).await;
 
         // ── Ghost SERP cascade lane ──
-        // 2026 Google serves a JS shell to plain HTTP (live-proven:
-        // 0 result anchors in 92KB), but it renders fine in our own
-        // headless browser (also live-proven: parse-ready div.g blocks).
+        // Google's desktop endpoint may serve a JS shell to plain HTTP.
+        // The WML HTTP lane uses a separate layout and legacy User-Agent.
         // When the plain fan-out AND its retry wave still left the
         // merge thin, one browser render buys a genuinely independent
         // index family instead of shipping weak results.
@@ -582,23 +596,28 @@ impl Searcher {
                 .map(|(h, _, _, _)| h.len())
                 .sum::<usize>();
         let force_lane = std::env::var_os("DONSEEK_FORCE_GHOST_LANE").is_some();
+        let google_http_ok = outcomes
+            .iter()
+            .chain(&retry_outcomes)
+            .any(|(engine, result)| engine_name(engine) == "google" && result.is_ok());
         let lane_permitted = self.ghost.is_some()
             && std::env::var_os("DONSEEK_NO_GHOST_LANES").is_none()
-            && !self.quarantined("google");
-        let lane_outcomes: Vec<(String, EngineResult)> =
-            if lane_permitted && (force_lane || ghost_lane_wanted(retry_ok, retry_hits)) {
-                let hook = self.ghost.as_ref().unwrap().clone();
-                let task = ghost_engine_task("google_ghost".to_string(), query.to_string(), hook);
-                match tokio::time::timeout(Duration::from_secs(30), task).await {
-                    Ok(outcome) => vec![outcome],
-                    Err(_) => vec![(
-                        "google_ghost".to_string(),
-                        Err(("ghost-timeout".into(), "ghost".into(), true)),
-                    )],
-                }
-            } else {
-                Vec::new()
-            };
+            && !self.quarantined("google_ghost");
+        let lane_outcomes: Vec<(String, EngineResult)> = if lane_permitted
+            && google_ghost_wanted(force_lane, google_http_ok, retry_ok, retry_hits)
+        {
+            let hook = self.ghost.as_ref().unwrap().clone();
+            let task = ghost_engine_task("google_ghost".to_string(), query.to_string(), hook);
+            match tokio::time::timeout(Duration::from_secs(30), task).await {
+                Ok(outcome) => vec![outcome],
+                Err(_) => vec![(
+                    "google_ghost".to_string(),
+                    Err(("ghost-timeout".into(), "ghost".into(), true)),
+                )],
+            }
+        } else {
+            Vec::new()
+        };
 
         let mut per_engine: Vec<(String, Vec<engines::Hit>)> = Vec::new();
         let mut report = Vec::new();
@@ -607,23 +626,26 @@ impl Searcher {
             .chain(retry_outcomes)
             .chain(lane_outcomes)
             .collect();
-        for (engine, outcome) in all {
+        for (label, outcome) in all {
+            let profile = label.split_once('@').map(|(_, p)| p.to_string());
+            let engine = engine_name(&label).to_string();
             let ghost_lane = engine == "google_ghost";
             match outcome {
                 Ok((hits, ms, egress_id, was_engine)) => {
-                    let base = engine.split('_').next().unwrap_or(&engine);
+                    let base = engine_health_key(&engine);
                     self.record_outcome(base, true);
                     if was_engine && !ghost_lane {
                         // "ghost" is not an egress id: pool
                         // bookkeeping must not record lanes that
                         // the pool never assigned.
-                        self.pool.report_ok(base, &egress_id);
+                        self.pool.report_ok(&engine, &egress_id);
                     }
                     if was_engine || ghost_lane {
                         self.bump_trust(base, true);
                     }
                     report.push(EngineReport {
                         engine: engine.clone(),
+                        profile: profile.clone(),
                         status: "ok".into(),
                         hits: hits.len(),
                         ms,
@@ -632,7 +654,7 @@ impl Searcher {
                     per_engine.push((engine, hits));
                 }
                 Err((status, egress_id, was_engine)) => {
-                    let base = engine.split('_').next().unwrap_or(&engine);
+                    let base = engine_health_key(&engine);
                     // Dead proxies and auth failures are egress/BYOK
                     // problems, not engine failures : don't quarantine
                     // or distrust the engine over them.
@@ -644,8 +666,8 @@ impl Searcher {
                             self.pool.report_dead(&egress_id);
                         } else if status == "auth-fail" {
                             self.pool.report_auth_fail(&egress_id);
-                        } else if status != "no-results" {
-                            self.pool.report_blocked(base, &egress_id);
+                        } else if is_engine_fault(&status) {
+                            self.pool.report_blocked(&engine, &egress_id);
                         }
                     }
                     if (was_engine || ghost_lane) && is_engine_fault(&status) {
@@ -653,6 +675,7 @@ impl Searcher {
                     }
                     report.push(EngineReport {
                         engine,
+                        profile,
                         status,
                         hits: 0,
                         ms: 0,
@@ -684,11 +707,18 @@ impl Searcher {
             )));
         }
 
-        let trust = self
+        let mut trust = self
             .trust
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner)
             .clone();
+        // Public result names stay stable; ranking must use the new HTTP
+        // health namespace, never legacy browser health stored as `google`.
+        let google_trust = trust
+            .get(engine_health_key("google"))
+            .copied()
+            .unwrap_or(1.0);
+        trust.insert("google".into(), google_trust);
         let total = rank::merged_total(&per_engine);
         // Always merge 12 results for the cache, then trim to
         // max_results for the response. Without this, a first
@@ -803,10 +833,71 @@ impl Searcher {
     }
 }
 
-/// Thinness gate for the ghost cascade lane, kept pure for
-/// tests. Same thresholds as the plain retry wave: a merge
-/// with <3 working lanes or <15 hits is not a healthy merge,
-/// and one browser render is cheaper than weak results.
+/// Assignment only: eligibility remains owned by EgressPool::pick.
+/// Keep this pass shared by the real fan-out and its offline regression tests.
+fn assign_egresses(
+    pool: &EgressPool,
+    assignments: Vec<(String, String)>,
+    used: &mut Vec<String>,
+) -> Vec<(String, String, egress::Egress)> {
+    let mut selected = Vec::new();
+    let has_proxies = pool.has_proxies();
+    for (engine, query) in assignments {
+        let Some(egress) = pool.pick(&engine, used, true) else {
+            // Unavailable for this engine does not mean unavailable for peers.
+            continue;
+        };
+        // Spread configured proxies; direct remains shared with pacing.
+        if has_proxies && egress.proxy.is_some() {
+            used.push(egress.id.clone());
+        }
+        selected.push((engine, query, egress));
+    }
+    selected
+}
+
+fn engine_name(label: &str) -> &str {
+    label.split('@').next().unwrap_or(label)
+}
+
+fn engine_health_key(engine: &str) -> &str {
+    let engine = engine_name(engine);
+    if engine == "google" {
+        return "google_http_v1";
+    }
+    // Different Google transports can fail independently; only ranking groups
+    // them into one index family. A WML block must not quarantine the browser.
+    if engine == "google_ghost" {
+        engine
+    } else {
+        egress::health_key(engine)
+    }
+}
+
+fn retry_engine_failure(status: &str) -> bool {
+    !matches!(status, "no-results" | "pacing-timeout" | "invalid-config")
+}
+
+/// Vertical retries retain explicit timeout outcomes; engine tasks own their
+/// deadline internally so diagnostics include the identity actually attempted.
+async fn bounded_retry(
+    task: TaskFut<'_>,
+    engine: String,
+    egress: String,
+    was_engine: bool,
+    budget: Duration,
+) -> (String, EngineResult) {
+    tokio::time::timeout(budget, task)
+        .await
+        .unwrap_or_else(|_| (engine, Err(("retry-timeout".into(), egress, was_engine))))
+}
+
+fn google_ghost_wanted(force: bool, http_ok: bool, engines_ok: usize, hits_ok: usize) -> bool {
+    force || (!http_ok && ghost_lane_wanted(engines_ok, hits_ok))
+}
+
+/// Thinness gate for the ghost cascade lane. A successful HTTP Google
+/// response already supplies that index; the caller skips the browser then.
 fn ghost_lane_wanted(engines_ok: usize, hits_ok: usize) -> bool {
     engines_ok < 3 || hits_ok < 15
 }
@@ -903,6 +994,156 @@ mod tests {
     use super::render::clip_snippet;
     use super::*;
 
+    #[test]
+    fn regression_unavailable_google_does_not_stop_other_assignments() {
+        let proxy = crate::transport::proxy::Proxy::parse("http://127.0.0.1:12345").unwrap();
+        let id = proxy.id();
+        let pool = EgressPool::new(vec![proxy]);
+        pool.report_blocked("google", &id);
+        let assignments = ["google", "bing"]
+            .map(|e| (e.into(), "query".into()))
+            .to_vec();
+        // Explicitly unavailable direct lane; the proxy is still viable for Bing.
+        let selected = assign_egresses(&pool, assignments, &mut vec!["direct".into()]);
+        assert_eq!(
+            selected
+                .iter()
+                .map(|(engine, _, _)| engine.as_str())
+                .collect::<Vec<_>>(),
+            ["bing"]
+        );
+    }
+
+    #[test]
+    fn assignments_preserve_proxy_spreading_and_shared_direct_lane() {
+        let proxies = ["http://127.0.0.1:12345", "http://127.0.0.1:12346"]
+            .map(|url| crate::transport::proxy::Proxy::parse(url).unwrap())
+            .to_vec();
+        let pool = EgressPool::new(proxies);
+        let assignments = ["bing", "yahoo", "brave", "ddg"]
+            .map(|e| (e.into(), "query".into()))
+            .to_vec();
+        let mut used = Vec::new();
+        let selected = assign_egresses(&pool, assignments, &mut used);
+        assert_eq!(selected.len(), 4);
+        assert_eq!(used, ["127.0.0.1:12345", "127.0.0.1:12346"]);
+        assert_eq!(selected[2].2.id, "direct");
+        assert_eq!(selected[3].2.id, "direct");
+    }
+
+    #[test]
+    fn google_transport_health_is_separate_but_index_family_is_shared() {
+        assert_eq!(engine_health_key("google@6230-05.50"), "google_http_v1");
+        assert_ne!(engine_health_key("google"), "google");
+        assert_ne!(
+            engine_health_key("google"),
+            engine_health_key("google_ghost")
+        );
+        assert_eq!(engine_health_key("ddg_html"), "ddg");
+        assert_eq!(
+            rank::engine_family("google"),
+            rank::engine_family("google_ghost")
+        );
+    }
+
+    #[test]
+    fn engine_reports_load_legacy_cache_and_preserve_new_profile() {
+        let mut report: EngineReport = serde_json::from_str(
+            r#"{"engine":"google","status":"ok","hits":10,"ms":700,"egress":"direct"}"#,
+        )
+        .unwrap();
+        assert!(report.profile.is_none());
+        report.profile = Some("6230-04.44".into());
+        let reloaded: EngineReport =
+            serde_json::from_str(&serde_json::to_string(&report).unwrap()).unwrap();
+        assert_eq!(reloaded.profile.as_deref(), Some("6230-04.44"));
+    }
+
+    #[test]
+    fn successful_google_http_skips_browser_unless_explicitly_forced() {
+        assert!(!google_ghost_wanted(false, true, 1, 3));
+        assert!(google_ghost_wanted(false, false, 1, 3));
+        assert!(!google_ghost_wanted(false, false, 4, 20));
+        assert!(google_ghost_wanted(true, true, 4, 20));
+    }
+
+    #[test]
+    fn all_engines_share_retry_eligibility() {
+        for status in [
+            "blocked:captcha",
+            "blocked:429",
+            "blocked:consent",
+            "blocked:http-status",
+            "empty-parse",
+            "net",
+            "timeout",
+            "dead-proxy",
+            "auth-fail",
+        ] {
+            assert!(retry_engine_failure(status));
+            if !matches!(status, "dead-proxy" | "auth-fail") {
+                assert!(is_engine_fault(status));
+            }
+        }
+        for status in ["invalid-config", "no-results", "pacing-timeout"] {
+            assert!(!retry_engine_failure(status));
+            assert!(!is_engine_fault(status));
+        }
+    }
+
+    #[tokio::test]
+    async fn slow_retry_does_not_discard_completed_peer() {
+        let fast: TaskFut = Box::pin(async {
+            (
+                "google".into(),
+                Err(("blocked:captcha".into(), "direct".into(), true)),
+            )
+        });
+        let slow: TaskFut = Box::pin(std::future::pending());
+        let outcomes = futures_util::future::join_all(vec![
+            bounded_retry(
+                fast,
+                "google".into(),
+                "direct".into(),
+                true,
+                Duration::from_millis(20),
+            ),
+            bounded_retry(
+                slow,
+                "bing".into(),
+                "direct".into(),
+                true,
+                Duration::from_millis(10),
+            ),
+        ])
+        .await;
+        assert_eq!(outcomes.len(), 2);
+        assert!(matches!(&outcomes[1].1, Err((s, _, _)) if s == "retry-timeout"));
+        assert_eq!(outcomes[0].0, "google");
+        // A second CAPTCHA is reported, not recursively scheduled.
+        assert!(matches!(&outcomes[0].1, Err((s, _, _)) if s == "blocked:captcha"));
+    }
+
+    #[test]
+    fn native_google_is_available_once_in_every_intent_roster() {
+        for intent in [
+            intent::Intent::Web,
+            intent::Intent::Code,
+            intent::Intent::News,
+            intent::Intent::Entity,
+            intent::Intent::Paper,
+        ] {
+            assert_eq!(
+                intent::engines_for(intent)
+                    .iter()
+                    .filter(|e| **e == "google")
+                    .count(),
+                1
+            );
+            assert!(!intent::engines_for(intent).contains(&"google_ghost"));
+        }
+    }
+
     // Egress/BYOK-auth noise must never look like the engine
     // misbehaving: record_outcome (quarantine) and bump_trust (the
     // ranking-weight EWMA) both gate on this predicate, and had
@@ -914,6 +1155,7 @@ mod tests {
         assert!(!is_engine_fault("dead-proxy"));
         assert!(!is_engine_fault("auth-fail"));
         assert!(!is_engine_fault("no-results"));
+        assert!(!is_engine_fault("invalid-config"));
         assert!(is_engine_fault("blocked:403"));
         assert!(is_engine_fault("blocked:captcha"));
         assert!(is_engine_fault("empty-parse"));
@@ -1234,6 +1476,7 @@ mod tests {
         search.report = vec![
             EngineReport {
                 engine: "bing".into(),
+                profile: None,
                 status: "ok".into(),
                 hits: 10,
                 ms: 12,
@@ -1241,6 +1484,7 @@ mod tests {
             },
             EngineReport {
                 engine: "ddg".into(),
+                profile: None,
                 status: "blocked:403".into(),
                 hits: 0,
                 ms: 20,

--- a/src/search/render.rs
+++ b/src/search/render.rs
@@ -315,9 +315,13 @@ pub fn render_meta(out: &SearchOutcome) -> Value {
                 "engines": seen_engines,
             })
         }).collect::<Vec<_>>(),
-        "engines": out.report.iter().map(|r| json!({
-            "engine": r.engine, "status": r.status, "hits": r.hits, "ms": r.ms,
-            "egress": egress_label(&r.egress),
-        })).collect::<Vec<_>>(),
+        "engines": out.report.iter().map(|r| {
+            let mut report = json!({
+                "engine": r.engine, "status": r.status, "hits": r.hits, "ms": r.ms,
+                "egress": egress_label(&r.egress),
+            });
+            if let Some(profile) = &r.profile { report["profile"] = json!(profile); }
+            report
+        }).collect::<Vec<_>>(),
     })
 }

--- a/src/search/tasks.rs
+++ b/src/search/tasks.rs
@@ -19,24 +19,82 @@ pub(super) type EngineResult =
 pub(super) type TaskFut<'a> =
     std::pin::Pin<Box<dyn std::future::Future<Output = (String, EngineResult)> + Send + 'a>>;
 
+#[derive(Clone, Copy)]
+pub(super) struct EngineContext<'a> {
+    pub fetcher: &'a Fetcher,
+    pub pool: &'a EgressPool,
+    pub google: &'a engines::google_wml::ProfileSelector,
+}
+
 pub(super) async fn engine_task(
     engine: String,
     query: String,
     egress_id: String,
     proxy: Option<crate::transport::proxy::Proxy>,
-    fetcher: &Fetcher,
-    pool: &EgressPool,
+    context: EngineContext<'_>,
 ) -> (String, EngineResult) {
-    let label = engine.clone();
-    pool.pace(&engine, &egress_id).await;
+    engine_task_with_budget(
+        engine,
+        query,
+        egress_id,
+        proxy,
+        context,
+        ENGINE_TIMEOUT,
+        None,
+    )
+    .await
+}
+
+/// One admission and HTTP attempt under a single deadline, including pacing.
+pub(super) async fn engine_task_with_budget(
+    engine: String,
+    query: String,
+    egress_id: String,
+    proxy: Option<crate::transport::proxy::Proxy>,
+    context: EngineContext<'_>,
+    budget: std::time::Duration,
+    previous: Option<(&str, &str)>,
+) -> (String, EngineResult) {
+    let EngineContext {
+        fetcher,
+        pool,
+        google,
+    } = context;
+    let mut label = engine.clone();
+    let deadline = tokio::time::Instant::now() + budget;
     let started = Instant::now();
+    if tokio::time::timeout_at(deadline, pool.pace(&engine, &egress_id))
+        .await
+        .is_err()
+    {
+        return (label, Err(("pacing-timeout".into(), egress_id, true)));
+    }
+    let lease = if engine == "google" {
+        match google.select(&egress_id, previous) {
+            Ok(lease) => {
+                label = lease.label();
+                Some(lease)
+            }
+            Err(status) => return (label, Err((status.into(), egress_id, true))),
+        }
+    } else {
+        None
+    };
+    let google_ua = lease.as_ref().map(|lease| lease.user_agent());
     let Some(url) = engines::serp_url(&engine, &query) else {
         return (label, Err(("no-url".into(), egress_id, true)));
     };
-    let out = match tokio::time::timeout(
-        ENGINE_TIMEOUT,
-        fetcher.fetch_once_via(&url, &[], proxy.as_ref(), false, None),
-    )
+    let out = match tokio::time::timeout_at(deadline, async {
+        if let Some(ua) = google_ua {
+            fetcher
+                .fetch_once_via_user_agent(&url, proxy.as_ref(), ua)
+                .await
+        } else {
+            fetcher
+                .fetch_once_via(&url, &[], proxy.as_ref(), false, None)
+                .await
+        }
+    })
     .await
     {
         Err(_) => return (label, Err(("timeout".into(), egress_id, true))),
@@ -52,12 +110,6 @@ pub(super) async fn engine_task(
         Ok(Ok(o)) => o,
     };
     let ms = started.elapsed().as_millis() as u64;
-    if out.status == 429 || !matches!(out.verdict, Verdict::ContentOk) {
-        return (
-            label,
-            Err((format!("blocked:{}", out.status), egress_id, true)),
-        );
-    }
     let html = crate::extract::charset::decode(
         &out.body,
         out.headers
@@ -66,6 +118,20 @@ pub(super) async fn engine_task(
             .map(|(_, v)| v.as_str())
             .unwrap_or(""),
     );
+    if engine == "google"
+        && let Some(status) = engines::google_wml::response_error(out.status, &out.headers, &html)
+    {
+        if let Some(lease) = &lease {
+            google.finish(lease, status);
+        }
+        return (label, Err((status.into(), egress_id, true)));
+    }
+    if out.status == 429 || !matches!(out.verdict, Verdict::ContentOk) {
+        return (
+            label,
+            Err((format!("blocked:{}", out.status), egress_id, true)),
+        );
+    }
     let hits = engines::parse(&engine, &html);
     if hits.len() < 3 {
         // Honest "no results" is NOT an engine failure :
@@ -78,22 +144,25 @@ pub(super) async fn engine_task(
         let status = if dry { "no-results" } else { "empty-parse" };
         return (label, Err((status.into(), egress_id, true)));
     }
+    if let Some(lease) = &lease {
+        google.finish(lease, "ok");
+    }
     (label, Ok((hits, ms, egress_id, true)))
 }
 
 /// The browser-render SERP lane. Runs the SERP URL through the
 /// shared ghost hook (render cache shortcut included), parses
-/// with the same layered parser as the plain-HTTP engine, and
+/// with the desktop parser (separate from the WML HTTP layout), and
 /// reports honestly: "google_ghost" on the engine list, egress
-/// "ghost". Engine id shares the "google" base for trust +
-/// quarantine so repeated cascades learn.
+/// "ghost". Health is transport-specific; ranking still counts only
+/// one Google index family across HTTP and browser results.
 pub(super) async fn ghost_engine_task(
     engine: String,
     query: String,
     hook: crate::crawl::GhostHook,
 ) -> (String, EngineResult) {
     let started = Instant::now();
-    let Some(url) = engines::serp_url("google", &query) else {
+    let Some(url) = engines::serp_url("google_ghost", &query) else {
         return (engine, Err(("no-url".into(), "ghost".into(), true)));
     };
     // The hook runs acquire + render + one retry internally,
@@ -112,7 +181,7 @@ pub(super) async fn ghost_engine_task(
         }
         Ok(Ok(r)) => r.html,
     };
-    let hits = engines::parse("google", &rendered);
+    let hits = engines::parse("google_ghost", &rendered);
     let ms = started.elapsed().as_millis() as u64;
     if hits.len() < 3 {
         // 200-but-no-results 2026 Google = bot wall or an AI-mode
@@ -162,6 +231,78 @@ fn vertical_success(vertical: String, hits: Vec<engines::Hit>, ms: u64) -> (Stri
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[tokio::test]
+    async fn engine_budget_includes_pacing_without_starting_network() {
+        let fetcher = Fetcher::new(crate::profile::BrowserProfile::host_default()).unwrap();
+        let pool = EgressPool::new(Vec::new());
+        let google = engines::google_wml::ProfileSelector::from_env();
+        let context = EngineContext {
+            fetcher: &fetcher,
+            pool: &pool,
+            google: &google,
+        };
+        pool.pace("bing", "direct").await;
+        let (_, outcome) = engine_task_with_budget(
+            "bing".into(),
+            "unused".into(),
+            "direct".into(),
+            None,
+            context,
+            std::time::Duration::from_millis(1),
+            None,
+        )
+        .await;
+        let (status, _, _) = outcome.unwrap_err();
+        assert_eq!(status, "pacing-timeout");
+        assert!(!super::super::is_engine_fault(&status));
+    }
+
+    /// Explicit live test of the actual fan-out task, not a second HTTP client.
+    /// Never runs in the ordinary offline test suite.
+    #[tokio::test]
+    #[ignore = "makes three paced, direct requests to Google; no browser or paid API"]
+    async fn google_wml_live() {
+        let fetcher = Fetcher::new(crate::profile::BrowserProfile::host_default()).unwrap();
+        let pool = EgressPool::new(Vec::new());
+        let google = engines::google_wml::ProfileSelector::from_env();
+        let context = EngineContext {
+            fetcher: &fetcher,
+            pool: &pool,
+            google: &google,
+        };
+        for query in [
+            "rust programming language",
+            "PostgreSQL documentation",
+            "musei di Roma",
+        ] {
+            let (engine, outcome) = engine_task(
+                "google".into(),
+                query.into(),
+                "direct".into(),
+                None,
+                context,
+            )
+            .await;
+            let (hits, ms, egress, was_engine) =
+                outcome.expect("Google HTTP lane must return usable results");
+            assert!(engine.starts_with("google@"));
+            assert_eq!(egress, "direct");
+            assert!(was_engine);
+            assert!(hits.len() >= 3);
+            assert!(
+                hits.iter()
+                    .all(|h| !h.title.is_empty() && url::Url::parse(&h.url).is_ok())
+            );
+            assert!(hits.iter().any(|h| !h.snippet.is_empty()));
+            eprintln!(
+                "{query:?}: {} hits, {ms} ms, first={}",
+                hits.len(),
+                hits[0].url
+            );
+            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+        }
+    }
 
     fn hit(title: &str, url: &str) -> engines::Hit {
         engines::Hit {

--- a/tests/request_class.rs
+++ b/tests/request_class.rs
@@ -44,6 +44,61 @@ fn header<'a>(raw: &'a str, name: &str) -> Option<&'a str> {
 }
 
 #[tokio::test]
+async fn legacy_user_agent_is_single_and_request_local() {
+    unsafe { std::env::set_var("DONSETCH_ALLOW_PRIVATE_EGRESS", "1") };
+    let fetcher =
+        donsetch::fetch::client::Fetcher::new(donsetch::profile::BrowserProfile::host_default())
+            .unwrap();
+    let ua = donsetch::search::engines::google_wml::USER_AGENT;
+    let (legacy_port, legacy_rx) = serve_once();
+    let (normal_port, normal_rx) = serve_once();
+    let legacy_url = format!("http://127.0.0.1:{legacy_port}/search");
+    let normal_url = format!("http://127.0.0.1:{normal_port}/page");
+    let (legacy, normal) = tokio::join!(
+        fetcher.fetch_once_via_user_agent(&legacy_url, None, ua),
+        fetcher.fetch_once_via(&normal_url, &[], None, false, None),
+    );
+    assert_eq!(legacy.unwrap().status, 200);
+    assert_eq!(normal.unwrap().status, 200);
+    let raw = legacy_rx
+        .recv_timeout(std::time::Duration::from_secs(5))
+        .unwrap();
+    assert_eq!(header(&raw, "user-agent"), Some(ua));
+    assert_eq!(
+        raw.lines()
+            .filter(|l| l.to_lowercase().starts_with("user-agent:"))
+            .count(),
+        1
+    );
+    assert!(!raw.to_lowercase().contains("sec-ch-ua"));
+    assert!(!raw.to_lowercase().contains("sec-fetch-"));
+    assert!(header(&raw, "cookie").is_none());
+    let raw = normal_rx
+        .recv_timeout(std::time::Duration::from_secs(5))
+        .unwrap();
+    assert_eq!(
+        header(&raw, "user-agent"),
+        Some(fetcher.profile().user_agent.as_str())
+    );
+    assert!(header(&raw, "sec-ch-ua").is_some());
+}
+
+#[tokio::test]
+async fn legacy_user_agent_rejects_header_injection_before_network() {
+    let fetcher =
+        donsetch::fetch::client::Fetcher::new(donsetch::profile::BrowserProfile::host_default())
+            .unwrap();
+    for ua in ["", "Nokia\r\nCookie: injected", "Nokia\0", "Nokià"] {
+        let error = fetcher
+            .fetch_once_via_user_agent("not-a-url", None, ua)
+            .await
+            .err()
+            .unwrap();
+        assert!(error.to_string().contains("invalid User-Agent"));
+    }
+}
+
+#[tokio::test]
 async fn subresource_class_goes_out_on_the_wire() {
     unsafe { std::env::set_var("DONSETCH_ALLOW_PRIVATE_EGRESS", "1") };
     let (port, rx) = serve_once();


### PR DESCRIPTION
# feat(search): bring back fast, keyless Google search

## Summary

One thing I appreciated in Hound was having Google without a paid API. I like
making useful keyless results available through the native stack.

After several approaches were blocked or returned unusable pages, a legacy
Nokia 6230 User-Agent gave us working Google results through DonSeTch's native
HTTP stack. Building on profiles found in other open-source repositories, we
then tested a broader set of Nokia profiles, including 114 additional candidates,
and selected seven profiles that returned valid results in our tests.
Availability is intermittent: the same profile can return
useful results in one run and a CAPTCHA in another. This PR restores native
Google search as a best-effort additional source, not a dependable foundation
for search coverage, and integrates it with the existing search lifecycle.

Google runs concurrently with the other HTTP engines. Observed CAPTCHA responses
were fast in recent direct checks (under one second), while proxy checks reached
about 1.6 seconds. This is not a guarantee
of sub-second responses or zero added
latency: the search waits for the full wave, so a slow Google attempt can delay
the final response up to its normal eight-second admission/I/O budget. A thin
merge may also trigger the shared three-second retry wave. When other engines
provide sufficient results, no Google retry is requested. I see this as a
nice-to-have source when available, with fallback to the other engines when
it is blocked, rather than something to rely on consistently.

In our tests, Google was much more reliable over a direct connection than through
the sampled Webshare proxies, suggesting that IP reputation may contribute to
blocking.

The default initial profile is `6230-03.15`, one of the two additional firmware
variants found during the extended screening. Profiles are preferred per egress
in memory, advance circularly on CAPTCHA,
and reset on restart. There are no per-profile cooldowns: all failures follow
the existing engine/egress health and quarantine rules. The shared thin-merge
wave permits one extra attempt with its normal egress selection and deadline.
Only the Google adapter selects identities. HTTP 429 does not advance the cursor.
An evolved egress preference takes precedence over stale retry evidence.
Browser fallback
keeps separate health; ranking still counts one Google family. No paid API,
Python/Node runtime dependency or interactive CAPTCHA solver is added.

## Type

- [x] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — deps, CI, tooling
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only

## Checks

- [ ] `cargo test --features ocr,rerank` passes (full suite pending)
- [ ] `cargo clippy --all-targets --features ocr,rerank -- -Dwarnings` passes
- [x] `cargo fmt --all -- --check` passes
- [ ] CI is green on all 3 platforms (Linux, macOS, Windows)

Local Clippy passed with `--profile ci --all-targets --features ocr,rerank,http
-- -Dwarnings`; this is not the exact feature combination above.

## Breaking changes

Google joins the default roster. Reports gain optional `profile` diagnostics;
old cached reports remain readable. Rust callers constructing `EngineReport`
literals must supply the new field. CLI syntax and existing JSON fields remain.

## Test plan

132 scoped search tests and four socket/header tests passed. Checks cover
parsing, circular profile preference, stale outcomes, cancellation, deadlines
and cache compatibility. Regression cases cover unavailable-engine scheduling,
shared DDG fallback health and concurrent same-profile success/CAPTCHA outcomes.
The scoped suite excludes BYOK/reranker/persistence
modules and runs serially because existing tests share process environment.
Actual CLI searches for Rust and PostgreSQL each returned ten Google hits,
fused with other engines; cached results preserved Google provenance.
In a later CLI check, a Rust search received a Google CAPTCHA and still
returned results through the other engines. A subsequent MCP search for
PostgreSQL succeeded with the then-default `6230-05.50` profile (767 ms); a second MCP
query completed without selecting Google. This does not verify live rotation
or prove that changing identity resolves a CAPTCHA.

Local profile checks demonstrate intermittent access, not stable profiles or a
reliable success-rate estimate. The native probe checks do not measure end-to-end
search latency or relevance independently.

The endpoint is unofficial. This is a small, single-network sample, not a
stability guarantee or an end-to-end speedup benchmark. Live CAPTCHA recovery
and multi-platform CI remain unverified. See `docs/google-wml.md` for configuration,
architecture and reproduction. Given the intermittent availability, I would
especially appreciate your assessment of whether this best-effort source is
worth enabling by default, as well as the bounded CAPTCHA fallback and shared
pacing changes.
