### PR TITLE
fix(mcp): fold state into [meta] for OpenCode too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ channel until the v4.0.0 release train.
   the shared 64 MiB cap before allocating; `routes.json` carries
   serialized TLS session material and lands owner-only (0600).
 - Experimental HTTP/3 lane (opt-in via `DONSETCH_H3=1`) on a quiche
-
   0.29.3 fork that shares one BoringSSL build with tier-1. An h3
   route is learned from `alt-svc` response headers (same-origin
   only, proxies exempt) and persisted in the cache dir under
@@ -167,6 +166,13 @@ channel until the v4.0.0 release train.
   is byte-length and char-boundary preserving, and is also what the
   HTML standard specifies for tag and attribute names. `attr()` had
   the same latent pattern and is fixed with it.
+- MCP text-only fold now covers OpenCode v1 (tested on 1.18.3):\
+  unlike Claude Code / VS Code, OpenCode renders the `content` array
+  and drops `structuredContent` entirely, so agents previously lost
+  every compact state field (URL handles, `next_offset`, verdicts,
+  error codes). Handshake detection now matches `opencode` and folds
+  the state into the leading `[meta]` text block, same as the other
+  text-only clients.
 - A corrupt local embedding model no longer wedges every subsequent
   fetch. `ensure_file` recursed into itself with identical arguments
   when the file on disk failed its SHA/size pin, never removing it, so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -155,7 +155,7 @@ channel until the v4.0.0 release train.
   one per 256-row chunk and one on completion) can no longer tear
   `index.json` through a shared tmp inode and parse-fail the next
   recall to an empty index.
-- Xvfb reuse gate now demands a bounded real-protocol answer
+- Subresource shadow-fetching no longer aborts the daemon on a page
   containing `İ`, `K` or `Ω`. The scanner searched a `to_lowercase()`
   copy of the document for tag offsets and then sliced the original
   string at them, but `to_lowercase` is not byte-length preserving, so

--- a/README.md
+++ b/README.md
@@ -298,14 +298,32 @@ connect to `http://localhost:8765/mcp`. Sessions, cancellation,
 `/health`, token auth via `DONSETCH_HTTP_TOKEN`, per-request timeout,
 all documented in `donsetch mcp --help`.
 
-**Structured-content compat (Claude Code / VS Code):** those harnesses
-show the model only `structuredContent` and drop the `content` array,
-which hides the page markdown behind tool metadata. DonSeTch detects
-them at the handshake (`clientInfo.name`) and merges the surfaces:
-a compact `[meta]` text block carries the structured state, the
-markdown stays a clean text block, and `structuredContent` is omitted.
-Any other client keeps the default token-optimal shape. To force the
-compat shape for an unrecognized client, set `DONSETCH_MCP_TEXT_ONLY=1`.
+**One-surface clients (the `[meta]` fold):** if your agent reports tool
+metadata but no page text, or gets the page text but can't cite a URL
+behind an `S3` handle, can't paginate, and never sees an error code,
+the client is rendering only one of the two MCP result surfaces and
+dropping the other. DonSeTch's default shape is split on purpose:
+`content` carries the document markdown, `structuredContent` carries
+compact actionable state (raw URLs behind the handles, `next_offset`,
+resume tokens, `content_ok`, `thin`, error codes, `next_action`). MCP
+never specified which surface a client shows, so both halves of that
+split get dropped in the wild — Claude Code and VS Code keep
+`structuredContent` and discard `content`; OpenCode v1 (tested on
+1.18.3) keeps `content` and discards `structuredContent`. Either way
+the fix is the same fold: a compact leading `[meta]` text block carries
+the state, the markdown stays a clean text block behind it, and
+`structuredContent` is omitted.
+
+Those three are detected at the handshake by `clientInfo.name`, matched
+exactly and case-insensitively against a hardcoded list, so a wrapper
+or fork under any other name — `claude-code-proxy`, say — is *not*
+detected and silently keeps the split shape. That is what
+`DONSETCH_MCP_TEXT_ONLY=1` is for: it forces the fold for every client
+regardless of the handshake, so an unlisted host is fixable today
+rather than at the next release. Fail-closed, like the other env flags
+— only an explicitly true value turns it on; `=false` leaves the
+handshake in charge. Every other client keeps the default token-optimal
+split shape.
 
 **2. CLI (for humans and scripts).** Same engine as MCP, thin adapter:
 

