### PR TITLE
test(routes): drop the Windows exclusion from the alt-svc kill-switch test

### DIFF
--- a/src/transport/routes.rs
+++ b/src/transport/routes.rs
@@ -515,19 +515,12 @@ mod tests {
 
         // The switch DONSETCH_NO_ALT_SVC shuts the bookkeeping up
         // entirely: absorbs still parse, they just do not record.
-        #[cfg(not(windows))]
-        unsafe {
-            std::env::set_var("DONSETCH_NO_ALT_SVC", "1")
-        };
-        #[cfg(not(windows))]
+        unsafe { std::env::set_var("DONSETCH_NO_ALT_SVC", "1") };
         assert_eq!(
             absorb_alt_svc("skip.test", "h3=\":443\"; ma=900", "direct"),
             None
         );
-        #[cfg(not(windows))]
-        unsafe {
-            std::env::remove_var("DONSETCH_NO_ALT_SVC")
-        };
+        unsafe { std::env::remove_var("DONSETCH_NO_ALT_SVC") };
 
         unsafe { std::env::remove_var("DONSETCH_CACHE_DIR") };
         let _ = std::fs::remove_dir_all(&dir);


### PR DESCRIPTION
Removes the #[cfg(not(windows))] on the three DONSETCH_NO_ALT_SVC lines in absorb_skips_the_file_rewrite_when_no_vouch_is_newer.

The gate left the kill switch untested on Windows. I could not find a platform reason for it: the assertion is pure Rust either side of
the env var (set_var -> config::env_flag -> var_os, all Win32, never the CRT copy), and the same test calls set_var/remove_var on
DONSETCH_CACHE_DIR ungated in the same function -- two lines below this hunk, in the identical one-line form after rustfmt -- with every mtime assertion depending on it. Ran the test on Windows 11 MSVC under nextest with the attributes removed: passes, as does the full lib suite and the local `all` recipe.

Question rather than a claim, since the commits that added it (39e9ead, cdb86be) don't mention Windows: was the exclusion deliberate? If it was guarding something I've missed, happy to close this -- could the reason go in a comment next to the attribute so it doesn't read as unexplained?

I have asked question about this, https://github.com/dondai44423/donsetch/issues/175#issuecomment-5632167684 but then I've checked locally and test ran without this gate, so I've decided to make this PR.