### PR TITLE
ci: one live run per pull request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,18 @@ on:
   pull_request:
     branches: [master]
 
+# One live run per pull request: a new push evicts that PR's own
+# still-running checks instead of queueing behind them. On a
+# pull_request event github.ref is refs/pull/<n>/merge, so the group
+# key carries the PR number and runs never cancel across PRs.
+#
+# Pushes to master keep the group key refs/heads/master and opt out of
+# cancellation: branch protection reads per-commit results, so a
+# cancelled master run would leave a gap rather than a verdict.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 env:
   CARGO_INCREMENTAL: 0
   CARGO_TERM_COLOR: always


### PR DESCRIPTION


## Summary

A new push to an open PR now evicts that PR's still-running checks instead of queueing behind them. On a pull_request event github.ref is refs/pull/<n>/merge, so the group key carries the PR number and runs never cancel across PRs.

Pushes to master opt out: branch protection reads per-commit results, and a cancelled master run leaves a gap rather than a verdict.

## Type

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [x] `chore` — deps, CI, tooling
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only

## Checks

- [x] `cargo test --features ocr,rerank` passes (622+ tests)  inapplicable
- [x] `cargo clippy --all-targets --features ocr,rerank -- -Dwarnings` passes (zero warnings)  inapplicable
- [x] `cargo fmt --all -- --check` passes  inapplicable
- [ ] CI is green on all 3 platforms (Linux, macOS, Windows)

## Verification:

it worked

<img width="418" height="720" alt="image" src="https://github.com/user-attachments/assets/99591be3-86e6-4850-8bdf-d237703e72b0" />
<img width="482" height="254" alt="image" src="https://github.com/user-attachments/assets/f138d162-3b15-4b55-be95-03b35dfa3ce5" />



