### PR TITLE
fix(cli): status used cfg! instead of #[cfg], breaking every default-feature build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,20 @@ channel until the v4.0.0 release train.
 
 ### Fixed
 
+- Default-feature builds compile again: the web-memory receipt in
+  `donsetch status` tested the rerank feature with `cfg!` instead of
+  `#[cfg]`. `cfg!` is a runtime boolean, so the rerank-only arms
+  stayed in the token stream and still had to resolve
+  `crate::memory::{kill_switch, rows, cap}`, which the module gates
+  behind the feature. Every `cargo build` without `rerank` failed
+  with three E0425s; the printed status text is unchanged in both
+  configurations. The memory ingest wrappers in `mcp/server` needed
+  the same treatment from the other side: their bodies are entirely
+  rerank-gated, so without the feature their parameters are unused
+  and clippy `-Dwarnings` failed once the crate compiled far enough
+  to lint. Also restores the five fuzz targets (extract, charset,
+  feed, sitemap, paginate), which build default-featured and had
+  stopped running.
 - Xvfb reuse gate now demands a bounded real-protocol answer
   (xdpyinfo within 2s) before handing a display to the pool, so a
   SIGKILLed Xvfb's tombstone socket can no longer wedge every

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -216,9 +216,10 @@ pub async fn run() {
     cli::print_kv("route memory", &route_line);
     // v4 phase 5.2: local web memory receipt. status for every
     // subsystem, kill switch honored, non-rerank build says so.
-    let mem_line = if !cfg!(feature = "rerank") {
-        "unavailable (this build lacks the rerank feature)".to_string()
-    } else if crate::memory::kill_switch() {
+    #[cfg(not(feature = "rerank"))]
+    let mem_line = "unavailable (this build lacks the rerank feature)".to_string();
+    #[cfg(feature = "rerank")]
+    let mem_line = if crate::memory::kill_switch() {
         "off (DONSETCH_NO_WEB_MEMORY)".to_string()
     } else {
         match crate::memory::rows() {

--- a/src/mcp/server/fetch_tool.rs
+++ b/src/mcp/server/fetch_tool.rs
@@ -97,6 +97,7 @@ pub(super) async fn fetch_tool(
 /// Store a successful fetch result page into the local web memory.
 /// Additive (v4 law 5): ingest failure never touches the fetch result;
 /// its only surface is a stderr receipt.
+#[cfg_attr(not(feature = "rerank"), allow(unused_variables))]
 fn memory_ingest_result(url: &str, result: &Value) {
     #[cfg(feature = "rerank")]
     if !crate::memory::kill_switch() && result.get("isError").and_then(Value::as_bool) != Some(true)

--- a/src/mcp/server/search_tool.rs
+++ b/src/mcp/server/search_tool.rs
@@ -185,6 +185,7 @@ pub(super) async fn search_inner(
 /// Remember snippets of the top search hits before rendering. The
 /// memory's body cap truncates us so this stays small, and the
 /// kill switch short-circuits everything.
+#[cfg_attr(not(feature = "rerank"), allow(unused_variables))]
 fn memory_ingest_outcome(out: &crate::search::SearchOutcome) {
     #[cfg(feature = "rerank")]
     if !crate::memory::kill_switch() {


### PR DESCRIPTION


## Summary


`cfg!` is a runtime boolean, so the rerank-only arms stayed in the token stream and still had to resolve crate::memory::{kill_switch, rows, cap} — which src/memory/mod.rs gates behind #[cfg(feature = "rerank")]. Three E0425s, so `cargo build` with default features has failed since the web-memory commit.

Every red CI lane is a `features: ''` lane; the green ones all pass --features ocr,rerank[,http]. That also silenced the five fuzz targets (extract, charset, feed, sitemap, paginate), which build default-featured and had stopped running.

## Type

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — deps, CI, tooling
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only

## Checks

- [x] `cargo test --features ocr,rerank` passes (622+ tests)
- [x] `cargo clippy --all-targets --features ocr,rerank -- -Dwarnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes
- [ ] CI is green on all 3 platforms (Linux, macOS, Windows)


