### PR TITLE
fix(fetch,memory): two daemon-killing paths in the v4 fetch and memory stacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -130,6 +130,25 @@ channel until the v4.0.0 release train.
 
 ### Fixed
 
+- Subresource shadow-fetching no longer aborts the daemon on a page
+  containing `İ`, `K` or `Ω`. The scanner searched a `to_lowercase()`
+  copy of the document for tag offsets and then sliced the original
+  string at them, but `to_lowercase` is not byte-length preserving, so
+  one such character shifted every later offset: assets silently
+  dropped where the shift landed on ASCII, a mid-codepoint slice panic
+  where it did not : and the release profile's `panic = "abort"` turns
+  that into a daemon kill. Folding is `to_ascii_lowercase` now, which
+  is byte-length and char-boundary preserving, and is also what the
+  HTML standard specifies for tag and attribute names. `attr()` had
+  the same latent pattern and is fixed with it.
+- A corrupt local embedding model no longer wedges every subsequent
+  fetch. `ensure_file` recursed into itself with identical arguments
+  when the file on disk failed its SHA/size pin, never removing it, so
+  the same bad bytes were read forever : a stack overflow, or an
+  infinite loop if the recursion was optimized into a tail call. The
+  bad file is removed and the existing atomic download path takes
+  over; a concurrent remover is tolerated with a receipt, any other
+  removal failure is honest and immediate.
 - Default-feature builds compile again: the web-memory receipt in
   `donsetch status` tested the rerank feature with `cfg!` instead of
   `#[cfg]`. `cfg!` is a runtime boolean, so the rerank-only arms