--- a/src/mcp/compat.rs
+++ b/src/mcp/compat.rs
@@ -1,6 +1,11 @@
 //! MCP client-compat layer for harnesses that show the model only
-//! `structuredContent` and discard the `content` array (Claude Code,
-//! VS Code: the model then sees tool metadata but never the document).
+//! one surface and discard the other.
+//!
+//! Two observed failure modes:
+//! - `structuredContent` only, `content` dropped (Claude Code, VS Code:
+//!   the model sees tool metadata but never the document).
+//! - `content` only, `structuredContent` dropped (OpenCode v1: the model
+//!   sees the document but never the compact state).
 //!
 //! DonSeTch's shape is deliberately split: `content` carries the
 //! document markdown, `structuredContent` carries compact actionable
@@ -71,17 +76,25 @@ impl Default for ModeCell {
     }
 }
 
-/// Clients observed showing the model only `structuredContent` while
-/// dropping every `content` block. Matched case-insensitively, exact.
+/// Clients observed showing the model only one surface and discarding
+/// the other. Matched case-insensitively, exact.
+///
+/// - Claude Code / VS Code: keep `structuredContent`, drop `content`.
+/// - OpenCode v1: keep `content`, drop `structuredContent`.
+///
 /// Wrappers reusing one of these names get one redundant surface at
 /// worst (a client that renders text AND matches here sees the meta
 /// block next to nothing else), so defaulting to a name match is the
 /// safe direction.
 ///
-/// EXIT PLAN: when a listed client starts rendering `content` blocks
-/// again, delete the entry and re-run a single `web_fetch` through it;
+/// EXIT PLAN: when a listed client starts rendering both surfaces,
+/// delete the entry and re-run a single `web_fetch` through it;
 /// if the document reaches the agent, the entry stays deleted.
-const TEXT_ONLY_CLIENTS: &[&str] = &["claude-code", "vscode"];
+const TEXT_ONLY_CLIENTS: &[&str] = &[
+    "claude-code", // renders structuredContent
+    "opencode",    // renders only content
+    "vscode",      // renders structuredContent
+];
 
 /// Handshake-detected mode from `clientInfo.name`. Lenient by
 /// construction: the caller hands over the raw JSON-RPC params, and
@@ -273,10 +286,15 @@ mod tests {
         // match: unknown clients keep the token-optimal default.
         let wrapper = json!({ "clientInfo": { "name": "claude-code-proxy" } });
         assert_eq!(mode_from_params(&wrapper), ClientMode::Default);
-        let other = json!({ "clientInfo": { "name": "opencode" } });
-        assert_eq!(mode_from_params(&other), ClientMode::Default);
+        // Listed for the OPPOSITE reason (renders content, drops
+        // structuredContent), and folded all the same.
+        let oc = json!({ "clientInfo": { "name": "opencode" } });
+        assert_eq!(mode_from_params(&oc), ClientMode::TextOnly);
         let vs = json!({ "clientInfo": { "name": "vscode" } });
         assert_eq!(mode_from_params(&vs), ClientMode::TextOnly);
+        // An unlisted client keeps the token-optimal split shape.
+        let other = json!({ "clientInfo": { "name": "cursor" } });
+        assert_eq!(mode_from_params(&other), ClientMode::Default);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

OpenCode v1.18.3 drops structuredContent and renders content --
the mirror of Claude Code, same breakage: no raw URLs behind
S-handles, no next_offset, no error codes. Same fold fixes it.

- TEXT_ONLY_CLIENTS and its EXIT PLAN described only one drop
  direction; reworded for both. Const keeps its name, the
  DONSETCH_MCP_TEXT_ONLY env var is public API.
- Negative case in the detection test moves to `cursor`.
- README leads with the symptoms, not the client names.

## Type

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — deps, CI, tooling
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only

## Checks

- [x] `cargo test --features ocr,rerank` passes (622+ tests)
- [x] `cargo clippy --all-targets --features ocr,rerank -- -Dwarnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes
- [x] CI is green on all 3 platforms (Linux, macOS, Windows)

## Breaking changes

Just fix, opencode wasn't recavinf full data

## Test plan

Test in OpenCode

## Bonus fix

Fixed broken changelog entry from another commit merge
