### PR TITLE
fix(memory): give each index persist its own staging file (concurrent-write corruption)

### DIFF
--- a/src/memory/store.rs
+++ b/src/memory/store.rs
@@ -13,6 +13,7 @@
 //! the previous file intact.
 
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::{Mutex, OnceLock};
 use std::time::{SystemTime, UNIX_EPOCH};
 
@@ -114,10 +115,27 @@ fn persist(entries: &[Entry]) -> Result<(), String> {
         entries: entries.to_vec(),
     };
     let body = serde_json::to_vec(&idx).map_err(|e| format!("memory: serialize: {e}"))?;
-    let tmp = path.with_extension(format!("{}.tmp", std::process::id()));
+    let tmp = stage_path(&path);
     std::fs::write(&tmp, &body).map_err(|e| format!("memory: write: {e}"))?;
     std::fs::rename(&tmp, &path).map_err(|e| format!("memory: rename: {e}"))?;
     Ok(())
+}
+
+/// A staging path unique to this write. The tmp was keyed on the PID
+/// alone, which was fine while ingest ran inline in the request task.
+/// ingest_async (issue #178) now hands every ingest to the blocking
+/// pool, and a single crawl fires it per 256-row chunk AND again on
+/// completion, so persists overlap: two writers opening one shared
+/// tmp with O_TRUNC truncate and interleave one inode, a rename moves
+/// the torn bytes into place, and the next load() parse-fails to an
+/// empty index (the whole recall cache silently wiped). A per-write
+/// suffix gives each persist its own inode; the rename is atomic, so
+/// index.json is always a complete file from some writer. PID stays
+/// in the name so a second process still never collides either.
+fn stage_path(path: &std::path::Path) -> PathBuf {
+    static SEQ: AtomicU64 = AtomicU64::new(0);
+    let n = SEQ.fetch_add(1, Ordering::Relaxed);
+    path.with_extension(format!("{}.{}.tmp", std::process::id(), n))
 }
 
 fn store() -> &'static Mutex<Vec<Entry>> {