--- a/src/fetch/shadow.rs
+++ b/src/fetch/shadow.rs
@@ -247,7 +247,13 @@ pub fn extract_assets(page_url: &str, html: &[u8]) -> Vec<(String, RequestClass)
 /// Byte-scan over the tag soup: no DOM, no allocation beyond the
 /// candidates. Looks at <link>, <script>, <img> only.
 fn scan_candidates(html: &str) -> Vec<(String, RequestClass)> {
-    let lower = html.to_lowercase();
+    // Offsets found here index back into `html`, and only
+    // to_ascii_lowercase preserves byte length and char boundaries.
+    // It is also the folding HTML specifies: tag and attribute names
+    // match ASCII-case-insensitively. A slice that lands mid-codepoint
+    // panics, and the release profile aborts rather than unwinding, so
+    // the cost of breaking this is the whole daemon, not one fetch.
+    let lower = html.to_ascii_lowercase();
     let bytes = lower.as_bytes();
     let mut out = Vec::new();
     let mut pos = 0usize;
@@ -342,7 +348,9 @@ fn find_from(hay: &[u8], needle: &[u8], from: usize) -> Option<usize> {
 /// Pull an attribute value out of a single tag's text. Handles
 /// double quotes, single quotes, and unquoted values.
 fn attr(tag: &str, name: &str) -> Option<String> {
-    let lower = tag.to_lowercase();
+    // ASCII-only folding, same reason as scan_candidates: `at` indexes
+    // back into `tag`.
+    let lower = tag.to_ascii_lowercase();
     let needle = format!("{name}=");
     let at = lower.find(&needle)? + needle.len();
     let rest = &tag[at..];
@@ -375,6 +383,35 @@ mod tests {
         <video src="/video/intro.mp4"></video>
         <a href="/about">about</a>
         </body></html>"#;
+
+    /// Fails if the folding in `scan_candidates` or `attr` returns to
+    /// `to_lowercase`. The markers are picked for their byte-length
+    /// deltas: `Ω` (3->2) shifts the offsets onto ASCII and the assets
+    /// vanish, `K` (3->1) shifts onto a continuation byte and the
+    /// slice panics. `İ` (2->3) still parses either way, kept so the
+    /// growth direction is covered too.
+    #[test]
+    fn non_ascii_before_a_tag_does_not_shift_offsets() {
+        for marker in ["\u{130}", "\u{212A}", "\u{2126}"] {
+            let html = format!(
+                "<html><head><p>{marker}{marker}{marker}</p>\
+                 <link rel=\"stylesheet\" href=\"/css/App.css\">\
+                 <script src=\"/js/App.js\"></script></head></html>"
+            );
+            let assets = extract_assets("https://example.com/p", html.as_bytes());
+            let urls: Vec<&str> = assets.iter().map(|(u, _)| u.as_str()).collect();
+            assert!(
+                urls.contains(&"https://example.com/css/App.css"),
+                "stylesheet lost after {marker:?}: {urls:?}"
+            );
+            // Fails if a fix slices `lower` instead of `tag`: URL
+            // paths are case-sensitive.
+            assert!(
+                urls.contains(&"https://example.com/js/App.js"),
+                "script lost or case-folded after {marker:?}: {urls:?}"
+            );
+        }
+    }
 
     #[test]
     fn extracts_browser_subresources_in_order() {

--- a/src/memory/model.rs
+++ b/src/memory/model.rs
@@ -18,6 +18,19 @@ use ort::value::TensorRef;
 use sha2::{Digest, Sha256};
 use tokenizers::{PaddingParams, PaddingStrategy, Tokenizer, TruncationParams, TruncationStrategy};
 
+// `resolve/main` is a branch reference, not a revision: the host
+// serves whatever currently sits at that repo's head, so the hash and
+// byte count below are the only guard on what actually arrives. An
+// upstream re-push fails the pin on every install until both are
+// bumped — a visible outage of web memory rather than a silent model
+// swap, which is the trade being made. Pinning the URL to a commit
+// would remove the exposure; the sibling downloaders in
+// search/rerank.rs and pdf/ocr.rs float the same way.
+//
+// The file installs under a fixed name rather than one derived from
+// its hash, so two pins never coexist: bumping one deletes the other's
+// download. That is acceptable while the model is effectively static,
+// and content-addressed paths are out of scope here.
 pub const MODEL_URL: &str =
     "https://huggingface.co/Xenova/all-MiniLM-L6-v2/resolve/main/onnx/model_quantized.onnx";
 pub const MODEL_SHA256: &str = "afdb6f1a0e45b715d0bb9b11772f032c399babd23bfc31fed1c170afc848bdb1";
@@ -86,9 +99,30 @@ fn ensure_file(
         if verify_bytes(&bytes, sha, size) {
             return Ok(());
         }
-        // A wrong existing file = redownload; on failure leave it for
-        // a clean re-run, do not pretend it is good.
-        return ensure_file(url, sha, size, dest, what);
+        // Delete before redownloading. The rename below would replace
+        // it on success, so this is about the failure path: a
+        // surviving bad file is reported as present by
+        // has_model()/ready(), and every later call pays a full
+        // re-read and re-hash before rejecting it again.
+        //
+        // A concurrent remover reached the state we wanted. Any other
+        // error fails fast: a sharing violation here would fail the
+        // rename too, after a 23MB download.
+        match std::fs::remove_file(dest) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+                eprintln!(
+                    "[memory] corrupt {what} at {} already removed by another process",
+                    dest.display()
+                );
+            }
+            Err(e) => {
+                return Err(format!(
+                    "memory: remove corrupt {what} at {}: {e}",
+                    dest.display()
+                ));
+            }
+        }
     }
     std::fs::create_dir_all(dest.parent().unwrap_or_else(|| Path::new(".")))
         .map_err(|e| format!("memory: mkdir {}: {e}", dest.display()))?;
@@ -322,4 +356,38 @@ pub fn embed_batch(texts: &[String]) -> Result<Vec<Vec<f32>>, String> {
     }
     let _ = d;
     Ok(vecs)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Fails if the failed-pin path returns to recursing into
+    /// `ensure_file` instead of deleting: every frame re-read the same
+    /// bytes, so the process dies on a stack overflow rather than the
+    /// assertion reporting.
+    #[test]
+    fn corrupt_existing_file_is_removed_and_does_not_recurse() {
+        let dir = std::env::temp_dir().join(format!("donsetch-model-test-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let dest = dir.join("model_quantized.onnx");
+        std::fs::write(&dest, b"not the model").expect("seed");
+
+        // Port 1 refuses instantly, so the redownload fails fast and
+        // the test never waits on the network.
+        let out = ensure_file(
+            "http://127.0.0.1:1/model.onnx",
+            "0000000000000000000000000000000000000000000000000000000000000000",
+            999_999,
+            &dest,
+            "test model",
+        );
+
+        assert!(out.is_err(), "a failed redownload must report, not pretend");
+        assert!(
+            !dest.exists(),
+            "the corrupt file must be removed, or the next call reads it again"
+        );
+        let _ = std::fs::remove_dir_all(&dir);
+    }
 }


### PR DESCRIPTION

## Summary

Both are unreleased v4 code, and both take down the whole MCP daemon rather than failing the request that hit them.

shadow.rs: scan_candidates searched a to_lowercase() copy of the document for tag offsets, then sliced the ORIGINAL string at them. to_lowercase is not byte-length preserving — İ 2->3, K 3->1, Ω 3->2 — so one such character shifted every later offset. Where the shift landed on ASCII the tag was mis-parsed and its assets silently dropped; where it did not, the slice started mid-codepoint and panicked, which the release profile's panic = "abort" turns into a daemon kill driven by page content. to_ascii_lowercase rewrites only 0x41-0x5A and leaves every byte >= 0x80 alone, so length and char boundaries are preserved and the offsets are valid by construction. It is also what HTML specifies: tag and attribute names match ASCII-case-insensitively. attr() carried the same pattern.

memory/model.rs: ensure_file returned ensure_file(..) with identical arguments when the file on disk failed its SHA/size pin, and never removed it, so every frame re-read the same bytes — a stack overflow, or an infinite loop if the recursion was optimized into a tail call. It repeated on every later call, so one corrupt model wedged every fetch that reached web-memory ingest. Remove the file and fall through to the existing download, which still installs by temp-write + verify
+ rename. A concurrent remover carries a receipt rather than an error; any other removal failure is immediate, since a sharing violation would fail the rename anyway after a 23MB download.

Regression tests for both. Against the old code the shadow input drops assets on Ω and panics on K, and the model test overflows the stack instead of reporting.

## Type

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — deps, CI, tooling
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only

## Checks

- [x] `cargo test --features ocr,rerank` passes (622+ tests)
- [x] `cargo clippy --all-targets --features ocr,rerank -- -Dwarnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes
- [ ] CI is green on all 3 platforms (Linux, macOS, Windows)

## Breaking changes

None.

One deliberate narrowing worth naming: the scanner now folds tag and attribute
names with `to_ascii_lowercase` instead of `to_lowercase`, so a tag name written
with a non-ASCII character whose Unicode lowercase lands in ASCII — in practice
only `K` U+212A KELVIN SIGN — is no longer recognized. Browsers do not recognize
it either: the HTML standard matches tag and attribute names ASCII-case-
insensitively, so this drops an over-match rather than a capability.

Operationally visible: a locally cached embedding model that fails its SHA/size
pin is now deleted and redownloaded (~23 MB) instead of being retried in place.
Previously that path never terminated, so nothing depended on the old behavior.

## Test plan

Two regression tests, both discriminators against the old code:

- `fetch::shadow::tests::non_ascii_before_a_tag_does_not_shift_offsets` — a page
  carrying `İ` / `K` / `Ω` before a `<link>` and a `<script>`. Against the old
  scanner `Ω` shifts the offsets onto ASCII and both assets vanish, and `K`
  shifts onto a continuation byte and the slice panics.
- `memory::model::tests::corrupt_existing_file_is_removed_and_does_not_recurse` —
  seeds a file that fails the pin, then calls `ensure_file` against
  `http://127.0.0.1:1/` for an immediate connection refusal. Against the old code
  the recursion re-reads the same bytes every frame and the process dies on a
  stack overflow instead of the assertion reporting.

Run: `cargo nextest run --locked --features ocr,rerank,http` (filtered to the two
new tests plus the pre-existing `extracts_browser_subresources_in_order`, to catch
a regression in normal parsing) — 3 passed, 0 failed, on Windows x86_64 MSVC.

Full clippy and test suite run locally on this branch, clean. Not verified by
execution: the per-character behavior of the *old* code is traced from the byte
offsets rather than run, and neither failure mode was reproduced against a live
page or a genuinely corrupt model file.
