### PR TITLE
fix(cookies): logout also wipes the rendered-DOM echo of the session (#173 deeper pass)

### DIFF
--- a/src/ghost/cache.rs
+++ b/src/ghost/cache.rs
@@ -657,6 +657,18 @@ pub fn clear_session_cookies_for(domain: &str) -> bool {
         });
         removed |= p.session_cookies.len() != before;
     }
+    // Issue #173 (deeper pass): the rendered-DOM cache is a fourth copy
+    // of the session's fruit. A page fetched behind the session is
+    // stored whole in `renders` (RENDER_TTL = 5 min) and served by the
+    // tier-2 fetch shortcut, so a logged-out domain's dashboard would
+    // still hand back its authenticated DOM for up to five minutes.
+    // Drop every render whose host belongs to the logged-out domain.
+    let before_r = state.renders.len();
+    state.renders.retain(|url, _| {
+        let host = crate::search::rank::host_of(url);
+        !crate::auth::cookie_belongs_to(&key, &host)
+    });
+    removed |= state.renders.len() != before_r;
     if removed {
         state.save();
     }

--- a/tests/auth_login.rs
+++ b/tests/auth_login.rs
@@ -403,8 +403,17 @@ async fn probe_domain_does_not_panic_inside_a_tokio_runtime() {
 }
 
 /// Tier-1 jar echo hygiene (v4 phase 1.4, issue #173): the logout
-/// sweep owns every persisted copy. Two records, one matches the
-/// domain, one stays for another host.
+/// sweep owns every persisted copy. Two cookie records and two
+/// rendered pages, one of each matching the domain, one of each for
+/// another host. The rendered-DOM cache is a fourth copy of the
+/// session's fruit (a page fetched behind the session is stored
+/// whole in `renders`, RENDER_TTL = 5 min, and served by the tier-2
+/// fetch shortcut); a logout that leaves it hands back the logged-in
+/// DOM with no network hop for up to five minutes.
+///
+/// One test carries both echoes on purpose: the suite shares one
+/// on-disk state via the static cache dir, so a second concurrent
+/// writer would race the whole-file save under `cargo test`.
 #[test]
 fn logout_wipes_the_tier1_echo() {
     isolate_state();
@@ -418,6 +427,11 @@ fn logout_wipes_the_tier1_echo() {
             cookie(".alpha.test", "session_cookie", "a", None),
             cookie("beta.test", "other_cookie", "b", None),
         ]);
+        state.record_render(
+            "https://app.alpha.test/dashboard",
+            "<html><body>logged-in dashboard</body></html>",
+        );
+        state.record_render("https://beta.test/page", "<html>public</html>");
         state.save();
     }
     assert!(clear_session_cookies_for("alpha.test"));
@@ -435,5 +449,15 @@ fn logout_wipes_the_tier1_echo() {
     assert!(
         tiers.iter().any(|d| d.ends_with("beta.test")),
         "background housekeeping must keep unrelated domains"
+    );
+    assert!(
+        state
+            .render_for("https://app.alpha.test/dashboard")
+            .is_none(),
+        "the rendered DOM of a logged-out domain must not survive logout"
+    );
+    assert!(
+        state.render_for("https://beta.test/page").is_some(),
+        "logout must not evict renders of unrelated domains"
     );
 }


### PR DESCRIPTION
## The gap

`c346a26` (#173) closed the tier-1 cookie echo that logout was missing. But the session leaves a **fourth** copy of its fruit that logout still doesn't touch: the **render cache**.

A page fetched behind a session is stored whole in `GhostState.renders` (keyed by URL, `RENDER_TTL = 5 min`) and served by the tier-2 fetch shortcut — `render_for(url)` on the fetch and search paths. So after:

```
donsetch login --logout example.com
```

a fetch of a page that was rendered while logged in returns the **authenticated DOM straight from cache**, no network hop, for up to five minutes. The logged-out dashboard is handed back as if the session were still live. It's not a live credential (it can't authenticate new requests, and it self-expires in ≤5 min), so this is a content echo, not a full auth bypass — but it directly contradicts the logout contract, which is exactly the class of leak #173 set out to close.

## The fix

`clear_session_cookies_for` now sweeps `renders` with the same rule it already applies to the two cookie buckets: drop every render whose host belongs to the logged-out domain (`search::rank::host_of` + `auth::cookie_belongs_to`), keep everything else.

```rust
let before_r = state.renders.len();
state.renders.retain(|url, _| {
    let host = crate::search::rank::host_of(url);
    !crate::auth::cookie_belongs_to(&key, &host)
});
removed |= state.renders.len() != before_r;
```

`host_of` parses via the `url` crate (host lowercased) and `cookie_belongs_to` is the same bidirectional apex/subdomain match the cookie sweep uses, so `--logout example.com` clears `app.example.com`'s render and a subdomain logout clears its apex-fed render, while unrelated domains are left alone.

## RED → GREEN

Coverage is folded into the existing `logout_wipes_the_tier1_echo` test **on purpose, not as a new test**: the `auth_login` suite shares one on-disk `ghost-state.json` through a static `DONSETCH_CACHE_DIR`, so a second concurrent state writer races the whole-file save under plain `cargo test` (CI's nextest is process-per-test and immune, but a new flaky test helps no one). The one test now records a matching render (`app.alpha.test`) and an unrelated one (`beta.test`), logs out `alpha.test`, and asserts:

```
the rendered DOM of a logged-out domain must not survive logout   # RED before this fix
logout must not evict renders of unrelated domains
```

Verification: RED confirmed on the unmodified sweep (the `app.alpha.test` render survived); GREEN after. Full `cargo nextest run` **1105/1105 passed** (1 skipped); `clippy --all-targets` and `fmt --check` clean; `auth_login` green 3× under nextest.

## Found in the same pass, reported separately (not in this PR)

- **`web_screenshot` CLI drift**: `spec.rs` declares the tool with `cli_cmd: "screenshot"` and `donsetch screenshot URL` examples (rendered in `--help`), but `main.rs` never dispatches `screenshot`, so the spec's own example returns `unknown command 'screenshot'`. Fix direction is a design call (wire the CLI vs make it MCP-only per the commit's "CLI-free surface"), so I'm flagging rather than guessing.
- **`memory::store::persist` shared tmp**: the per-PID tmp (`index.PID.tmp`, `O_TRUNC` + rename) is now written by overlapping `ingest_async` tasks (fired per-256-chunk and on completion within one crawl); two concurrent persists can truncate/interleave one inode and the next `load()` parse-fails to `unwrap_or_default()` (a silent full index wipe). Real by construction; I could not force a deterministic repro locally (fast tmpfs), so I'm reporting it with the trivial fix (unique tmp per call) rather than shipping an unverified corruption claim.

https://claude.ai/code/session_01Vg2CMnuvDevTxCpmJGbnRU