@@ -369,6 +387,68 @@ mod tests {
         assert_eq!(snippetize(&long, usize::MAX).chars().count(), 300);
         let cjk = "東".repeat(10);
         assert!(!snippetize(&cjk, 8).is_empty());
+    }
+
+    // Two persists that overlap must not share one staging file.
+    // The old per-PID-only tmp meant every write in a process opened
+    // the SAME path with O_TRUNC; ingest_async (issue #178) made those
+    // writes concurrent (per-chunk + on-completion within one crawl),
+    // so a second writer could truncate the first mid-flight and the
+    // rename would move torn bytes into index.json -> next load()
+    // parse-fails to an empty index. Distinct staging paths per write
+    // are the invariant that keeps each rename a complete file.
+    #[test]
+    fn stage_paths_are_unique_per_write() {
+        let base = std::path::Path::new("/tmp/donsetch-idx/index.json");
+        let a = stage_path(base);
+        let b = stage_path(base);
+        assert_ne!(a, b, "each persist must stage to its own tmp file");
+        assert_ne!(a.file_name(), b.file_name());
+        // Both still land beside the target (same dir) and read as tmp.
+        assert_eq!(a.parent(), Some(std::path::Path::new("/tmp/donsetch-idx")));
+        assert!(a.to_string_lossy().ends_with(".tmp"));
+    }
+
+    // A best-effort concurrency guard: many overlapping persists to
+    // one path must always leave a parseable, complete index (never a
+    // truncated/interleaved corpse). Deterministic reproduction of the
+    // race needs a slow filesystem; this at least exercises the path
+    // and locks the post-fix guarantee. SAFETY: nextest isolates the
+    // process; index_path() lives under model_dir() here.
+    #[test]
+    fn concurrent_persist_leaves_a_valid_index() {
+        let snap = |tag: usize| -> Vec<Entry> {
+            (0..64)
+                .map(|i| Entry {
+                    url: format!("https://ex{tag}.test/{i}"),
+                    title: format!("t{tag}-{i}"),
+                    body: "x".repeat(4096),
+                    ts: i as u64,
+                    vec: vec![0.1f32; 384],
+                })
+                .collect()
+        };
+        let handles: Vec<_> = (0..8)
+            .map(|tag| {
+                let s = snap(tag);
+                std::thread::spawn(move || {
+                    for _ in 0..20 {
+                        let _ = persist(&s);
+                    }
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+        let raw = std::fs::read(index_path()).expect("index present after persists");
+        let parsed = serde_json::from_slice::<Index>(&raw);
+        assert!(parsed.is_ok(), "index.json must stay valid JSON");
+        assert_eq!(
+            parsed.unwrap().entries.len(),
+            64,
+            "a full snapshot survived"
+        );
     }
 
     /// The cap floor: junk or tiny values fall back to the default,


### PR DESCRIPTION
## The race

`677b1ce` (#178) moved web-memory ingest onto the blocking pool via `ingest_async`, and a single crawl now fires it **twice concurrently** — once per 256-row chunk during the crawl (`crawl_tool.rs`) and again with the remainder on completion. Search and fetch tools add more `ingest_async` callers. So `persist()` runs from overlapping `spawn_blocking` tasks.

`persist()` staged the whole index to a tmp keyed on the **PID alone** and wrote it with `O_TRUNC`, then renamed:

```rust
let tmp = path.with_extension(format!("{}.tmp", std::process::id()));  // same path every call
std::fs::write(&tmp, &body)?;   // O_CREAT | O_TRUNC
std::fs::rename(&tmp, &path)?;
```

Two concurrent persists open the **same** tmp. The second's `O_TRUNC` truncates the file the first is still writing; the two writers interleave one inode; whichever `rename` runs first moves the torn bytes into `index.json`. `load()` then hits `serde_json::from_str(...).ok()` → `unwrap_or_default()` and returns an **empty index** — the user's whole accumulated recall cache silently wiped on the next daemon start. (The second `rename` also fails ENOENT, swallowed by `ingest_async`'s `eprintln!`.)

The per-PID tmp was correct while ingest ran inline in the request task (persists never overlapped); it did nothing once `ingest_async` made them concurrent.

## The fix

Each persist stages to its **own** file — PID plus an atomic counter — so overlapping writers never share an inode, and every `rename` publishes a complete file from some writer:

```rust
fn stage_path(path: &Path) -> PathBuf {
    static SEQ: AtomicU64 = AtomicU64::new(0);
    let n = SEQ.fetch_add(1, Ordering::Relaxed);
    path.with_extension(format!("{}.{}.tmp", std::process::id(), n))
}
```

`rename` is atomic, so `index.json` is always a whole, valid file. The PID stays in the name so a second process never collides either.

## Verification — and an honest limit

This is a data race, so a deterministic corruption repro needs a slow filesystem: on a fast tmpfs the ~MB `write_all` completes as a burst before the `rename` window opens, and I could **not** force the interleave locally (32 threads × 60 iterations × 4 MB stayed clean). Rather than ship an unverified "reproduced a wipe" claim, the fix rests on removing the shared mutable staging file — an unambiguous antipattern once the writers became concurrent — and the tests pin what is deterministically checkable:

- `stage_paths_are_unique_per_write` — the invariant the fix guarantees (two calls stage to distinct files in the same dir); this is what the old per-PID path violated.
- `concurrent_persist_leaves_a_valid_index` — a best-effort guard that 8 threads hammering `persist()` always leave a parseable, complete index.

Full `cargo nextest run --features rerank` **1133/1133** (1 skipped); `clippy --all-targets` and `fmt --check` clean.

Residual, not addressed here (self-healing, minor): with `persist` deliberately outside the store lock (for latency), a slower writer's older snapshot can still be the last `rename`, dropping a row on disk until it is re-ingested. That is a lost row, not a corrupt file — the corruption/total-wipe path is what this PR closes. Closing the row-loss too would mean re-snapshotting under a writer lock, a larger change I left out.

https://claude.ai/code/session_01Vg2CMnuvDevTxCpmJGbnRU