### PR TITLE
feat(config): one typed runtime config, layered (closes #193)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,12 +10,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 V4 work in progress on `master`. Nothing below ships through a release
 channel until the v4.0.0 release train.
 
+### Changed
+- Every runtime env read now flows through the typed config. The old
+  env names keep their exact historical trigger semantics and still
+  work, but they are deprecated and will be removed at the v4
+  release; `donsetch doctor` lists the ones your shell still sets and
+  maps each to its config key.
+
 ### Added
 - `just win-check`: type-checks the crate for `x86_64-pc-windows-gnu`
   from Linux (clippy, no linkage), both `--no-default-features` and
   the full feature set, so `#[cfg(windows)]` breakage from a
   Linux-only change surfaces before the push instead of in Windows
   CI. Needs mingw-w64; see CONTRIBUTING.md.
+- One typed runtime config (`src/config.rs`, issue #193): every knob
+  lives in a layered struct, defaults < `donsetch.toml`
+  (`DONSETCH_CONFIG` or `<config-dir>/donsetch/donsetch.toml`,
+  skippable via `DONSETCH_NO_CONFIG_FILE=1`) < `DONSETCH_<SECTION>__<KEY>`
+  env names. Values validate loudly at load; unknown TOML keys name
+  the offending file. `donsetch config show` prints each knob with
+  its value and origin (`--markdown` for the reference table,
+  `--legacy` for the old-name map); `donsetch doctor` warns about
+  deprecated env names active in the shell.
 - `web_screenshot` MCP tool: a rendered PNG of a page through the
   existing tier-2 browser (url, full_page, wait_ms). The capture is
   in-process only; the MCP result carries an image content block and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -159,6 +159,11 @@ channel until the v4.0.0 release train.
   zstd 0.14.0, psl 2.1.231, actions/checkout 4 -> 7.
 
 ### Fixed
+- The browser probe timeout now kills the whole process group, not
+  just the parent: a wedged browser whose descendant held the stdout
+  pipe used to hang `donsetch doctor` forever. The probe now fails
+  at the timeout, bounded, on every platform.
+
 
 - The MCP supervisor no longer loses a request buffered into a
   child that dies before consuming it. The write succeeds while

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -646,6 +646,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc14f565cf027a105f7a44ccf9e5b424348421a1d8952a8fc9d499d313107789"
 
 [[package]]
+name = "config"
+version = "0.15.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b85f248a4de22d204ceabc6299d89d2c70fbd7f09fea53c06c852369652d8139"
+dependencies = [
+ "pathdiff",
+ "serde_core",
+ "toml",
+ "winnow",
+]
+
+[[package]]
 name = "console"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1080,6 +1092,7 @@ dependencies = [
  "boring-sys",
  "brotli 9.0.0",
  "clap",
+ "config",
  "dirs",
  "ed25519-dalek",
  "encoding_rs",
@@ -2699,6 +2712,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
 name = "pem"
 version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3610,6 +3629,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4136,6 +4164,37 @@ dependencies = [
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml"
+version = "1.1.6+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "920602543f0911ab71da12c50d59701da54c196d1a2bf5cb4b75667f137a406a"
+dependencies = [
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow",
 ]
 
 [[package]]
@@ -4691,6 +4750,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "winresource"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ scraper = "0.27.0"
 encoding_rs = "0.8.35"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+config = { version = "0.15", default-features = false, features = ["toml"] }
 tokio-tungstenite = "0.30"
 futures-util = "0.3"
 # HTTP server for MCP HTTP transport (axum, SSE). Optional: gates

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ reqwest; the core paths that run on every fetch do not.)
 Works with every MCP client (Claude Code, Cursor, OpenCode, Pi, Hermes)
 and as a standalone CLI.
 
-> **V4 is coming. And it's not just any upgrade.**
+> **V4 is coming soon.**
 
 ## ✨ What makes it different
 
@@ -273,6 +273,34 @@ donsetch doctor --fix    # repairs mechanical problems automatically
 `doctor --json` emits a machine-readable report; it also detects your
 MCP client and prints ready-to-paste registration blocks.
 
+## ⚙️ Configuration
+
+Every runtime knob lives in one typed config (`src/config.rs`). Four layers, later wins:
+
+1. Compiled defaults. A bare `donsetch mcp` stays the law: zero config needed.
+2. Legacy env vars (the pre-v4 names like `DONSETCH_NO_CRAWL_SHAPE`). Honored exactly as before, now reported as deprecated, cut at the v4 release.
+3. `donsetch.toml` at `<config-dir>/donsetch/donsetch.toml` (or anywhere via `DONSETCH_CONFIG=/path/file.toml`). Unknown keys and bad values are hard errors naming the file. `DONSETCH_NO_CONFIG_FILE=1` skips the file layer entirely (setting both is an error).
+4. New env names: `DONSETCH_<SECTION>__<KEY>`, for example `DONSETCH_FETCH__PDF_MAX_MB=25`. Section upper-case, double underscore, key upper-case.
+
+Knob sections: `transport`, `mcp`, `paths`, `state`, `proxy`, `tls`, `persona`, `cli`, `fetch`, `bypass`, `search`, `browser`, `debug`.
+
+- `donsetch config show` prints every knob with its value and its origin (default, legacy, file, env).
+- `donsetch config show --markdown` prints the full reference table, one row per knob.
+- `donsetch config show --legacy` maps every old env name to its config key.
+- `donsetch doctor` warns about the legacy vars active in your shell, mapped to their keys.
+
+```toml
+[fetch]
+h3 = true               # opt into the h3 lane
+shadow_fetch = "never"  # or "auto" / "always"
+pdf_max_mb = 100
+
+[state]
+web_memory_cap = 300
+```
+
+Booleans take `true` / `false`; enum knobs take their listed spellings. The exact TOML keys come from `donsetch config show`.
+
 ## Quickstart
 
 Two ways to use it:
@@ -331,6 +359,7 @@ split shape.
 donsetch fetch https://example.com --focus "pricing"
 donsetch search "rust async patterns" --intent code
 donsetch crawl https://docs.python.org --mode map --topic asyncio
+donsetch config show            # every knob with its origin (see Configuration)
 ```
 
 ## 🔀 HTTP Proxy

--- a/src/adapters/mod.rs
+++ b/src/adapters/mod.rs
@@ -26,17 +26,17 @@ pub mod wiki_infobox;
 
 /// Kill switch : checked once, then cached.
 fn enabled() -> bool {
-    static ON: std::sync::OnceLock<bool> = std::sync::OnceLock::new();
-    *ON.get_or_init(|| std::env::var("DONSETCH_NO_ADAPTERS").is_err())
+    crate::config::cfg().fetch.adapters
 }
 
 /// Debug capture: `DONSETCH_ADAPTER_DUMP=<dir>` writes every body
 /// an adapter inspects : fixture capture for adapter development.
 /// Best-effort, never a failure path.
 fn debug_dump(html: &str, url: &str) {
-    let Ok(dir) = std::env::var("DONSETCH_ADAPTER_DUMP") else {
+    let dir = crate::config::cfg().fetch.adapter_dump_dir.clone();
+    if dir.is_empty() {
         return;
-    };
+    }
     use std::hash::{Hash, Hasher};
     let mut h = std::collections::hash_map::DefaultHasher::new();
     url.hash(&mut h);

--- a/src/auth.rs
+++ b/src/auth.rs
@@ -60,7 +60,7 @@ impl AuthRegistry {
     pub fn save(&self) {
         #[cfg(not(test))]
         {
-            if std::env::var_os("DONSEEK_NO_DISK_STATE").is_some() {
+            if crate::config::cfg().state.no_disk_state {
                 return;
             }
         }

--- a/src/cli/adapters.rs
+++ b/src/cli/adapters.rs
@@ -9,8 +9,8 @@ use crate::adapters;
 use crate::adapters::plugins;
 
 pub fn run() {
-    if std::env::var_os("DONSETCH_NO_ADAPTERS").is_some() {
-        println!("Adapter registry is OFF (DONSETCH_NO_ADAPTERS is set).");
+    if !crate::config::cfg().fetch.adapters {
+        println!("Adapter registry is OFF (fetch.adapters is false).");
         println!("Everything below stays loaded in memory but never fires.");
         println!();
     }

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -278,7 +278,11 @@ async fn check_network(fetcher: &Fetcher) -> CheckResult {
             // fetch: curl works via the env proxy, direct sockets
             // get reset. Surface the fix instead of a generic
             // "check your connection".
-            let proxy_env_set = [
+            // The advice must match what the daemon actually does:
+            // a proxy comes from the ambient env vars OR the [proxy]
+            // slots in donsetch.toml (from_env_for consults the
+            // config layer first; the pool lane adds proxy.pool).
+            let proxy_configured = [
                 "HTTPS_PROXY",
                 "https_proxy",
                 "HTTP_PROXY",
@@ -287,12 +291,19 @@ async fn check_network(fetcher: &Fetcher) -> CheckResult {
                 "all_proxy",
             ]
             .iter()
-            .any(|v| std::env::var_os(v).is_some());
-            let hint = if proxy_env_set {
-                "The environment exports a proxy and the direct fetch still failed: this looks like a TLS-intercepting egress network. donsetch honors the env proxy automatically (see 'Fetch egress'); if it still fails, export SSL_CERT_FILE=<the network's CA bundle> so the re-signed certificates verify, then re-run doctor."
+            .any(|v| std::env::var_os(v).is_some())
+                || {
+                    let p = &crate::config::cfg().proxy;
+                    !p.https.trim().is_empty()
+                        || !p.http.trim().is_empty()
+                        || !p.all.trim().is_empty()
+                        || !p.pool.is_empty()
+                };
+            let hint = if proxy_configured {
+                "A proxy is configured (env vars or [proxy] in donsetch.toml) and the direct fetch still failed: this looks like a TLS-intercepting egress network. donsetch honors it automatically (see 'Fetch egress'); if it still fails, export SSL_CERT_FILE=<the network's CA bundle> or set [tls] cert_file in donsetch.toml so the re-signed certificates verify, then re-run doctor."
                     .to_string()
             } else {
-                "Check your network connection and DNS. Behind an egress proxy? Export HTTPS_PROXY/HTTP_PROXY (donsetch honors them; NO_PROXY accepted).".into()
+                "Check your network connection and DNS. Behind an egress proxy? Set [proxy] https/http in donsetch.toml or export HTTPS_PROXY/HTTP_PROXY (NO_PROXY accepted).".into()
             };
             CheckResult::Fail(e.to_string(), hint)
         }
@@ -303,21 +314,25 @@ async fn check_network(fetcher: &Fetcher) -> CheckResult {
 /// and the two certificate stores the connector builds from.
 /// Local-only: no network, stays in fast mode.
 fn check_fetch_egress() -> CheckResult {
-    let kill = !crate::config::cfg().proxy.from_environment;
-    let resolved = if kill {
-        None
-    } else {
-        crate::transport::proxy::from_env_for("https://example.com")
-    };
+    let proxy = &crate::config::cfg().proxy;
+    let slot_set = !proxy.https.trim().is_empty()
+        || !proxy.http.trim().is_empty()
+        || !proxy.all.trim().is_empty();
+    // from_env_for already consults the [proxy] slots first and
+    // gates only the ambient env read on from_environment: call it
+    // unconditionally so the doctor's view matches the daemon's
+    // (a TOML proxy with from_environment = false used to be
+    // reported as direct egress).
+    let resolved = crate::transport::proxy::from_env_for("https://example.com");
     let (sys_roots, env_roots) = crate::transport::tls::trust_store_report();
     let cert_bundle = std::env::var_os("SSL_CERT_FILE").map(|p| p.to_string_lossy().into_owned());
 
     let mut bits = Vec::new();
     if let Some(p) = resolved {
-        bits.push(format!("egress via {} proxy {}:{} (env; SOCKS5 keeps TLS end-to-end, HTTP CONNECT gets the interception-safe handshake)", if p.is_http_connect() { "http" } else { "socks5" }, p.host, p.port));
+        bits.push(format!("egress via {} proxy {}:{} ({}; SOCKS5 keeps TLS end-to-end, HTTP CONNECT gets the interception-safe handshake)", if p.is_http_connect() { "http" } else { "socks5" }, p.host, p.port, if slot_set { "config" } else { "env" }));
     } else {
-        bits.push(if kill {
-            "direct egress (proxy.from_environment = false disables the env-proxy convention)"
+        bits.push(if !proxy.from_environment {
+            "direct egress (proxy.from_environment = false disables the env-proxy convention; [proxy] slots in donsetch.toml stay live)"
                 .into()
         } else {
             "direct egress (no proxy env vars; export HTTPS_PROXY/HTTP_PROXY to route fetches)"

--- a/src/cli/doctor.rs
+++ b/src/cli/doctor.rs
@@ -183,6 +183,26 @@ pub async fn run() {
     // 16. MCP client registration (detect + print blocks).
     print_mcp_section();
 
+    // 17. Legacy env vars (the pre-v4 names): still honored, but
+    // each one active in this shell gets ONE warning naming its
+    // config key. Cut at the v4 release.
+    let legacy: Vec<&'static str> = crate::config::legacy_vars_in_env();
+    if legacy.is_empty() {
+        report!("Legacy env vars", CheckResult::Pass("none set".to_string()));
+    } else {
+        let names: Vec<String> = legacy
+            .iter()
+            .map(|name| {
+                let (section, key) = crate::config::legacy_target_of(name);
+                format!("{name} -> {section}.{key}")
+            })
+            .collect();
+        report!(
+            "Legacy env vars",
+            CheckResult::Warn(format!("{} (deprecated, cut at v4)", names.join(", ")))
+        );
+    }
+
     // ── Self-healing pass (--fix) ───────────────────────────
     if fix {
         println!();
@@ -283,7 +303,7 @@ async fn check_network(fetcher: &Fetcher) -> CheckResult {
 /// and the two certificate stores the connector builds from.
 /// Local-only: no network, stays in fast mode.
 fn check_fetch_egress() -> CheckResult {
-    let kill = crate::config::env_flag("DONSETCH_NO_ENV_PROXY");
+    let kill = !crate::config::cfg().proxy.from_environment;
     let resolved = if kill {
         None
     } else {
@@ -297,7 +317,8 @@ fn check_fetch_egress() -> CheckResult {
         bits.push(format!("egress via {} proxy {}:{} (env; SOCKS5 keeps TLS end-to-end, HTTP CONNECT gets the interception-safe handshake)", if p.is_http_connect() { "http" } else { "socks5" }, p.host, p.port));
     } else {
         bits.push(if kill {
-            "direct egress (DONSETCH_NO_ENV_PROXY=1 disables the env-proxy convention)".into()
+            "direct egress (proxy.from_environment = false disables the env-proxy convention)"
+                .into()
         } else {
             "direct egress (no proxy env vars; export HTTPS_PROXY/HTTP_PROXY to route fetches)"
                 .into()
@@ -800,7 +821,7 @@ fn check_ocr_models() -> CheckResult {
     #[cfg(feature = "ocr")]
     {
         if !crate::pdf::ocr::enabled() {
-            return CheckResult::Warn("disabled (DONSHEET_OCR=off)".into());
+            return CheckResult::Warn("disabled (fetch.ocr = false)".into());
         }
 
         let dir = crate::pdf::ocr::ocr_cache_dir();

--- a/src/cli/login.rs
+++ b/src/cli/login.rs
@@ -156,7 +156,7 @@ async fn interactive(site: Option<&str>, fresh: bool, probe: bool) -> Result<(),
     let resolved = crate::ghost::resolve_browser_without_download()
         .map_err(|e| format!("no usable browser: {e} (run `donsetch doctor` for guidance)"))?;
     // A login needs a visible browser. Headless machines use --import.
-    if std::env::var_os("DONSETCH_LOGIN_FORCE").is_none() && !display_available() {
+    if !crate::config::cfg().browser.login_force && !display_available() {
         return Err(
             "no display available: interactive login needs a visible browser. \
              On servers use `donsetch login --import cookies.txt [domain]` instead."

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -41,10 +41,18 @@ pub fn init() {
 use std::io::IsTerminal;
 
 fn colours() -> bool {
-    if std::env::var_os("NO_COLOR").is_some() {
-        return false;
+    use crate::config::ColorMode;
+    match crate::config::cfg().cli.color {
+        ColorMode::Always => true,
+        ColorMode::Never => false,
+        // Auto: honor NO_COLOR, then the tty check.
+        ColorMode::Auto => {
+            if std::env::var_os("NO_COLOR").is_some() {
+                return false;
+            }
+            std::io::stdout().is_terminal()
+        }
     }
-    std::io::stdout().is_terminal()
 }
 
 const GREEN: &str = "\x1b[32m";

--- a/src/cli/status.rs
+++ b/src/cli/status.rs
@@ -168,12 +168,13 @@ pub async fn run() {
 
     // v4 phase 0: route-memory visibility (the self-improvement
     // loop must be observable, never magic).
-    let route_line = if crate::config::env_flag("DONSETCH_NO_ROUTE_MEMORY") {
-        "off (DONSETCH_NO_ROUTE_MEMORY)".to_string()
+    let route_line = if crate::config::cfg().state.route_memory == crate::config::RouteMemory::Off {
+        "off (state.route_memory = off)".to_string()
     } else {
         let state = crate::ghost::cache::GhostState::load();
         let (hosts, walled, warm, cooldowns, flaky) = state.route_stats();
-        let ro = if crate::config::env_flag("DONSETCH_ROUTE_MEMORY_READONLY") {
+        let ro = if crate::config::cfg().state.route_memory == crate::config::RouteMemory::ReadOnly
+        {
             " · read-only"
         } else {
             ""

--- a/src/config.rs
+++ b/src/config.rs
@@ -1965,6 +1965,56 @@ pub fn origins(
     out
 }
 
+/// Knobs whose values can carry credentials. Proxy URLs embed
+/// user:password; `config show` masks the secret part so terminal
+/// scrollback and pasted bug reports never leak it.
+fn is_secret(section: &str, key: &str) -> bool {
+    section == "proxy" && matches!(key, "http" | "https" | "all" | "pool")
+}
+
+/// Mask the userinfo of a URL credential: scheme://user:pass@host
+/// becomes scheme://***@host. Values without userinfo are not
+/// secrets and show as-is; bare non-URL values (never expected in
+/// these fields) mask fully rather than risk a leak.
+fn mask_url_secret(url: &str) -> String {
+    if let Some(scheme_end) = url.find("://") {
+        let rest = &url[scheme_end + 3..];
+        if let Some(at) = rest.find('@') {
+            return format!("{}://***@{}", &url[..scheme_end], &rest[at + 1..]);
+        }
+        return url.to_string();
+    }
+    if url.is_empty() {
+        String::new()
+    } else {
+        "***".to_string()
+    }
+}
+
+/// `config show` display form for one knob: value_of output for
+/// everything, credentials masked for the secret proxy fields.
+fn masked_value(c: &DonsetchConfig, section: &str, key: &str, shown: String) -> String {
+    if !is_secret(section, key) {
+        return shown;
+    }
+    if key == "pool" {
+        let masked = c
+            .proxy
+            .pool
+            .iter()
+            .map(|p| format!("\"{}\"", mask_url_secret(p)))
+            .collect::<Vec<_>>()
+            .join(", ");
+        return format!("[{masked}]");
+    }
+    let raw = match key {
+        "http" => c.proxy.http.as_str(),
+        "https" => c.proxy.https.as_str(),
+        _ => c.proxy.all.as_str(),
+    };
+    format!("\"{}\"", mask_url_secret(raw))
+}
+
 /// Human-readable `config show` output: every knob, value, source.
 pub fn show_text(loaded: &Loaded) -> String {
     let mut out = String::new();
@@ -1991,7 +2041,10 @@ pub fn show_text(loaded: &Loaded) -> String {
             out.push_str(&format!("[{section}]\n"));
             last_section = section;
         }
-        out.push_str(&format!("  {key:<18} = {value:<20} ({origin})\n"));
+        out.push_str(&format!(
+            "  {key:<18} = {} ({origin})\n",
+            masked_value(&loaded.config, section, key, value)
+        ));
     }
     out
 }
@@ -2345,6 +2398,11 @@ mod tests {
     /// proxy.from_environment gates the AMBIENT proxy convention, not
     /// the config-file slots: an explicit TOML proxy must survive the
     /// kill switch (the old caller-side gate starved it).
+    ///
+    /// Isolation note: relies on nextest's process-per-test runner
+    /// (env mutation + the process-wide cfg() OnceLock: the first
+    /// cfg() call freezes the config layer, so keep this out of
+    /// shared-process runners).
     #[test]
     fn from_environment_off_keeps_toml_proxy_slots_alive() {
         let guard = clean_env();
@@ -2462,6 +2520,31 @@ mod tests {
             .find(|l| l.contains("`kind`"))
             .expect("transport.kind not in the table");
         assert!(kind_row.contains("\\|"), "kind row lost its escaped pipe");
+    }
+
+    #[test]
+    fn show_text_redacts_proxy_secrets() {
+        let mut c = DonsetchConfig::default();
+        c.proxy.https = "http://alice:s3cr3t@gw.example:2334".into();
+        c.proxy.all = "socks5://bob:hunter2@other.example:1080".into();
+        c.proxy.pool = vec!["http://carol:pw@a.example:8080".into()];
+        let loaded = Loaded {
+            config: c,
+            merged: config::Map::new(),
+            warnings: Vec::new(),
+            file: None,
+        };
+        let text = super::show_text(&loaded);
+        for leak in ["s3cr3t", "hunter2", "pw@a.example"] {
+            assert!(!text.contains(leak), "config show leaked {leak:?}");
+        }
+        for masked in [
+            "http://***@gw.example:2334",
+            "socks5://***@other.example:1080",
+            "http://***@a.example:8080",
+        ] {
+            assert!(text.contains(masked), "missing masked form {masked:?}");
+        }
     }
 
     #[test]

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,15 +1,2087 @@
-//! Small, shared parsers for process-level runtime configuration.
+//! Runtime configuration: one typed struct, layered sources, one home.
+//!
+//! Layers, lowest to highest precedence:
+//!   1. serde defaults (this file, matching the historical runtime defaults)
+//!   2. legacy env names (the pre-v4 scattered knobs, exact trigger semantics preserved)
+//!   3. `donsetch.toml` file layer (`DONSETCH_CONFIG` explicit, or the default location)
+//!   4. new env names: `DONSETCH_<SECTION>__<KEY>` (two underscores = one dot)
+//!
+//! Standard process vars (HTTP_PROXY, SSL_CERT_FILE, TZ, LANG, NO_COLOR,
+//! PLAYWRIGHT_BROWSERS_PATH, PATH, HOME, ...) stay ambient and are read at
+//! call time; the config value of the mirrored knob wins over the ambient
+//! var whenever it is set.
+//!
+//! Notes:
+//! - `DONSETCH_CACHE_DIR` is NOT a knob: `paths::cache_dir()` keeps reading
+//!   it per call so tests can isolate state; `paths.cache_dir` in the TOML
+//!   layer is the fallback when the env var is absent.
+//! - `DONSETCH_NO_CONFIG_FILE=1` skips the file layer entirely (hermetic
+//!   runs, CI).
+//! - Values from the new env layer or TOML fail the whole load when
+//!   unparsable or out of range (loud, with the key path named). Legacy
+//!   names keep their historical silent-fallback semantics, except that a
+//!   bad value now also emits a stderr warning.
+//! - `cargo test` users are broken by design: the global is frozen at first
+//!   use. Our runner is nextest (one process per test), which makes the env
+//!   layers behave exactly like before for every test.
 
-use std::ffi::OsStr;
+use config::Source as _;
+use std::sync::OnceLock;
 
-/// Read a security-sensitive opt-in flag from the environment.
-///
-/// Only explicit affirmative values enable the flag. Matching is
-/// ASCII-case-insensitive and ignores surrounding ASCII/Unicode
-/// whitespace; missing, non-Unicode, false, and unknown values all
-/// fail closed.
-pub(crate) fn env_flag(name: &str) -> bool {
+// ---------------------------------------------------------------------------
+// The struct
+// ---------------------------------------------------------------------------
+
+macro_rules! section {
+    ($name:ident { $($field:ident : $ty:ty = $default:expr),* $(,)? }) => {
+        #[derive(Debug, Clone, PartialEq, serde::Deserialize, serde::Serialize)]
+        #[serde(default, deny_unknown_fields)]
+        pub struct $name {
+            $(pub $field: $ty,)*
+        }
+        impl Default for $name {
+            fn default() -> Self {
+                Self { $($field: $default,)* }
+            }
+        }
+        impl $name {
+            /// Fold one layer into the accumulator: copy every field the
+            /// layer explicitly set (differing from the struct default).
+            pub(crate) fn fold_from(&mut self, other: &Self) {
+                let defaults = Self::default();
+                $( if other.$field != defaults.$field {
+                    self.$field = other.$field.clone();
+                } )*
+            }
+        }
+    };
+}
+
+section!(TransportSection {
+    kind: TransportKind = TransportKind::Stdio,
+    host: String = "127.0.0.1".into(),
+    port: u16 = 8765,
+    token: String = String::new(),
+    timeout_secs: u64 = 300,
+    cors: bool = false,
+});
+
+section!(McpSection {
+    text_only: bool = false,
+    answer_tool: bool = true,
+    url_handles: bool = true,
+});
+
+section!(PathsSection {
+    cache_dir: String = String::new(),
+});
+
+section!(StateSection {
+    no_disk_state: bool = false,
+    route_memory: RouteMemory = RouteMemory::ReadWrite,
+    cookie_vault: bool = true,
+    web_memory: bool = true,
+    web_memory_cap: usize = 4000,
+});
+
+section!(ProxySection {
+    from_environment: bool = true,
+    http: String = String::new(),
+    https: String = String::new(),
+    all: String = String::new(),
+    no_proxy: String = String::new(),
+    pool: Vec<String> = Vec::new(),
+});
+
+section!(TlsSection {
+    cert_file: String = String::new(),
+    cert_dir: String = String::new(),
+});
+
+section!(PersonaSection {
+    timezone: String = String::new(),
+    locale: String = String::new(),
+});
+
+section!(CliSection {
+    color: ColorMode = ColorMode::Auto,
+});
+
+section!(FetchSection {
+    allow_private_egress: bool = false,
+    h3: bool = false,
+    alt_svc: bool = true,
+    shadow_fetch: ShadowFetch = ShadowFetch::Auto,
+    shadow_deadline_ms: u64 = 3000,
+    adapters: bool = true,
+    adapter_dump_dir: String = String::new(),
+    crawl_shape: bool = true,
+    prewarm: bool = true,
+    pdf_max_mb: usize = 100,
+    ocr: bool = true,
+    ocr_max_pages: u32 = 25,
+});
+
+section!(BypassSection {
+    enabled: bool = true,
+    zone: String = String::new(),
+    max_daily: u32 = 50,
+    timeout_secs: u64 = 120,
+    render: bool = false,
+    endpoint: String = String::new(),
+    cache: bool = true,
+    cache_ttl_secs: u64 = 21_600,
+    cache_max_entries: u32 = 200,
+});
+
+section!(SearchSection {
+    google_profile: String = String::new(),
+    ghost_lane: GhostLane = GhostLane::Auto,
+    rerank_topup: bool = true,
+    rerank_threads: u32 = 0,
+    brightdata_zone: String = String::new(),
+});
+
+section!(BrowserSection {
+    backend: BrowserBackend = BrowserBackend::Auto,
+    chromium_path: String = String::new(),
+    no_sandbox: bool = false,
+    cloak_auto_download: bool = false,
+    cloak_path: String = String::new(),
+    cloak_version: String = String::new(),
+    cloak_cache_dir: String = String::new(),
+    playwright_path: String = String::new(),
+    pool_slots: u32 = 0,
+    xvfb_display: u16 = 0,
+    route_probes: bool = true,
+    probe_scan_secs: u64 = 120,
+    probe_stale_secs: u64 = 21_600,
+    login_force: bool = false,
+});
+
+section!(DebugSection {
+    ghost: bool = false,
+    search: bool = false,
+    pdf: bool = false,
+    pdf_matrix: bool = false,
+    pdf_chars: bool = false,
+    pdf_words: bool = false,
+    extract: bool = false,
+    echo_scorecard: bool = false,
+});
+
+#[derive(Debug, Clone, PartialEq, Default, serde::Deserialize, serde::Serialize)]
+#[serde(default, deny_unknown_fields)]
+pub struct DonsetchConfig {
+    pub transport: TransportSection,
+    pub mcp: McpSection,
+    pub paths: PathsSection,
+    pub state: StateSection,
+    pub proxy: ProxySection,
+    pub tls: TlsSection,
+    pub persona: PersonaSection,
+    pub cli: CliSection,
+    pub fetch: FetchSection,
+    pub bypass: BypassSection,
+    pub search: SearchSection,
+    pub browser: BrowserSection,
+    pub debug: DebugSection,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum TransportKind {
+    #[default]
+    Stdio,
+    Http,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum RouteMemory {
+    Off,
+    #[default]
+    #[serde(alias = "readwrite")]
+    ReadWrite,
+    #[serde(alias = "readonly")]
+    ReadOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ShadowFetch {
+    #[default]
+    Auto,
+    Always,
+    Never,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum GhostLane {
+    #[default]
+    Auto,
+    Always,
+    Never,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum BrowserBackend {
+    #[default]
+    Auto,
+    #[serde(alias = "chrome", alias = "original")]
+    Chromium,
+    #[serde(alias = "headless", alias = "original-headless")]
+    Headless,
+    #[serde(alias = "cloakbrowser")]
+    Cloak,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Deserialize, serde::Serialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ColorMode {
+    #[default]
+    Auto,
+    Never,
+    Always,
+}
+
+// ---------------------------------------------------------------------------
+// Loading
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum ConfigError {
+    Env(String),
+    File { path: String, message: String },
+    Validate(String),
+}
+
+impl std::fmt::Display for ConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConfigError::Env(m) => write!(f, "invalid env value: {m}"),
+            ConfigError::File { path, message } => {
+                write!(f, "invalid config file {path}: {message}")
+            }
+            ConfigError::Validate(m) => write!(f, "invalid config value: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for ConfigError {}
+
+pub struct Loaded {
+    pub config: DonsetchConfig,
+    /// Non-fatal notes: ignored legacy values, unknown DONSETCH_* vars.
+    pub warnings: Vec<String>,
+    /// The file the TOML layer came from, if any.
+    pub file: Option<std::path::PathBuf>,
+}
+
+/// Load the layered config from defaults + env + TOML file and validate it.
+pub fn load() -> Result<Loaded, ConfigError> {
+    let mut warnings = Vec::new();
+
+    let mut file_layer: Option<config::Map<String, config::Value>> = None;
+    let mut file_path: Option<std::path::PathBuf> = None;
+    let skip_file = std::env::var_os("DONSETCH_NO_CONFIG_FILE").is_some();
+    if !skip_file {
+        match toml_path() {
+            Some(path) => {
+                let text = std::fs::read_to_string(&path).map_err(|e| ConfigError::File {
+                    path: path.display().to_string(),
+                    message: format!("unreadable ({e})"),
+                })?;
+                let source = config::File::from_str(&text, config::FileFormat::Toml);
+                file_layer = Some(source.collect().map_err(|e| ConfigError::File {
+                    path: path.display().to_string(),
+                    message: e.to_string(),
+                })?);
+                file_path = Some(path);
+            }
+            None => {
+                if let Some(explicit) = std::env::var_os("DONSETCH_CONFIG") {
+                    return Err(ConfigError::File {
+                        path: explicit.to_string_lossy().into_owned(),
+                        message: "not found".into(),
+                    });
+                }
+            }
+        }
+    } else if let Some(explicit) = std::env::var_os("DONSETCH_CONFIG") {
+        return Err(ConfigError::Env(format!(
+            "DONSETCH_NO_CONFIG_FILE=1 but DONSETCH_CONFIG={} is set; drop one of them",
+            explicit.to_string_lossy()
+        )));
+    }
+
+    let (legacy_map, legacy_warnings) = legacy_layer();
+    warnings.extend(legacy_warnings);
+    let (env_map, env_warnings, env_errors) = new_env_layer();
+    warnings.extend(env_warnings);
+    if let Some(e) = env_errors.first() {
+        return Err(ConfigError::Env(e.clone()));
+    }
+
+    let mut raw = DonsetchConfig::default();
+    if let Some(file) = file_layer {
+        // Deserialize the file layer on its own so unknown keys fail loudly
+        // with the file path attached, then fold into the merged struct.
+        let file_cfg = deserialize_layer_table(&file).map_err(|m| ConfigError::File {
+            path: file_path
+                .as_ref()
+                .map(|p| p.display().to_string())
+                .unwrap_or_default(),
+            message: m.to_string(),
+        })?;
+        fold(&mut raw, &file_cfg);
+    }
+    if !legacy_map.is_empty() {
+        let legacy_cfg = deserialize_layer_table(&legacy_map)?;
+        fold(&mut raw, &legacy_cfg);
+    }
+    if !env_map.is_empty() {
+        let env_cfg = deserialize_layer_table(&env_map)?;
+        fold(&mut raw, &env_cfg);
+    }
+
+    validate(&raw)?;
+    Ok(Loaded {
+        config: raw,
+        warnings,
+        file: file_path,
+    })
+}
+
+fn deserialize_layer_table(
+    map: &config::Map<String, config::Value>,
+) -> Result<DonsetchConfig, ConfigError> {
+    #[derive(Debug, Clone)]
+    struct MapSource(config::Map<String, config::Value>);
+    impl config::Source for MapSource {
+        fn collect(&self) -> Result<config::Map<String, config::Value>, config::ConfigError> {
+            Ok(self.0.clone())
+        }
+        fn clone_into_box(&self) -> Box<dyn config::Source + Send + Sync> {
+            Box::new(self.clone())
+        }
+    }
+    let builder = config::Config::builder().add_source(MapSource(map.clone()));
+    builder
+        .build()
+        .and_then(|c| c.try_deserialize::<DonsetchConfig>())
+        .map_err(|e| ConfigError::Env(e.to_string()))
+}
+
+/// Fold a layer into the accumulator: every field the layer explicitly
+/// set (differing from the struct default) is copied over the current
+/// value. Later layers win.
+fn fold(dst: &mut DonsetchConfig, src: &DonsetchConfig) {
+    dst.transport.fold_from(&src.transport);
+    dst.mcp.fold_from(&src.mcp);
+    dst.paths.fold_from(&src.paths);
+    dst.state.fold_from(&src.state);
+    dst.proxy.fold_from(&src.proxy);
+    dst.tls.fold_from(&src.tls);
+    dst.persona.fold_from(&src.persona);
+    dst.cli.fold_from(&src.cli);
+    dst.fetch.fold_from(&src.fetch);
+    dst.bypass.fold_from(&src.bypass);
+    dst.search.fold_from(&src.search);
+    dst.browser.fold_from(&src.browser);
+    dst.debug.fold_from(&src.debug);
+}
+
+/// The file layer path: `DONSETCH_CONFIG` explicit, else the default
+/// location when the file exists. `None` = no file layer.
+fn toml_path() -> Option<std::path::PathBuf> {
+    if let Some(explicit) = std::env::var_os("DONSETCH_CONFIG") {
+        return Some(std::path::PathBuf::from(explicit));
+    }
+    let dir = dirs::config_dir()?;
+    let path = dir.join("donsetch").join("donsetch.toml");
+    path.is_file().then_some(path)
+}
+
+// ---------------------------------------------------------------------------
+// Legacy env names
+// ---------------------------------------------------------------------------
+
+type VMap = config::Map<String, config::Value>;
+
+fn put(map: &mut VMap, path: &str, value: config::ValueKind, origin: &str) {
+    let mut parts = path.split('.');
+    let head = match parts.next() {
+        Some(p) => p,
+        None => return,
+    };
+    let origin = Some(origin.to_string());
+    let oref = origin.as_ref();
+    match parts.next() {
+        None => {
+            map.insert(head.to_string(), config::Value::new(oref, value));
+        }
+        Some(key) => {
+            let section = map
+                .entry(head.to_string())
+                .or_insert_with(|| config::Value::new(None, config::ValueKind::Table(VMap::new())));
+            if let config::ValueKind::Table(inner) = &mut section.kind {
+                inner.insert(key.to_string(), config::Value::new(oref, value));
+            }
+        }
+    }
+}
+
+/// Legacy strict opt-in flag: only `1`, `true`, `on` count.
+fn legacy_flag(name: &str) -> bool {
     env_flag_value(std::env::var_os(name).as_deref())
+}
+
+fn legacy_layer() -> (VMap, Vec<String>) {
+    let mut m = VMap::new();
+    let mut warnings = Vec::new();
+    let int_env = |name: &str| -> Option<i64> {
+        std::env::var(name)
+            .ok()
+            .and_then(|v| v.trim().parse::<i64>().ok())
+    };
+
+    // transport
+    if std::env::var("DONSETCH_TRANSPORT").as_deref() == Ok("http") {
+        put(
+            &mut m,
+            "transport.kind",
+            "http".into(),
+            "DONSETCH_TRANSPORT",
+        );
+    }
+    if let Some(v) = std::env::var_os("DONSETCH_HTTP_HOST") {
+        put(
+            &mut m,
+            "transport.host",
+            v.to_string_lossy().into_owned().into(),
+            "DONSETCH_HTTP_HOST",
+        );
+    }
+    match int_env("DONSETCH_HTTP_PORT") {
+        Some(p) => put(&mut m, "transport.port", p.into(), "DONSETCH_HTTP_PORT"),
+        None if std::env::var_os("DONSETCH_HTTP_PORT").is_some() => {
+            warnings.push("ignoring DONSETCH_HTTP_PORT: not a number".into())
+        }
+        None => {}
+    }
+    if let Some(v) = std::env::var_os("DONSETCH_HTTP_TOKEN") {
+        put(
+            &mut m,
+            "transport.token",
+            v.to_string_lossy().into_owned().into(),
+            "DONSETCH_HTTP_TOKEN",
+        );
+    }
+    match int_env("DONSETCH_HTTP_TIMEOUT_SECS") {
+        Some(s) => put(
+            &mut m,
+            "transport.timeout_secs",
+            s.into(),
+            "DONSETCH_HTTP_TIMEOUT_SECS",
+        ),
+        None if std::env::var_os("DONSETCH_HTTP_TIMEOUT_SECS").is_some() => {
+            warnings.push("ignoring DONSETCH_HTTP_TIMEOUT_SECS: not a number".into())
+        }
+        None => {}
+    }
+    if legacy_flag("DONSETCH_HTTP_CORS") {
+        put(&mut m, "transport.cors", true.into(), "DONSETCH_HTTP_CORS");
+    }
+
+    // mcp
+    if legacy_flag("DONSETCH_MCP_TEXT_ONLY") {
+        put(
+            &mut m,
+            "mcp.text_only",
+            true.into(),
+            "DONSETCH_MCP_TEXT_ONLY",
+        );
+    }
+    if legacy_flag("DONSETCH_NO_ANSWER_TOOL") {
+        put(
+            &mut m,
+            "mcp.answer_tool",
+            false.into(),
+            "DONSETCH_NO_ANSWER_TOOL",
+        );
+    }
+    if let Some(v) = std::env::var_os("DONSETCH_URL_HANDLES") {
+        // Historical semantics: every value except the exact string "off"
+        // keeps url handles enabled.
+        let on = v.to_str() != Some("off");
+        put(&mut m, "mcp.url_handles", on.into(), "DONSETCH_URL_HANDLES");
+    }
+
+    // state
+    if std::env::var_os("DONSEEK_NO_DISK_STATE").is_some() {
+        put(
+            &mut m,
+            "state.no_disk_state",
+            true.into(),
+            "DONSEEK_NO_DISK_STATE",
+        );
+    }
+    if legacy_flag("DONSETCH_NO_ROUTE_MEMORY") {
+        put(
+            &mut m,
+            "state.route_memory",
+            "off".into(),
+            "DONSETCH_NO_ROUTE_MEMORY",
+        );
+    }
+    if legacy_flag("DONSETCH_ROUTE_MEMORY_READONLY") {
+        put(
+            &mut m,
+            "state.route_memory",
+            "read_only".into(),
+            "DONSETCH_ROUTE_MEMORY_READONLY",
+        );
+    }
+    if legacy_flag("DONSETCH_NO_COOKIE_VAULT") {
+        put(
+            &mut m,
+            "state.cookie_vault",
+            false.into(),
+            "DONSETCH_NO_COOKIE_VAULT",
+        );
+    }
+    if std::env::var_os("DONSETCH_NO_WEB_MEMORY").is_some() {
+        put(
+            &mut m,
+            "state.web_memory",
+            false.into(),
+            "DONSETCH_NO_WEB_MEMORY",
+        );
+    }
+    match int_env("DONSETCH_WEB_MEMORY_CAP") {
+        Some(n) => put(
+            &mut m,
+            "state.web_memory_cap",
+            n.into(),
+            "DONSETCH_WEB_MEMORY_CAP",
+        ),
+        None if std::env::var_os("DONSETCH_WEB_MEMORY_CAP").is_some() => {
+            warnings.push("ignoring DONSETCH_WEB_MEMORY_CAP: not a number".into())
+        }
+        None => {}
+    }
+
+    // fetch
+    if legacy_flag("DONSETCH_ALLOW_PRIVATE_EGRESS") {
+        put(
+            &mut m,
+            "fetch.allow_private_egress",
+            true.into(),
+            "DONSETCH_ALLOW_PRIVATE_EGRESS",
+        );
+    }
+    if legacy_flag("DONSETCH_H3") {
+        put(&mut m, "fetch.h3", true.into(), "DONSETCH_H3");
+    }
+    if legacy_flag("DONSETCH_NO_H3") {
+        put(&mut m, "fetch.h3", false.into(), "DONSETCH_NO_H3");
+    }
+    if legacy_flag("DONSETCH_NO_ALT_SVC") {
+        put(&mut m, "fetch.alt_svc", false.into(), "DONSETCH_NO_ALT_SVC");
+    }
+    if legacy_flag("DONSETCH_SHADOW_FETCH") {
+        put(
+            &mut m,
+            "fetch.shadow_fetch",
+            "always".into(),
+            "DONSETCH_SHADOW_FETCH",
+        );
+    }
+    if legacy_flag("DONSETCH_NO_SHADOW_FETCH") {
+        put(
+            &mut m,
+            "fetch.shadow_fetch",
+            "never".into(),
+            "DONSETCH_NO_SHADOW_FETCH",
+        );
+    }
+    match int_env("DONSETCH_SHADOW_DEADLINE_MS") {
+        Some(n) => put(
+            &mut m,
+            "fetch.shadow_deadline_ms",
+            n.into(),
+            "DONSETCH_SHADOW_DEADLINE_MS",
+        ),
+        None if std::env::var_os("DONSETCH_SHADOW_DEADLINE_MS").is_some() => {
+            warnings.push("ignoring DONSETCH_SHADOW_DEADLINE_MS: not a number".into())
+        }
+        None => {}
+    }
+    if legacy_flag("DONSETCH_NO_CRAWL_SHAPE") {
+        put(
+            &mut m,
+            "fetch.crawl_shape",
+            false.into(),
+            "DONSETCH_NO_CRAWL_SHAPE",
+        );
+    }
+    if legacy_flag("DONSETCH_NO_PREWARM") {
+        put(&mut m, "fetch.prewarm", false.into(), "DONSETCH_NO_PREWARM");
+    }
+    match int_env("DONSETCH_PDF_MAX_MB") {
+        Some(n) => put(&mut m, "fetch.pdf_max_mb", n.into(), "DONSETCH_PDF_MAX_MB"),
+        None if std::env::var_os("DONSETCH_PDF_MAX_MB").is_some() => {
+            warnings.push("ignoring DONSETCH_PDF_MAX_MB: not a number".into())
+        }
+        None => {}
+    }
+    if let Some(v) = std::env::var_os("DONSHEET_OCR") {
+        // Historical semantics: every value except the exact string "off"
+        // keeps OCR enabled.
+        let on = v.to_str() != Some("off");
+        put(&mut m, "fetch.ocr", on.into(), "DONSHEET_OCR");
+    }
+    match int_env("DONSHEET_OCR_MAX_PAGES") {
+        Some(n) => put(
+            &mut m,
+            "fetch.ocr_max_pages",
+            n.into(),
+            "DONSHEET_OCR_MAX_PAGES",
+        ),
+        None if std::env::var_os("DONSHEET_OCR_MAX_PAGES").is_some() => {
+            warnings.push("ignoring DONSHEET_OCR_MAX_PAGES: not a number".into())
+        }
+        None => {}
+    }
+    // adapters: any value set (even "0") disables, historically.
+    if std::env::var_os("DONSETCH_NO_ADAPTERS").is_some() {
+        put(
+            &mut m,
+            "fetch.adapters",
+            false.into(),
+            "DONSETCH_NO_ADAPTERS",
+        );
+    }
+    if let Some(v) = std::env::var_os("DONSETCH_ADAPTER_DUMP") {
+        put(
+            &mut m,
+            "fetch.adapter_dump_dir",
+            v.to_string_lossy().into_owned().into(),
+            "DONSETCH_ADAPTER_DUMP",
+        );
+    }
+
+    // bypass
+    if let Some(v) = std::env::var_os("DONSETCH_BYPASS") {
+        // Historical semantics: enabled unless the value is a falsy off-word.
+        let off = v
+            .to_str()
+            .map(|s| {
+                ["0", "false", "off", "no", ""].contains(&s.trim().to_ascii_lowercase().as_str())
+            })
+            .unwrap_or(false);
+        put(&mut m, "bypass.enabled", (!off).into(), "DONSETCH_BYPASS");
+    }
+    if let Some(v) = std::env::var_os("DONSETCH_UNLOCKER_ZONE") {
+        put(
+            &mut m,
+            "bypass.zone",
+            v.to_string_lossy().into_owned().into(),
+            "DONSETCH_UNLOCKER_ZONE",
+        );
+    }
+    match int_env("DONSETCH_BYPASS_MAX_DAILY") {
+        Some(n) => put(
+            &mut m,
+            "bypass.max_daily",
+            n.into(),
+            "DONSETCH_BYPASS_MAX_DAILY",
+        ),
+        None if std::env::var_os("DONSETCH_BYPASS_MAX_DAILY").is_some() => {
+            warnings.push("ignoring DONSETCH_BYPASS_MAX_DAILY: not a number".into())
+        }
+        None => {}
+    }
+    match int_env("DONSETCH_BYPASS_TIMEOUT_SECS") {
+        Some(n) => put(
+            &mut m,
+            "bypass.timeout_secs",
+            n.into(),
+            "DONSETCH_BYPASS_TIMEOUT_SECS",
+        ),
+        None if std::env::var_os("DONSETCH_BYPASS_TIMEOUT_SECS").is_some() => {
+            warnings.push("ignoring DONSETCH_BYPASS_TIMEOUT_SECS: not a number".into())
+        }
+        None => {}
+    }
+    if std::env::var("DONSETCH_BYPASS_RENDER")
+        .is_ok_and(|v| ["1", "true", "on", "yes"].contains(&v.trim().to_ascii_lowercase().as_str()))
+    {
+        put(
+            &mut m,
+            "bypass.render",
+            true.into(),
+            "DONSETCH_BYPASS_RENDER",
+        );
+    }
+    if let Some(v) = std::env::var_os("DONSETCH_BYPASS_ENDPOINT") {
+        put(
+            &mut m,
+            "bypass.endpoint",
+            v.to_string_lossy().into_owned().into(),
+            "DONSETCH_BYPASS_ENDPOINT",
+        );
+    }
+    if let Some(v) = std::env::var_os("DONSETCH_BYPASS_CACHE") {
+        let off = v
+            .to_str()
+            .map(|s| {
+                ["0", "false", "off", "no", ""].contains(&s.trim().to_ascii_lowercase().as_str())
+            })
+            .unwrap_or(false);
+        put(
+            &mut m,
+            "bypass.cache",
+            (!off).into(),
+            "DONSETCH_BYPASS_CACHE",
+        );
+    }
+    match int_env("DONSETCH_BYPASS_CACHE_TTL_SECS") {
+        Some(n) => put(
+            &mut m,
+            "bypass.cache_ttl_secs",
+            n.into(),
+            "DONSETCH_BYPASS_CACHE_TTL_SECS",
+        ),
+        None if std::env::var_os("DONSETCH_BYPASS_CACHE_TTL_SECS").is_some() => {
+            warnings.push("ignoring DONSETCH_BYPASS_CACHE_TTL_SECS: not a number".into())
+        }
+        None => {}
+    }
+    match int_env("DONSETCH_BYPASS_CACHE_MAX_ENTRIES") {
+        Some(n) => put(
+            &mut m,
+            "bypass.cache_max_entries",
+            n.into(),
+            "DONSETCH_BYPASS_CACHE_MAX_ENTRIES",
+        ),
+        None if std::env::var_os("DONSETCH_BYPASS_CACHE_MAX_ENTRIES").is_some() => {
+            warnings.push("ignoring DONSETCH_BYPASS_CACHE_MAX_ENTRIES: not a number".into())
+        }
+        None => {}
+    }
+
+    // search
+    if let Some(v) = std::env::var_os("DONSETCH_GOOGLE_PROFILE") {
+        put(
+            &mut m,
+            "search.google_profile",
+            v.to_string_lossy().into_owned().into(),
+            "DONSETCH_GOOGLE_PROFILE",
+        );
+    }
+    if std::env::var_os("DONSEEK_FORCE_GHOST_LANE").is_some() {
+        put(
+            &mut m,
+            "search.ghost_lane",
+            "always".into(),
+            "DONSEEK_FORCE_GHOST_LANE",
+        );
+    }
+    if std::env::var_os("DONSEEK_NO_GHOST_LANES").is_some() {
+        put(
+            &mut m,
+            "search.ghost_lane",
+            "never".into(),
+            "DONSEEK_NO_GHOST_LANES",
+        );
+    }
+    if std::env::var_os("DONSEEK_NO_TOPUP").is_some() {
+        put(
+            &mut m,
+            "search.rerank_topup",
+            false.into(),
+            "DONSEEK_NO_TOPUP",
+        );
+    }
+    match int_env("DONSEEK_RERANK_THREADS") {
+        Some(n) => put(
+            &mut m,
+            "search.rerank_threads",
+            n.into(),
+            "DONSEEK_RERANK_THREADS",
+        ),
+        None if std::env::var_os("DONSEEK_RERANK_THREADS").is_some() => {
+            warnings.push("ignoring DONSEEK_RERANK_THREADS: not a number".into())
+        }
+        None => {}
+    }
+    if let Some(v) = std::env::var_os("DONSETCH_BRIGHTDATA_ZONE") {
+        put(
+            &mut m,
+            "search.brightdata_zone",
+            v.to_string_lossy().into_owned().into(),
+            "DONSETCH_BRIGHTDATA_ZONE",
+        );
+    }
+
+    // browser
+    if let Some(v) = std::env::var_os("DONSETCH_BROWSER_BACKEND")
+        .or_else(|| std::env::var_os("DONGHOST_BROWSER_BACKEND"))
+    {
+        let v = v.to_string_lossy().to_ascii_lowercase();
+        let backend = match v.as_str() {
+            "auto" | "" => "auto",
+            "chromium" | "chrome" | "original" => "chromium",
+            "cloak" | "cloakbrowser" => "cloak",
+            _ => {
+                warnings.push(format!(
+                    "ignoring unknown browser backend {v:?} (auto | chromium | cloak)"
+                ));
+                ""
+            }
+        };
+        if !backend.is_empty() {
+            put(
+                &mut m,
+                "browser.backend",
+                backend.into(),
+                "DONSETCH_BROWSER_BACKEND",
+            );
+        }
+    }
+    if let Some(v) = std::env::var_os("DONGHOST_CHROME") {
+        put(
+            &mut m,
+            "browser.chromium_path",
+            v.to_string_lossy().into_owned().into(),
+            "DONGHOST_CHROME",
+        );
+    }
+    if std::env::var_os("DONGHOST_NO_SANDBOX").is_some_and(|v| v == "1") {
+        put(
+            &mut m,
+            "browser.no_sandbox",
+            true.into(),
+            "DONGHOST_NO_SANDBOX",
+        );
+    }
+    if std::env::var_os("DONSETCH_CLOAK_AUTO_DOWNLOAD").is_some_and(|v| v == "1") {
+        put(
+            &mut m,
+            "browser.cloak_auto_download",
+            true.into(),
+            "DONSETCH_CLOAK_AUTO_DOWNLOAD",
+        );
+    }
+    if let Some(v) = std::env::var_os("CLOAKBROWSER_BINARY_PATH") {
+        put(
+            &mut m,
+            "browser.cloak_path",
+            v.to_string_lossy().into_owned().into(),
+            "CLOAKBROWSER_BINARY_PATH",
+        );
+    }
+    if let Some(v) = std::env::var_os("CLOAKBROWSER_VERSION") {
+        put(
+            &mut m,
+            "browser.cloak_version",
+            v.to_string_lossy().into_owned().into(),
+            "CLOAKBROWSER_VERSION",
+        );
+    }
+    if let Some(v) = std::env::var_os("CLOAKBROWSER_CACHE_DIR") {
+        put(
+            &mut m,
+            "browser.cloak_cache_dir",
+            v.to_string_lossy().into_owned().into(),
+            "CLOAKBROWSER_CACHE_DIR",
+        );
+    }
+    if std::env::var_os("DONSETCH_NO_GHOST_POOL").is_some() {
+        put(
+            &mut m,
+            "browser.pool_slots",
+            1i64.into(),
+            "DONSETCH_NO_GHOST_POOL",
+        );
+    }
+    match int_env("DONSETCH_GHOST_POOL_SLOTS") {
+        Some(n) => put(
+            &mut m,
+            "browser.pool_slots",
+            n.into(),
+            "DONSETCH_GHOST_POOL_SLOTS",
+        ),
+        None if std::env::var_os("DONSETCH_GHOST_POOL_SLOTS").is_some() => {
+            warnings.push("ignoring DONSETCH_GHOST_POOL_SLOTS: not a number".into())
+        }
+        None => {}
+    }
+    if let Some(v) = std::env::var_os("DONSETCH_XVFB_DISPLAY") {
+        match v
+            .to_str()
+            .map(|s| s.trim().trim_start_matches(':').parse::<i64>())
+        {
+            Some(Ok(n)) => put(
+                &mut m,
+                "browser.xvfb_display",
+                n.into(),
+                "DONSETCH_XVFB_DISPLAY",
+            ),
+            _ => warnings.push("ignoring DONSETCH_XVFB_DISPLAY: not a display number".into()),
+        }
+    }
+    if legacy_flag("DONSETCH_NO_ROUTE_PROBES") {
+        put(
+            &mut m,
+            "browser.route_probes",
+            false.into(),
+            "DONSETCH_NO_ROUTE_PROBES",
+        );
+    }
+    match int_env("DONSETCH_PROBE_SCAN_SECS") {
+        Some(n) => put(
+            &mut m,
+            "browser.probe_scan_secs",
+            n.into(),
+            "DONSETCH_PROBE_SCAN_SECS",
+        ),
+        None if std::env::var_os("DONSETCH_PROBE_SCAN_SECS").is_some() => {
+            warnings.push("ignoring DONSETCH_PROBE_SCAN_SECS: not a number".into())
+        }
+        None => {}
+    }
+    match int_env("DONSETCH_PROBE_STALE_SECS") {
+        Some(n) => put(
+            &mut m,
+            "browser.probe_stale_secs",
+            n.into(),
+            "DONSETCH_PROBE_STALE_SECS",
+        ),
+        None if std::env::var_os("DONSETCH_PROBE_STALE_SECS").is_some() => {
+            warnings.push("ignoring DONSETCH_PROBE_STALE_SECS: not a number".into())
+        }
+        None => {}
+    }
+    if std::env::var_os("DONSETCH_LOGIN_FORCE").is_some() {
+        put(
+            &mut m,
+            "browser.login_force",
+            true.into(),
+            "DONSETCH_LOGIN_FORCE",
+        );
+    }
+
+    // proxy
+    if legacy_flag("DONSETCH_NO_ENV_PROXY") {
+        put(
+            &mut m,
+            "proxy.from_environment",
+            false.into(),
+            "DONSETCH_NO_ENV_PROXY",
+        );
+    }
+    if let Ok(raw) = std::env::var("DONSEEK_PROXIES") {
+        let oref = Some(&"DONSEEK_PROXIES".to_string());
+        let pool = config::ValueKind::Array(
+            raw.split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(|s| config::Value::new(oref, s))
+                .collect(),
+        );
+        put(&mut m, "proxy.pool", pool, "DONSEEK_PROXIES");
+    }
+
+    // debug
+    if std::env::var_os("DONGHOST_DEBUG").is_some() {
+        put(&mut m, "debug.ghost", true.into(), "DONGHOST_DEBUG");
+    }
+    if std::env::var_os("DONSEEK_DEBUG").is_some() {
+        put(&mut m, "debug.search", true.into(), "DONSEEK_DEBUG");
+    }
+    if std::env::var_os("DONSHEET_DEBUG").is_some() {
+        put(&mut m, "debug.pdf", true.into(), "DONSHEET_DEBUG");
+    }
+    if std::env::var_os("DONSHEET_DEBUG_MATRIX").is_some() {
+        put(
+            &mut m,
+            "debug.pdf_matrix",
+            true.into(),
+            "DONSHEET_DEBUG_MATRIX",
+        );
+    }
+    if std::env::var_os("DONSHEET_DEBUG_CHARS").is_some() {
+        put(
+            &mut m,
+            "debug.pdf_chars",
+            true.into(),
+            "DONSHEET_DEBUG_CHARS",
+        );
+    }
+    if std::env::var_os("DONSHEET_DEBUG_WORDS").is_some() {
+        put(
+            &mut m,
+            "debug.pdf_words",
+            true.into(),
+            "DONSHEET_DEBUG_WORDS",
+        );
+    }
+    if std::env::var_os("DONSIFT_DEBUG").is_some() {
+        put(&mut m, "debug.extract", true.into(), "DONSIFT_DEBUG");
+    }
+    if legacy_flag("DONSETCH_DEBUG_ECHO") {
+        put(
+            &mut m,
+            "debug.echo_scorecard",
+            true.into(),
+            "DONSETCH_DEBUG_ECHO",
+        );
+    }
+
+    (m, warnings)
+}
+
+// ---------------------------------------------------------------------------
+// New env names: DONSETCH_<SECTION>__<KEY>
+// ---------------------------------------------------------------------------
+
+/// Field book: (section, key, kind, default display, description).
+/// Single source of truth for env coercion, `config show` and the
+/// generated markdown table.
+pub(crate) type Fieldbook = [(
+    &'static str,
+    &'static str,
+    FieldKind,
+    &'static str,
+    &'static str,
+)];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum FieldKind {
+    Str,
+    Bool,
+    Int,
+    List,
+}
+
+pub(crate) fn fieldbook() -> &'static Fieldbook {
+    &[
+        // transport
+        (
+            "transport",
+            "kind",
+            FieldKind::Str,
+            "stdio",
+            "stdio | http: which transport the daemon serves",
+        ),
+        (
+            "transport",
+            "host",
+            FieldKind::Str,
+            "127.0.0.1",
+            "HTTP server bind address",
+        ),
+        (
+            "transport",
+            "port",
+            FieldKind::Int,
+            "8765",
+            "HTTP server port",
+        ),
+        (
+            "transport",
+            "token",
+            FieldKind::Str,
+            "(empty)",
+            "HTTP bearer token; empty = token auth off",
+        ),
+        (
+            "transport",
+            "timeout_secs",
+            FieldKind::Int,
+            "300",
+            "HTTP idle timeout in seconds",
+        ),
+        (
+            "transport",
+            "cors",
+            FieldKind::Bool,
+            "false",
+            "send permissive CORS headers",
+        ),
+        // mcp
+        (
+            "mcp",
+            "text_only",
+            FieldKind::Bool,
+            "false",
+            "strip image blocks from tool output",
+        ),
+        (
+            "mcp",
+            "answer_tool",
+            FieldKind::Bool,
+            "true",
+            "expose web_answer",
+        ),
+        (
+            "mcp",
+            "url_handles",
+            FieldKind::Bool,
+            "true",
+            "return compact [H1] url handles in big results",
+        ),
+        // paths
+        (
+            "paths",
+            "cache_dir",
+            FieldKind::Str,
+            "(platform default)",
+            "override the cache/state root (fallback; env DONSETCH_CACHE_DIR still wins)",
+        ),
+        // state
+        (
+            "state",
+            "no_disk_state",
+            FieldKind::Bool,
+            "false",
+            "keep every persisted state in memory only (test hook)",
+        ),
+        (
+            "state",
+            "route_memory",
+            FieldKind::Str,
+            "readwrite",
+            "off | readwrite | readonly: per-domain stealth route memory",
+        ),
+        (
+            "state",
+            "cookie_vault",
+            FieldKind::Bool,
+            "true",
+            "persist tier-1/tier-2 clearance cookies",
+        ),
+        (
+            "state",
+            "web_memory",
+            FieldKind::Bool,
+            "true",
+            "enable the local web-memory store",
+        ),
+        (
+            "state",
+            "web_memory_cap",
+            FieldKind::Int,
+            "4000",
+            "web-memory max entries (256..=100000)",
+        ),
+        // proxy
+        (
+            "proxy",
+            "from_environment",
+            FieldKind::Bool,
+            "true",
+            "honor ambient HTTP(S)_PROXY/ALL_PROXY/NO_PROXY",
+        ),
+        (
+            "proxy",
+            "http",
+            FieldKind::Str,
+            "(ambient)",
+            "explicit HTTP proxy; beats the ambient var",
+        ),
+        (
+            "proxy",
+            "https",
+            FieldKind::Str,
+            "(ambient)",
+            "explicit HTTPS proxy; beats the ambient var",
+        ),
+        (
+            "proxy",
+            "all",
+            FieldKind::Str,
+            "(ambient)",
+            "explicit proxy for both schemes",
+        ),
+        (
+            "proxy",
+            "no_proxy",
+            FieldKind::Str,
+            "(ambient)",
+            "comma list of hosts to bypass the proxy",
+        ),
+        (
+            "proxy",
+            "pool",
+            FieldKind::List,
+            "(empty)",
+            "extra proxy pool, comma-separated",
+        ),
+        // tls
+        (
+            "tls",
+            "cert_file",
+            FieldKind::Str,
+            "(ambient)",
+            "extra CA cert file",
+        ),
+        (
+            "tls",
+            "cert_dir",
+            FieldKind::Str,
+            "(ambient)",
+            "extra CA cert directory",
+        ),
+        // persona
+        (
+            "persona",
+            "timezone",
+            FieldKind::Str,
+            "(ambient TZ)",
+            "timezone for persona headers",
+        ),
+        (
+            "persona",
+            "locale",
+            FieldKind::Str,
+            "(ambient LANG)",
+            "locale for persona headers",
+        ),
+        // cli
+        (
+            "cli",
+            "color",
+            FieldKind::Str,
+            "auto",
+            "auto | never | always",
+        ),
+        // fetch
+        (
+            "fetch",
+            "allow_private_egress",
+            FieldKind::Bool,
+            "false",
+            "allow fetch to private/loopback addresses",
+        ),
+        (
+            "fetch",
+            "h3",
+            FieldKind::Bool,
+            "false",
+            "opt-in HTTP/3 exit lane",
+        ),
+        (
+            "fetch",
+            "alt_svc",
+            FieldKind::Bool,
+            "true",
+            "honor Alt-Svc upgrade hints",
+        ),
+        (
+            "fetch",
+            "shadow_fetch",
+            FieldKind::Str,
+            "auto",
+            "auto | always | never: tier-1 shadow fetch lane",
+        ),
+        (
+            "fetch",
+            "shadow_deadline_ms",
+            FieldKind::Int,
+            "3000",
+            "shadow-fetch burst deadline in ms",
+        ),
+        (
+            "fetch",
+            "adapters",
+            FieldKind::Bool,
+            "true",
+            "enable data-only site adapters",
+        ),
+        (
+            "fetch",
+            "adapter_dump_dir",
+            FieldKind::Str,
+            "(unset)",
+            "dump raw adapter payloads here for plugin development",
+        ),
+        (
+            "fetch",
+            "crawl_shape",
+            FieldKind::Bool,
+            "true",
+            "crawl result shaping",
+        ),
+        (
+            "fetch",
+            "prewarm",
+            FieldKind::Bool,
+            "true",
+            "pre-warm URLs found by search",
+        ),
+        (
+            "fetch",
+            "pdf_max_mb",
+            FieldKind::Int,
+            "100",
+            "max PDF download size in MB (1..=4096)",
+        ),
+        (
+            "fetch",
+            "ocr",
+            FieldKind::Bool,
+            "true",
+            "OCR arbitration for scanned PDFs",
+        ),
+        (
+            "fetch",
+            "ocr_max_pages",
+            FieldKind::Int,
+            "25",
+            "max OCR pages per PDF (1..=500)",
+        ),
+        // bypass
+        (
+            "bypass",
+            "enabled",
+            FieldKind::Bool,
+            "true",
+            "unlocker bypass lane",
+        ),
+        (
+            "bypass",
+            "zone",
+            FieldKind::Str,
+            "(unset)",
+            "Bright Data unlocker zone name",
+        ),
+        (
+            "bypass",
+            "max_daily",
+            FieldKind::Int,
+            "50",
+            "max bypass solves per day (1..=10000)",
+        ),
+        (
+            "bypass",
+            "timeout_secs",
+            FieldKind::Int,
+            "120",
+            "bypass solve timeout in seconds",
+        ),
+        (
+            "bypass",
+            "render",
+            FieldKind::Bool,
+            "false",
+            "render inside bypass solves",
+        ),
+        (
+            "bypass",
+            "endpoint",
+            FieldKind::Str,
+            "(production)",
+            "unlocker endpoint override",
+        ),
+        (
+            "bypass",
+            "cache",
+            FieldKind::Bool,
+            "true",
+            "persist bypass solutions",
+        ),
+        (
+            "bypass",
+            "cache_ttl_secs",
+            FieldKind::Int,
+            "21600",
+            "bypass solution TTL in seconds",
+        ),
+        (
+            "bypass",
+            "cache_max_entries",
+            FieldKind::Int,
+            "200",
+            "bypass solution cache size",
+        ),
+        // search
+        (
+            "search",
+            "google_profile",
+            FieldKind::Str,
+            "(unset)",
+            "Google web-light profile id",
+        ),
+        (
+            "search",
+            "ghost_lane",
+            FieldKind::Str,
+            "auto",
+            "auto | always | never: ghost lane for search results",
+        ),
+        (
+            "search",
+            "rerank_topup",
+            FieldKind::Bool,
+            "true",
+            "rerank top-up pass",
+        ),
+        (
+            "search",
+            "rerank_threads",
+            FieldKind::Int,
+            "0 (auto)",
+            "rerank thread count; 0 = auto, max 64",
+        ),
+        (
+            "search",
+            "brightdata_zone",
+            FieldKind::Str,
+            "(unset)",
+            "BYOK Bright Data search zone",
+        ),
+        // browser
+        (
+            "browser",
+            "backend",
+            FieldKind::Str,
+            "auto",
+            "auto | chromium | cloak",
+        ),
+        (
+            "browser",
+            "chromium_path",
+            FieldKind::Str,
+            "(discovery)",
+            "explicit Chromium/Chrome binary path",
+        ),
+        (
+            "browser",
+            "no_sandbox",
+            FieldKind::Bool,
+            "false",
+            "run Chromium with --no-sandbox",
+        ),
+        (
+            "browser",
+            "cloak_auto_download",
+            FieldKind::Bool,
+            "false",
+            "allow downloading the cloak browser",
+        ),
+        (
+            "browser",
+            "cloak_path",
+            FieldKind::Str,
+            "(discovery)",
+            "explicit cloak browser binary",
+        ),
+        (
+            "browser",
+            "cloak_version",
+            FieldKind::Str,
+            "(latest)",
+            "pin a cloak browser version",
+        ),
+        (
+            "browser",
+            "cloak_cache_dir",
+            FieldKind::Str,
+            "(platform default)",
+            "cloak browser download cache",
+        ),
+        (
+            "browser",
+            "playwright_path",
+            FieldKind::Str,
+            "(ambient)",
+            "extra Playwright browsers root",
+        ),
+        (
+            "browser",
+            "pool_slots",
+            FieldKind::Int,
+            "0 (auto)",
+            "browser pool size; 1..=16, 0 = auto",
+        ),
+        (
+            "browser",
+            "xvfb_display",
+            FieldKind::Int,
+            "0 (auto)",
+            "Xvfb display number; 0 = auto",
+        ),
+        (
+            "browser",
+            "route_probes",
+            FieldKind::Bool,
+            "true",
+            "background route probing",
+        ),
+        (
+            "browser",
+            "probe_scan_secs",
+            FieldKind::Int,
+            "120",
+            "probe scan interval in seconds",
+        ),
+        (
+            "browser",
+            "probe_stale_secs",
+            FieldKind::Int,
+            "21600",
+            "probe result staleness in seconds",
+        ),
+        (
+            "browser",
+            "login_force",
+            FieldKind::Bool,
+            "false",
+            "run login flows headless even without a display",
+        ),
+        // debug
+        (
+            "debug",
+            "ghost",
+            FieldKind::Bool,
+            "false",
+            "ghost/transport debug logging",
+        ),
+        (
+            "debug",
+            "search",
+            FieldKind::Bool,
+            "false",
+            "search debug logging",
+        ),
+        (
+            "debug",
+            "pdf",
+            FieldKind::Bool,
+            "false",
+            "pdf debug logging",
+        ),
+        (
+            "debug",
+            "pdf_matrix",
+            FieldKind::Bool,
+            "false",
+            "pdf matrix debug",
+        ),
+        (
+            "debug",
+            "pdf_chars",
+            FieldKind::Bool,
+            "false",
+            "pdf char dump",
+        ),
+        (
+            "debug",
+            "pdf_words",
+            FieldKind::Bool,
+            "false",
+            "pdf word dump",
+        ),
+        (
+            "debug",
+            "extract",
+            FieldKind::Bool,
+            "false",
+            "extraction debug logging",
+        ),
+        (
+            "debug",
+            "echo_scorecard",
+            FieldKind::Bool,
+            "false",
+            "scorecard echo debug",
+        ),
+    ]
+}
+
+const RESERVED_VARS: &[&str] = &[
+    "DONSETCH_CACHE_DIR",
+    "DONSETCH_CONFIG",
+    "DONSETCH_NO_CONFIG_FILE",
+    "DONSETCH_PLUGIN",
+    "BLESS_MCP_FIXTURES",
+];
+
+const LEGACY_VARS: &[&str] = &[
+    "DONSETCH_TRANSPORT",
+    "DONSETCH_HTTP_HOST",
+    "DONSETCH_HTTP_PORT",
+    "DONSETCH_HTTP_TOKEN",
+    "DONSETCH_HTTP_TIMEOUT_SECS",
+    "DONSETCH_HTTP_CORS",
+    "DONSETCH_MCP_TEXT_ONLY",
+    "DONSETCH_NO_ANSWER_TOOL",
+    "DONSETCH_URL_HANDLES",
+    "DONSEEK_NO_DISK_STATE",
+    "DONSETCH_NO_ROUTE_MEMORY",
+    "DONSETCH_ROUTE_MEMORY_READONLY",
+    "DONSETCH_NO_COOKIE_VAULT",
+    "DONSETCH_NO_WEB_MEMORY",
+    "DONSETCH_WEB_MEMORY_CAP",
+    "DONSETCH_ALLOW_PRIVATE_EGRESS",
+    "DONSETCH_H3",
+    "DONSETCH_NO_H3",
+    "DONSETCH_NO_ALT_SVC",
+    "DONSETCH_SHADOW_FETCH",
+    "DONSETCH_NO_SHADOW_FETCH",
+    "DONSETCH_SHADOW_DEADLINE_MS",
+    "DONSETCH_NO_ENV_PROXY",
+    "DONSEEK_PROXIES",
+    "DONSETCH_NO_ADAPTERS",
+    "DONSETCH_ADAPTER_DUMP",
+    "DONSETCH_NO_CRAWL_SHAPE",
+    "DONSETCH_NO_PREWARM",
+    "DONSETCH_PDF_MAX_MB",
+    "DONSHEET_OCR",
+    "DONSHEET_OCR_MAX_PAGES",
+    "DONSETCH_UNLOCKER_ZONE",
+    "DONSETCH_BYPASS_MAX_DAILY",
+    "DONSETCH_BYPASS_TIMEOUT_SECS",
+    "DONSETCH_BYPASS_RENDER",
+    "DONSETCH_BYPASS_ENDPOINT",
+    "DONSETCH_BYPASS_CACHE",
+    "DONSETCH_BYPASS_CACHE_TTL_SECS",
+    "DONSETCH_BYPASS_CACHE_MAX_ENTRIES",
+    "DONSETCH_GOOGLE_PROFILE",
+    "DONSEEK_FORCE_GHOST_LANE",
+    "DONSEEK_NO_GHOST_LANES",
+    "DONSEEK_NO_TOPUP",
+    "DONSEEK_RERANK_THREADS",
+    "DONSETCH_BRIGHTDATA_ZONE",
+    "DONSETCH_BROWSER_BACKEND",
+    "DONGHOST_BROWSER_BACKEND",
+    "DONGHOST_CHROME",
+    "DONGHOST_NO_SANDBOX",
+    "DONSETCH_CLOAK_AUTO_DOWNLOAD",
+    "CLOAKBROWSER_BINARY_PATH",
+    "CLOAKBROWSER_VERSION",
+    "CLOAKBROWSER_CACHE_DIR",
+    "DONSETCH_NO_GHOST_POOL",
+    "DONSETCH_GHOST_POOL_SLOTS",
+    "DONSETCH_XVFB_DISPLAY",
+    "DONSETCH_NO_ROUTE_PROBES",
+    "DONSETCH_PROBE_SCAN_SECS",
+    "DONSETCH_PROBE_STALE_SECS",
+    "DONSETCH_LOGIN_FORCE",
+    "DONGHOST_DEBUG",
+    "DONSEEK_DEBUG",
+    "DONSHEET_DEBUG",
+    "DONSHEET_DEBUG_MATRIX",
+    "DONSHEET_DEBUG_CHARS",
+    "DONSHEET_DEBUG_WORDS",
+    "DONSIFT_DEBUG",
+    "DONSETCH_DEBUG_ECHO",
+];
+
+/// Every legacy knob still set in the environment (for doctor + show).
+pub(crate) fn legacy_vars_in_env() -> Vec<&'static str> {
+    LEGACY_VARS
+        .iter()
+        .copied()
+        .filter(|name| std::env::var_os(name).is_some())
+        .collect()
+}
+
+fn boolish(value: &str) -> Option<bool> {
+    let v = value.trim();
+    for on in ["1", "true", "on", "yes", "y"] {
+        if v.eq_ignore_ascii_case(on) {
+            return Some(true);
+        }
+    }
+    for off in ["0", "false", "off", "no", "n"] {
+        if v.eq_ignore_ascii_case(off) {
+            return Some(false);
+        }
+    }
+    None
+}
+
+fn new_env_layer() -> (VMap, Vec<String>, Vec<String>) {
+    let mut map = VMap::new();
+    let mut warnings = Vec::new();
+    let mut errors = Vec::new();
+
+    for (name, value) in std::env::vars_os() {
+        let (Some(name), Some(value)) = (name.to_str(), value.to_str()) else {
+            continue;
+        };
+        if !name.starts_with("DONSETCH_") || name == "DONSETCH_" {
+            continue;
+        }
+        if RESERVED_VARS.contains(&name) || LEGACY_VARS.contains(&name) {
+            continue;
+        }
+        let path = name["DONSETCH_".len()..].to_ascii_lowercase();
+        let parts: Vec<&str> = path.split("__").collect();
+        let (section, key) = if parts.len() == 2 {
+            (parts[0], parts[1])
+        } else {
+            warnings.push(format!(
+                "ignoring {name}: expected DONSETCH_<SECTION>__<KEY>"
+            ));
+            continue;
+        };
+        let kind = fieldbook()
+            .iter()
+            .find(|(s, k, _, _, _)| *s == section && *k == key)
+            .map(|entry| entry.2);
+        let Some(kind) = kind else {
+            warnings.push(format!(
+                "ignoring {name}: unknown knob (see `donsetch config show`)"
+            ));
+            continue;
+        };
+        let vkind = match kind {
+            FieldKind::Str => config::ValueKind::String(value.to_string()),
+            FieldKind::Bool => match boolish(value) {
+                Some(b) => b.into(),
+                None => {
+                    errors.push(format!(
+                        "{name}={value:?} is not a boolean (1/true/on/yes/0/false/off/no)"
+                    ));
+                    continue;
+                }
+            },
+            FieldKind::Int => match value.trim().parse::<i64>() {
+                Ok(n) => n.into(),
+                Err(_) => {
+                    errors.push(format!("{name}={value:?} is not an integer"));
+                    continue;
+                }
+            },
+            FieldKind::List => value
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect::<Vec<_>>()
+                .into(),
+        };
+        put(&mut map, &format!("{section}.{key}"), vkind, name);
+    }
+
+    (map, warnings, errors)
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+fn validate(c: &DonsetchConfig) -> Result<(), ConfigError> {
+    let err = |msg: String| Err(ConfigError::Validate(msg));
+    if c.transport.port == 0 {
+        return err("transport.port = 0 (valid 1..=65535)".into());
+    }
+    if c.transport.timeout_secs == 0 || c.transport.timeout_secs > 3600 {
+        return err("transport.timeout_secs must be 1..=3600".into());
+    }
+    if c.state.web_memory_cap < 256 || c.state.web_memory_cap > 100_000 {
+        return err("state.web_memory_cap must be 256..=100_000".into());
+    }
+    if c.bypass.max_daily == 0 || c.bypass.max_daily > 10_000 {
+        return err("bypass.max_daily must be 1..=10_000".into());
+    }
+    if c.bypass.timeout_secs == 0 || c.bypass.timeout_secs > 3600 {
+        return err("bypass.timeout_secs must be 1..=3600".into());
+    }
+    if c.bypass.cache_ttl_secs == 0 || c.bypass.cache_ttl_secs > 86_400 {
+        return err("bypass.cache_ttl_secs must be 1..=86_400".into());
+    }
+    if c.bypass.cache_max_entries == 0 || c.bypass.cache_max_entries > 100_000 {
+        return err("bypass.cache_max_entries must be 1..=100_000".into());
+    }
+    if !(1..=4096).contains(&c.fetch.pdf_max_mb) {
+        return err("fetch.pdf_max_mb must be 1..=4096".into());
+    }
+    if c.fetch.ocr_max_pages == 0 || c.fetch.ocr_max_pages > 500 {
+        return err("fetch.ocr_max_pages must be 1..=500".into());
+    }
+    if c.fetch.shadow_deadline_ms == 0 || c.fetch.shadow_deadline_ms > 60_000 {
+        return err("fetch.shadow_deadline_ms must be 1..=60_000".into());
+    }
+    if c.browser.pool_slots > 16 {
+        return err("browser.pool_slots must be 0 (auto) or 1..=16".into());
+    }
+    if c.browser.xvfb_display > 254 {
+        return err("browser.xvfb_display must be 0 (auto) or 1..=254".into());
+    }
+    if c.browser.probe_scan_secs == 0 || c.browser.probe_scan_secs > 3600 {
+        return err("browser.probe_scan_secs must be 1..=3600".into());
+    }
+    if c.browser.probe_stale_secs < 60 || c.browser.probe_stale_secs > 604_800 {
+        return err("browser.probe_stale_secs must be 60..=604800".into());
+    }
+    if c.search.rerank_threads > 64 {
+        return err("search.rerank_threads must be 0 (auto) or 1..=64".into());
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Show: origins, human table, markdown table
+// ---------------------------------------------------------------------------
+
+fn value_of(c: &DonsetchConfig, section: &str, key: &str) -> String {
+    let json = serde_json::to_value(c).unwrap_or(serde_json::Value::Null);
+    match json.get(section).and_then(|s| s.get(key)) {
+        Some(serde_json::Value::Bool(b)) => b.to_string(),
+        Some(serde_json::Value::Number(n)) => n.to_string(),
+        Some(serde_json::Value::String(s)) => format!("\"{s}\""),
+        Some(serde_json::Value::Array(a)) => {
+            let parts: Vec<String> = a
+                .iter()
+                .map(|v| match v {
+                    serde_json::Value::String(s) => format!("\"{s}\""),
+                    other => other.to_string(),
+                })
+                .collect();
+            format!("[{}]", parts.join(", "))
+        }
+        _ => "(unknown)".into(),
+    }
+}
+
+/// (section, key, current value, origin) for every documented knob.
+/// Origin = "default" | the env var that set it | "file:<path>".
+pub fn origins(c: &DonsetchConfig) -> Vec<(&'static str, &'static str, String, String)> {
+    let mut out = Vec::new();
+    let file = toml_path().map(|p| format!("file:{}", p.display()));
+    for (section, key, _, _, _) in fieldbook() {
+        let section = *section;
+        let key = *key;
+        let mut origin = "default".to_string();
+        // Report the topmost setter: new env names beat legacy names,
+        // legacy names beat the file layer.
+        let s = section.to_uppercase();
+        let k = key.to_uppercase();
+        let env_name = format!("DONSETCH_{s}__{k}");
+        if std::env::var_os(&env_name).is_some() {
+            origin = env_name;
+        } else {
+            for var in LEGACY_VARS {
+                if legacy_target_of(var) == (section, key) && std::env::var_os(var).is_some() {
+                    origin = format!("legacy:{var}");
+                    break;
+                }
+            }
+            if origin == "default"
+                && let Some(file) = &file
+            {
+                origin = file.clone();
+            }
+        }
+        out.push((section, key, value_of(c, section, key), origin));
+    }
+    out
+}
+
+/// Human-readable `config show` output: every knob, value, source.
+pub fn show_text(c: &DonsetchConfig) -> String {
+    let mut out = String::new();
+    if let Some(path) = toml_path() {
+        out.push_str(&format!("config file: {}\n", path.display()));
+    } else {
+        out.push_str("config file: (none, using env + defaults)\n");
+    }
+    let legacy = legacy_vars_in_env();
+    if !legacy.is_empty() {
+        out.push_str(&format!(
+            "legacy env vars detected: {} (still honored; migrate to the keys in `donsetch config show --legacy`)\n",
+            legacy.join(", ")
+        ));
+    }
+    out.push('\n');
+    let rows = origins(c);
+    let mut last_section = "";
+    for (section, key, value, origin) in rows {
+        if section != last_section {
+            if !last_section.is_empty() {
+                out.push('\n');
+            }
+            out.push_str(&format!("[{section}]\n"));
+            last_section = section;
+        }
+        out.push_str(&format!("  {key:<18} = {value:<20} ({origin})\n"));
+    }
+    out
+}
+
+/// The knob reference table as markdown (single source: this file).
+pub fn show_markdown() -> String {
+    let mut out = String::new();
+    out.push_str("| Key | Type | Default | What it does |\n|---|---|---|---|\n");
+    let mut last_section = "";
+    for (section, key, kind, default, doc) in fieldbook() {
+        let section = *section;
+        let kind = *kind;
+        let type_str = match kind {
+            FieldKind::Str => "string",
+            FieldKind::Bool => "bool",
+            FieldKind::Int => "integer",
+            FieldKind::List => "list",
+        };
+        if section != last_section {
+            out.push_str(&format!("\n**`[{section}]`**\n\n"));
+            last_section = section;
+        }
+        let esc = |s: &str| s.replace('|', "\\|");
+        out.push_str(&format!(
+            "| `{key}` | {type_str} | {} | {} |\n",
+            esc(default),
+            esc(doc)
+        ));
+    }
+    out
+}
+
+/// The legacy -> new mapping as markdown.
+pub fn show_legacy_markdown() -> String {
+    let mut out = String::new();
+    out.push_str("| Legacy env var | New key | Still honored? |\n|---|---|---|\n");
+    for name in LEGACY_VARS {
+        let (section, key) = legacy_target_of(name);
+        out.push_str(&format!(
+            "| `{name}` | `{section}.{key}` | yes (deprecated, cut at v4) |\n"
+        ));
+    }
+    out
+}
+
+/// Best-effort mapping of a legacy var name to its config key (for
+/// doctor output and `--legacy` docs; mirrors legacy_layer()).
+pub(crate) fn legacy_target_of(name: &str) -> (&'static str, &'static str) {
+    match name {
+        "DONSETCH_TRANSPORT" => ("transport", "kind"),
+        "DONSETCH_HTTP_HOST" => ("transport", "host"),
+        "DONSETCH_HTTP_PORT" => ("transport", "port"),
+        "DONSETCH_HTTP_TOKEN" => ("transport", "token"),
+        "DONSETCH_HTTP_TIMEOUT_SECS" => ("transport", "timeout_secs"),
+        "DONSETCH_HTTP_CORS" => ("transport", "cors"),
+        "DONSETCH_MCP_TEXT_ONLY" => ("mcp", "text_only"),
+        "DONSETCH_NO_ANSWER_TOOL" => ("mcp", "answer_tool"),
+        "DONSETCH_URL_HANDLES" => ("mcp", "url_handles"),
+        "DONSEEK_NO_DISK_STATE" => ("state", "no_disk_state"),
+        "DONSETCH_NO_ROUTE_MEMORY" => ("state", "route_memory"),
+        "DONSETCH_ROUTE_MEMORY_READONLY" => ("state", "route_memory"),
+        "DONSETCH_NO_COOKIE_VAULT" => ("state", "cookie_vault"),
+        "DONSETCH_NO_WEB_MEMORY" => ("state", "web_memory"),
+        "DONSETCH_WEB_MEMORY_CAP" => ("state", "web_memory_cap"),
+        "DONSETCH_ALLOW_PRIVATE_EGRESS" => ("fetch", "allow_private_egress"),
+        "DONSETCH_H3" => ("fetch", "h3"),
+        "DONSETCH_NO_H3" => ("fetch", "h3"),
+        "DONSETCH_NO_ALT_SVC" => ("fetch", "alt_svc"),
+        "DONSETCH_SHADOW_FETCH" => ("fetch", "shadow_fetch"),
+        "DONSETCH_NO_SHADOW_FETCH" => ("fetch", "shadow_fetch"),
+        "DONSETCH_SHADOW_DEADLINE_MS" => ("fetch", "shadow_deadline_ms"),
+        "DONSETCH_NO_ENV_PROXY" => ("proxy", "from_environment"),
+        "DONSEEK_PROXIES" => ("proxy", "pool"),
+        "DONSETCH_NO_ADAPTERS" => ("fetch", "adapters"),
+        "DONSETCH_ADAPTER_DUMP" => ("fetch", "adapter_dump_dir"),
+        "DONSETCH_NO_CRAWL_SHAPE" => ("fetch", "crawl_shape"),
+        "DONSETCH_NO_PREWARM" => ("fetch", "prewarm"),
+        "DONSETCH_PDF_MAX_MB" => ("fetch", "pdf_max_mb"),
+        "DONSHEET_OCR" => ("fetch", "ocr"),
+        "DONSHEET_OCR_MAX_PAGES" => ("fetch", "ocr_max_pages"),
+        "DONSETCH_UNLOCKER_ZONE" => ("bypass", "zone"),
+        "DONSETCH_BYPASS_MAX_DAILY" => ("bypass", "max_daily"),
+        "DONSETCH_BYPASS_TIMEOUT_SECS" => ("bypass", "timeout_secs"),
+        "DONSETCH_BYPASS_RENDER" => ("bypass", "render"),
+        "DONSETCH_BYPASS_ENDPOINT" => ("bypass", "endpoint"),
+        "DONSETCH_BYPASS_CACHE" => ("bypass", "cache"),
+        "DONSETCH_BYPASS_CACHE_TTL_SECS" => ("bypass", "cache_ttl_secs"),
+        "DONSETCH_BYPASS_CACHE_MAX_ENTRIES" => ("bypass", "cache_max_entries"),
+        "DONSETCH_GOOGLE_PROFILE" => ("search", "google_profile"),
+        "DONSEEK_FORCE_GHOST_LANE" => ("search", "ghost_lane"),
+        "DONSEEK_NO_GHOST_LANES" => ("search", "ghost_lane"),
+        "DONSEEK_NO_TOPUP" => ("search", "rerank_topup"),
+        "DONSEEK_RERANK_THREADS" => ("search", "rerank_threads"),
+        "DONSETCH_BRIGHTDATA_ZONE" => ("search", "brightdata_zone"),
+        "DONSETCH_BROWSER_BACKEND" | "DONGHOST_BROWSER_BACKEND" => ("browser", "backend"),
+        "DONGHOST_CHROME" => ("browser", "chromium_path"),
+        "DONGHOST_NO_SANDBOX" => ("browser", "no_sandbox"),
+        "DONSETCH_CLOAK_AUTO_DOWNLOAD" => ("browser", "cloak_auto_download"),
+        "CLOAKBROWSER_BINARY_PATH" => ("browser", "cloak_path"),
+        "CLOAKBROWSER_VERSION" => ("browser", "cloak_version"),
+        "CLOAKBROWSER_CACHE_DIR" => ("browser", "cloak_cache_dir"),
+        "DONSETCH_NO_GHOST_POOL" => ("browser", "pool_slots"),
+        "DONSETCH_GHOST_POOL_SLOTS" => ("browser", "pool_slots"),
+        "DONSETCH_XVFB_DISPLAY" => ("browser", "xvfb_display"),
+        "DONSETCH_NO_ROUTE_PROBES" => ("browser", "route_probes"),
+        "DONSETCH_PROBE_SCAN_SECS" => ("browser", "probe_scan_secs"),
+        "DONSETCH_PROBE_STALE_SECS" => ("browser", "probe_stale_secs"),
+        "DONSETCH_LOGIN_FORCE" => ("browser", "login_force"),
+        "DONGHOST_DEBUG" => ("debug", "ghost"),
+        "DONSEEK_DEBUG" => ("debug", "search"),
+        "DONSHEET_DEBUG" => ("debug", "pdf"),
+        "DONSHEET_DEBUG_MATRIX" => ("debug", "pdf_matrix"),
+        "DONSHEET_DEBUG_CHARS" => ("debug", "pdf_chars"),
+        "DONSHEET_DEBUG_WORDS" => ("debug", "pdf_words"),
+        "DONSIFT_DEBUG" => ("debug", "extract"),
+        "DONSETCH_DEBUG_ECHO" => ("debug", "echo_scorecard"),
+        _ => ("", ""),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// The global
+// ---------------------------------------------------------------------------
+
+static CONFIG: OnceLock<DonsetchConfig> = OnceLock::new();
+
+/// Install a validated config (the CLI/MCP entry point does this after
+/// merging CLI flags). Errors are fatal and reported to the caller.
+pub fn install(cfg: DonsetchConfig) -> Result<(), ConfigError> {
+    validate(&cfg)?;
+    let _ = CONFIG.set(cfg);
+    Ok(())
+}
+
+/// The process config, initializing lazily from defaults + env + file.
+///
+/// Errors at this path cannot be fatal (no caller context), so the error
+/// and the default config are reported to stderr and the default is used;
+/// the binary entry points call `load()` + `install()` first so real users
+/// always get the loud path.
+pub fn cfg() -> &'static DonsetchConfig {
+    CONFIG.get_or_init(|| match load() {
+        Ok(loaded) => {
+            for w in &loaded.warnings {
+                eprintln!("[donsetch config] {w}");
+            }
+            loaded.config
+        }
+        Err(e) => {
+            eprintln!("[donsetch config] {e}; using defaults");
+            DonsetchConfig::default()
+        }
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Shared parsers (kept for tests + non-config uses)
+// ---------------------------------------------------------------------------
+
+/// Strict opt-in flag parser: only `1`, `true`, `on` count.
+pub(crate) fn env_flag_value(value: Option<&std::ffi::OsStr>) -> bool {
+    value
+        .and_then(|v| v.to_str())
+        .map(str::trim)
+        .is_some_and(|value| {
+            value.eq_ignore_ascii_case("1")
+                || value.eq_ignore_ascii_case("true")
+                || value.eq_ignore_ascii_case("on")
+        })
 }
 
 /// Write a file that holds credentials (API keys, proxy passwords)
@@ -44,25 +2116,42 @@ pub(crate) fn write_private(path: &std::path::Path, bytes: &[u8]) -> std::io::Re
     }
 }
 
-fn env_flag_value(value: Option<&OsStr>) -> bool {
-    value
-        .and_then(OsStr::to_str)
-        .map(str::trim)
-        .is_some_and(|value| {
-            value.eq_ignore_ascii_case("1")
-                || value.eq_ignore_ascii_case("true")
-                || value.eq_ignore_ascii_case("on")
-        })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    /// Markdown tables must never split a row: raw pipes in defaults
+    /// and descriptions are escaped ("\\|"), so a data row has the
+    /// same " | " separator count as the header (4 = 4 columns).
+    #[test]
+    fn show_markdown_keeps_one_row_per_knob() {
+        let md = super::show_markdown();
+        let header_cols = md.lines().next().unwrap().matches(" | ").count();
+        let data_rows: Vec<&str> = md.lines().filter(|l| l.starts_with("| `")).collect();
+        assert!(data_rows.len() > 50, "fieldbook shrunk?");
+        for row in &data_rows {
+            assert_eq!(
+                row.matches(" | ").count(),
+                header_cols,
+                "row split by an unescaped pipe: {row}"
+            );
+        }
+        // The transport.kind description does contain a pipe; the escape
+        // must have fired on it.
+        let kind_row = data_rows
+            .iter()
+            .find(|l| l.contains("`kind`"))
+            .expect("transport.kind not in the table");
+        assert!(kind_row.contains("\\|"), "kind row lost its escaped pipe");
+    }
+
     #[test]
     fn opt_in_flags_accept_only_explicit_true_values() {
         for value in ["1", "true", "TRUE", "on", "ON", " true ", "\t1\n"] {
-            assert!(env_flag_value(Some(OsStr::new(value))), "{value:?}");
+            assert!(
+                env_flag_value(Some(std::ffi::OsStr::new(value))),
+                "{value:?}"
+            );
         }
 
         for value in [
@@ -78,7 +2167,10 @@ mod tests {
             "anything",
             " true-ish ",
         ] {
-            assert!(!env_flag_value(Some(OsStr::new(value))), "{value:?}");
+            assert!(
+                !env_flag_value(Some(std::ffi::OsStr::new(value))),
+                "{value:?}"
+            );
         }
 
         assert!(!env_flag_value(None));
@@ -89,19 +2181,53 @@ mod tests {
     fn opt_in_flags_reject_non_unicode_values() {
         use std::os::unix::ffi::OsStrExt;
 
-        assert!(!env_flag_value(Some(OsStr::from_bytes(b"true\xff"))));
+        assert!(!env_flag_value(Some(std::ffi::OsStr::from_bytes(
+            b"true\xff"
+        ))));
     }
 
-    #[cfg(unix)]
-    fn mode_of(p: &std::path::Path) -> u32 {
-        use std::os::unix::fs::PermissionsExt;
-        std::fs::metadata(p).unwrap().permissions().mode() & 0o777
+    #[test]
+    fn boolish_covers_both_truth_and_falsity_vocabularies() {
+        for on in ["1", "true", "TRUE", "On", "YES", "y"] {
+            assert_eq!(boolish(on), Some(true), "{on:?}");
+        }
+        for off in ["0", "false", "OFF", "No", "n"] {
+            assert_eq!(boolish(off), Some(false), "{off:?}");
+        }
+        assert_eq!(boolish("maybe"), None);
+        assert_eq!(boolish(""), None);
     }
 
-    // A fresh file must be 0600 from the moment it exists (not
-    // created at the umask default and chmod'ed afterwards, which
-    // leaves a world-readable window and a world-readable file on
-    // any crash in between).
+    #[test]
+    fn every_fieldbook_entry_has_a_known_section() {
+        for (section, key, _, _, _) in fieldbook() {
+            match *section {
+                "transport" | "mcp" | "paths" | "state" | "proxy" | "tls" | "persona" | "cli"
+                | "fetch" | "bypass" | "search" | "browser" | "debug" => {}
+                other => panic!("unknown section {other} for {section}.{key}"),
+            }
+        }
+    }
+
+    #[test]
+    fn defaults_are_valid() {
+        validate(&DonsetchConfig::default()).expect("defaults must pass validation");
+    }
+
+    #[test]
+    fn put_builds_nested_tables_and_overwrites_leaves() {
+        let mut m = VMap::new();
+        put(&mut m, "fetch.h3", true.into(), "A");
+        put(&mut m, "fetch.h3", false.into(), "B");
+        put(&mut m, "fetch.pdf_max_mb", 5i64.into(), "C");
+        let fetch = m.get("fetch").expect("fetch section in map");
+        let fetch_str = fetch.to_string();
+        assert!(fetch_str.contains("h3"), "{fetch_str}");
+        assert!(fetch_str.contains("false"), "{fetch_str}");
+        assert!(fetch_str.contains("pdf_max_mb"), "{fetch_str}");
+        assert!(fetch_str.contains(" => 5"), "{fetch_str}");
+    }
+
     #[cfg(unix)]
     #[test]
     fn write_private_creates_owner_only() {
@@ -113,13 +2239,15 @@ mod tests {
 
         write_private(&p, b"{\"key\":\"s3cr3t\"}").unwrap();
 
-        assert_eq!(mode_of(&p), 0o600);
+        use std::os::unix::fs::PermissionsExt;
+        assert_eq!(
+            std::fs::metadata(&p).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
         assert_eq!(std::fs::read(&p).unwrap(), b"{\"key\":\"s3cr3t\"}");
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    // An existing world-readable file (e.g. an export written by an
-    // older build) is tightened as well as truncated and rewritten.
     #[cfg(unix)]
     #[test]
     fn write_private_tightens_an_existing_file() {
@@ -136,7 +2264,10 @@ mod tests {
 
         write_private(&p, b"new").unwrap();
 
-        assert_eq!(mode_of(&p), 0o600);
+        assert_eq!(
+            std::fs::metadata(&p).unwrap().permissions().mode() & 0o777,
+            0o600
+        );
         assert_eq!(std::fs::read(&p).unwrap(), b"new");
         let _ = std::fs::remove_dir_all(&dir);
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -44,16 +44,6 @@ macro_rules! section {
                 Self { $($field: $default,)* }
             }
         }
-        impl $name {
-            /// Fold one layer into the accumulator: copy every field the
-            /// layer explicitly set (differing from the struct default).
-            pub(crate) fn fold_from(&mut self, other: &Self) {
-                let defaults = Self::default();
-                $( if other.$field != defaults.$field {
-                    self.$field = other.$field.clone();
-                } )*
-            }
-        }
     };
 }
 
@@ -278,6 +268,8 @@ pub struct Loaded {
     pub warnings: Vec<String>,
     /// The file the TOML layer came from, if any.
     pub file: Option<std::path::PathBuf>,
+    /// The fully layered tree, leaf origins intact (for `config show`).
+    pub merged: config::Map<String, config::Value>,
 }
 
 /// Load the layered config from defaults + env + TOML file and validate it.
@@ -286,7 +278,10 @@ pub fn load() -> Result<Loaded, ConfigError> {
 
     let mut file_layer: Option<config::Map<String, config::Value>> = None;
     let mut file_path: Option<std::path::PathBuf> = None;
-    let skip_file = std::env::var_os("DONSETCH_NO_CONFIG_FILE").is_some();
+    let skip_file = std::env::var("DONSETCH_NO_CONFIG_FILE")
+        .ok()
+        .map(|v| v.trim().to_ascii_lowercase())
+        .is_some_and(|v| !matches!(v.as_str(), "0" | "false" | "off" | "no"));
     if !skip_file {
         match toml_path() {
             Some(path) => {
@@ -295,10 +290,14 @@ pub fn load() -> Result<Loaded, ConfigError> {
                     message: format!("unreadable ({e})"),
                 })?;
                 let source = config::File::from_str(&text, config::FileFormat::Toml);
-                file_layer = Some(source.collect().map_err(|e| ConfigError::File {
+                let mut map = source.collect().map_err(|e| ConfigError::File {
                     path: path.display().to_string(),
                     message: e.to_string(),
-                })?);
+                })?;
+                // from_str leaves origins unstamped: stamp every leaf
+                // with the file label so the display can name it.
+                restamp_origins(&mut map, &Some(format!("file:{}", path.display())));
+                file_layer = Some(map);
                 file_path = Some(path);
             }
             None => {
@@ -325,73 +324,87 @@ pub fn load() -> Result<Loaded, ConfigError> {
         return Err(ConfigError::Env(e.clone()));
     }
 
-    let mut raw = DonsetchConfig::default();
-    if let Some(file) = file_layer {
-        // Deserialize the file layer on its own so unknown keys fail loudly
-        // with the file path attached, then fold into the merged struct.
-        let file_cfg = deserialize_layer_table(&file).map_err(|m| ConfigError::File {
+    // Validate the file layer on its own so unknown keys and bad types
+    // fail loudly with the file path attached, exactly once.
+    if let Some(file) = &file_layer {
+        deserialize_layer_table(file).map_err(|m| ConfigError::File {
             path: file_path
                 .as_ref()
                 .map(|p| p.display().to_string())
                 .unwrap_or_default(),
             message: m.to_string(),
         })?;
-        fold(&mut raw, &file_cfg);
     }
+
+    // The config crate's builder does the layering: sources are added
+    // bottom-up (defaults < legacy < file < new env) and each leaf of
+    // the merged tree carries the origin of the layer that won it.
+    // Presence is preserved by the builder, so a layer setting a field
+    // back to its default value still wins and still owns the origin.
+    let mut builder = config::Config::builder();
+    builder = builder.add_source(
+        config::Config::try_from(&DonsetchConfig::default())
+            .map_err(|e| ConfigError::Env(format!("serializing defaults: {e}")))?,
+    );
     if !legacy_map.is_empty() {
-        let legacy_cfg = deserialize_layer_table(&legacy_map)?;
-        fold(&mut raw, &legacy_cfg);
+        builder = builder.add_source(MapSource(legacy_map));
+    }
+    if let Some(file) = file_layer {
+        builder = builder.add_source(MapSource(file));
     }
     if !env_map.is_empty() {
-        let env_cfg = deserialize_layer_table(&env_map)?;
-        fold(&mut raw, &env_cfg);
+        builder = builder.add_source(MapSource(env_map));
     }
+    let merged = builder
+        .build()
+        .map_err(|e| ConfigError::Env(e.to_string()))?;
+    let raw: DonsetchConfig = merged
+        .clone()
+        .try_deserialize()
+        .map_err(|e| ConfigError::Env(e.to_string()))?;
 
     validate(&raw)?;
     Ok(Loaded {
         config: raw,
         warnings,
         file: file_path,
+        merged: merged
+            .collect()
+            .map_err(|e| ConfigError::Env(e.to_string()))?,
     })
+}
+
+/// Recursively restamp every leaf origin in a layer map: used for the
+/// TOML file (from_str leaves origins unstamped).
+fn restamp_origins(map: &mut config::Map<String, config::Value>, origin: &Option<String>) {
+    for value in map.values_mut() {
+        if let config::ValueKind::Table(inner) = &mut value.kind {
+            restamp_origins(inner, origin);
+        }
+        let kind = std::mem::replace(&mut value.kind, config::ValueKind::Nil);
+        *value = config::Value::new(origin.as_ref(), kind);
+    }
+}
+
+#[derive(Debug, Clone)]
+struct MapSource(config::Map<String, config::Value>);
+impl config::Source for MapSource {
+    fn collect(&self) -> Result<config::Map<String, config::Value>, config::ConfigError> {
+        Ok(self.0.clone())
+    }
+    fn clone_into_box(&self) -> Box<dyn config::Source + Send + Sync> {
+        Box::new(self.clone())
+    }
 }
 
 fn deserialize_layer_table(
     map: &config::Map<String, config::Value>,
 ) -> Result<DonsetchConfig, ConfigError> {
-    #[derive(Debug, Clone)]
-    struct MapSource(config::Map<String, config::Value>);
-    impl config::Source for MapSource {
-        fn collect(&self) -> Result<config::Map<String, config::Value>, config::ConfigError> {
-            Ok(self.0.clone())
-        }
-        fn clone_into_box(&self) -> Box<dyn config::Source + Send + Sync> {
-            Box::new(self.clone())
-        }
-    }
     let builder = config::Config::builder().add_source(MapSource(map.clone()));
     builder
         .build()
         .and_then(|c| c.try_deserialize::<DonsetchConfig>())
         .map_err(|e| ConfigError::Env(e.to_string()))
-}
-
-/// Fold a layer into the accumulator: every field the layer explicitly
-/// set (differing from the struct default) is copied over the current
-/// value. Later layers win.
-fn fold(dst: &mut DonsetchConfig, src: &DonsetchConfig) {
-    dst.transport.fold_from(&src.transport);
-    dst.mcp.fold_from(&src.mcp);
-    dst.paths.fold_from(&src.paths);
-    dst.state.fold_from(&src.state);
-    dst.proxy.fold_from(&src.proxy);
-    dst.tls.fold_from(&src.tls);
-    dst.persona.fold_from(&src.persona);
-    dst.cli.fold_from(&src.cli);
-    dst.fetch.fold_from(&src.fetch);
-    dst.bypass.fold_from(&src.bypass);
-    dst.search.fold_from(&src.search);
-    dst.browser.fold_from(&src.browser);
-    dst.debug.fold_from(&src.debug);
 }
 
 /// The file layer path: `DONSETCH_CONFIG` explicit, else the default
@@ -447,6 +460,22 @@ fn legacy_layer() -> (VMap, Vec<String>) {
             .ok()
             .and_then(|v| v.trim().parse::<i64>().ok())
     };
+    // Legacy numerics keep their historical soft semantics: a value
+    // outside the sane range is ignored with a warning, never a hard
+    // failure. (New-name env and TOML values stay strict.)
+    let put_num = |map: &mut VMap,
+                   warnings: &mut Vec<String>,
+                   path: &str,
+                   origin: &str,
+                   n: i64,
+                   lo: i64,
+                   hi: i64| {
+        if (lo..=hi).contains(&n) {
+            put(map, path, n.into(), origin);
+        } else {
+            warnings.push(format!("ignoring {origin}={n}: out of range {lo}..={hi}"));
+        }
+    };
 
     // transport
     if std::env::var("DONSETCH_TRANSPORT").as_deref() == Ok("http") {
@@ -466,7 +495,15 @@ fn legacy_layer() -> (VMap, Vec<String>) {
         );
     }
     match int_env("DONSETCH_HTTP_PORT") {
-        Some(p) => put(&mut m, "transport.port", p.into(), "DONSETCH_HTTP_PORT"),
+        Some(n) => put_num(
+            &mut m,
+            &mut warnings,
+            "transport.port",
+            "DONSETCH_HTTP_PORT",
+            n,
+            1,
+            65535,
+        ),
         None if std::env::var_os("DONSETCH_HTTP_PORT").is_some() => {
             warnings.push("ignoring DONSETCH_HTTP_PORT: not a number".into())
         }
@@ -481,11 +518,14 @@ fn legacy_layer() -> (VMap, Vec<String>) {
         );
     }
     match int_env("DONSETCH_HTTP_TIMEOUT_SECS") {
-        Some(s) => put(
+        Some(n) => put_num(
             &mut m,
+            &mut warnings,
             "transport.timeout_secs",
-            s.into(),
             "DONSETCH_HTTP_TIMEOUT_SECS",
+            n,
+            1,
+            3600,
         ),
         None if std::env::var_os("DONSETCH_HTTP_TIMEOUT_SECS").is_some() => {
             warnings.push("ignoring DONSETCH_HTTP_TIMEOUT_SECS: not a number".into())
@@ -562,11 +602,14 @@ fn legacy_layer() -> (VMap, Vec<String>) {
         );
     }
     match int_env("DONSETCH_WEB_MEMORY_CAP") {
-        Some(n) => put(
+        Some(n) => put_num(
             &mut m,
+            &mut warnings,
             "state.web_memory_cap",
-            n.into(),
             "DONSETCH_WEB_MEMORY_CAP",
+            n,
+            256,
+            100000,
         ),
         None if std::env::var_os("DONSETCH_WEB_MEMORY_CAP").is_some() => {
             warnings.push("ignoring DONSETCH_WEB_MEMORY_CAP: not a number".into())
@@ -609,11 +652,14 @@ fn legacy_layer() -> (VMap, Vec<String>) {
         );
     }
     match int_env("DONSETCH_SHADOW_DEADLINE_MS") {
-        Some(n) => put(
+        Some(n) => put_num(
             &mut m,
+            &mut warnings,
             "fetch.shadow_deadline_ms",
-            n.into(),
             "DONSETCH_SHADOW_DEADLINE_MS",
+            n,
+            1,
+            60000,
         ),
         None if std::env::var_os("DONSETCH_SHADOW_DEADLINE_MS").is_some() => {
             warnings.push("ignoring DONSETCH_SHADOW_DEADLINE_MS: not a number".into())
@@ -632,7 +678,15 @@ fn legacy_layer() -> (VMap, Vec<String>) {
         put(&mut m, "fetch.prewarm", false.into(), "DONSETCH_NO_PREWARM");
     }
     match int_env("DONSETCH_PDF_MAX_MB") {
-        Some(n) => put(&mut m, "fetch.pdf_max_mb", n.into(), "DONSETCH_PDF_MAX_MB"),
+        Some(n) => put_num(
+            &mut m,
+            &mut warnings,
+            "fetch.pdf_max_mb",
+            "DONSETCH_PDF_MAX_MB",
+            n,
+            1,
+            4096,
+        ),
         None if std::env::var_os("DONSETCH_PDF_MAX_MB").is_some() => {
             warnings.push("ignoring DONSETCH_PDF_MAX_MB: not a number".into())
         }
@@ -645,11 +699,14 @@ fn legacy_layer() -> (VMap, Vec<String>) {
         put(&mut m, "fetch.ocr", on.into(), "DONSHEET_OCR");
     }
     match int_env("DONSHEET_OCR_MAX_PAGES") {
-        Some(n) => put(
+        Some(n) => put_num(
             &mut m,
+            &mut warnings,
             "fetch.ocr_max_pages",
-            n.into(),
             "DONSHEET_OCR_MAX_PAGES",
+            n,
+            1,
+            500,
         ),
         None if std::env::var_os("DONSHEET_OCR_MAX_PAGES").is_some() => {
             warnings.push("ignoring DONSHEET_OCR_MAX_PAGES: not a number".into())
@@ -694,11 +751,14 @@ fn legacy_layer() -> (VMap, Vec<String>) {
         );
     }
     match int_env("DONSETCH_BYPASS_MAX_DAILY") {
-        Some(n) => put(
+        Some(n) => put_num(
             &mut m,
+            &mut warnings,
             "bypass.max_daily",
-            n.into(),
             "DONSETCH_BYPASS_MAX_DAILY",
+            n,
+            1,
+            10000,
         ),
         None if std::env::var_os("DONSETCH_BYPASS_MAX_DAILY").is_some() => {
             warnings.push("ignoring DONSETCH_BYPASS_MAX_DAILY: not a number".into())
@@ -706,11 +766,14 @@ fn legacy_layer() -> (VMap, Vec<String>) {
         None => {}
     }
     match int_env("DONSETCH_BYPASS_TIMEOUT_SECS") {
-        Some(n) => put(
+        Some(n) => put_num(
             &mut m,
+            &mut warnings,
             "bypass.timeout_secs",
-            n.into(),
             "DONSETCH_BYPASS_TIMEOUT_SECS",
+            n,
+            1,
+            3600,
         ),
         None if std::env::var_os("DONSETCH_BYPASS_TIMEOUT_SECS").is_some() => {
             warnings.push("ignoring DONSETCH_BYPASS_TIMEOUT_SECS: not a number".into())
@@ -750,11 +813,14 @@ fn legacy_layer() -> (VMap, Vec<String>) {
         );
     }
     match int_env("DONSETCH_BYPASS_CACHE_TTL_SECS") {
-        Some(n) => put(
+        Some(n) => put_num(
             &mut m,
+            &mut warnings,
             "bypass.cache_ttl_secs",
-            n.into(),
             "DONSETCH_BYPASS_CACHE_TTL_SECS",
+            n,
+            1,
+            86400,
         ),
         None if std::env::var_os("DONSETCH_BYPASS_CACHE_TTL_SECS").is_some() => {
             warnings.push("ignoring DONSETCH_BYPASS_CACHE_TTL_SECS: not a number".into())
@@ -762,11 +828,14 @@ fn legacy_layer() -> (VMap, Vec<String>) {
         None => {}
     }
     match int_env("DONSETCH_BYPASS_CACHE_MAX_ENTRIES") {
-        Some(n) => put(
+        Some(n) => put_num(
             &mut m,
+            &mut warnings,
             "bypass.cache_max_entries",
-            n.into(),
             "DONSETCH_BYPASS_CACHE_MAX_ENTRIES",
+            n,
+            1,
+            100000,
         ),
         None if std::env::var_os("DONSETCH_BYPASS_CACHE_MAX_ENTRIES").is_some() => {
             warnings.push("ignoring DONSETCH_BYPASS_CACHE_MAX_ENTRIES: not a number".into())
@@ -808,11 +877,14 @@ fn legacy_layer() -> (VMap, Vec<String>) {
         );
     }
     match int_env("DONSEEK_RERANK_THREADS") {
-        Some(n) => put(
+        Some(n) => put_num(
             &mut m,
+            &mut warnings,
             "search.rerank_threads",
-            n.into(),
             "DONSEEK_RERANK_THREADS",
+            n,
+            0,
+            64,
         ),
         None if std::env::var_os("DONSEEK_RERANK_THREADS").is_some() => {
             warnings.push("ignoring DONSEEK_RERANK_THREADS: not a number".into())
@@ -836,10 +908,11 @@ fn legacy_layer() -> (VMap, Vec<String>) {
         let backend = match v.as_str() {
             "auto" | "" => "auto",
             "chromium" | "chrome" | "original" => "chromium",
+            "headless" | "original-headless" => "headless",
             "cloak" | "cloakbrowser" => "cloak",
             _ => {
                 warnings.push(format!(
-                    "ignoring unknown browser backend {v:?} (auto | chromium | cloak)"
+                    "ignoring unknown browser backend {v:?} (auto | chromium | headless | cloak)"
                 ));
                 ""
             }
@@ -901,37 +974,45 @@ fn legacy_layer() -> (VMap, Vec<String>) {
             "CLOAKBROWSER_CACHE_DIR",
         );
     }
-    if std::env::var_os("DONSETCH_NO_GHOST_POOL").is_some() {
+    let no_pool = std::env::var_os("DONSETCH_NO_GHOST_POOL").is_some();
+    if no_pool {
         put(
             &mut m,
             "browser.pool_slots",
             1i64.into(),
             "DONSETCH_NO_GHOST_POOL",
         );
-    }
-    match int_env("DONSETCH_GHOST_POOL_SLOTS") {
-        Some(n) => put(
-            &mut m,
-            "browser.pool_slots",
-            n.into(),
-            "DONSETCH_GHOST_POOL_SLOTS",
-        ),
-        None if std::env::var_os("DONSETCH_GHOST_POOL_SLOTS").is_some() => {
-            warnings.push("ignoring DONSETCH_GHOST_POOL_SLOTS: not a number".into())
+    } else {
+        match int_env("DONSETCH_GHOST_POOL_SLOTS") {
+            Some(n) => put_num(
+                &mut m,
+                &mut warnings,
+                "browser.pool_slots",
+                "DONSETCH_GHOST_POOL_SLOTS",
+                n,
+                0,
+                16,
+            ),
+            None if std::env::var_os("DONSETCH_GHOST_POOL_SLOTS").is_some() => {
+                warnings.push("ignoring DONSETCH_GHOST_POOL_SLOTS: not a number".into())
+            }
+            None => {}
         }
-        None => {}
     }
     if let Some(v) = std::env::var_os("DONSETCH_XVFB_DISPLAY") {
         match v
             .to_str()
             .map(|s| s.trim().trim_start_matches(':').parse::<i64>())
         {
-            Some(Ok(n)) => put(
+            Some(Ok(n)) if (0..=254).contains(&n) => put(
                 &mut m,
                 "browser.xvfb_display",
                 n.into(),
                 "DONSETCH_XVFB_DISPLAY",
             ),
+            Some(Ok(n)) => warnings.push(format!(
+                "ignoring DONSETCH_XVFB_DISPLAY={n}: out of range 0..=254"
+            )),
             _ => warnings.push("ignoring DONSETCH_XVFB_DISPLAY: not a display number".into()),
         }
     }
@@ -944,11 +1025,14 @@ fn legacy_layer() -> (VMap, Vec<String>) {
         );
     }
     match int_env("DONSETCH_PROBE_SCAN_SECS") {
-        Some(n) => put(
+        Some(n) => put_num(
             &mut m,
+            &mut warnings,
             "browser.probe_scan_secs",
-            n.into(),
             "DONSETCH_PROBE_SCAN_SECS",
+            n,
+            1,
+            3600,
         ),
         None if std::env::var_os("DONSETCH_PROBE_SCAN_SECS").is_some() => {
             warnings.push("ignoring DONSETCH_PROBE_SCAN_SECS: not a number".into())
@@ -956,11 +1040,14 @@ fn legacy_layer() -> (VMap, Vec<String>) {
         None => {}
     }
     match int_env("DONSETCH_PROBE_STALE_SECS") {
-        Some(n) => put(
+        Some(n) => put_num(
             &mut m,
+            &mut warnings,
             "browser.probe_stale_secs",
-            n.into(),
             "DONSETCH_PROBE_STALE_SECS",
+            n,
+            60,
+            604800,
         ),
         None if std::env::var_os("DONSETCH_PROBE_STALE_SECS").is_some() => {
             warnings.push("ignoring DONSETCH_PROBE_STALE_SECS: not a number".into())
@@ -1229,14 +1316,14 @@ pub(crate) fn fieldbook() -> &'static Fieldbook {
             "cert_file",
             FieldKind::Str,
             "(ambient)",
-            "extra CA cert file",
+            "extra CA cert file (additive on top of the ambient set)",
         ),
         (
             "tls",
             "cert_dir",
             FieldKind::Str,
             "(ambient)",
-            "extra CA cert directory",
+            "extra CA cert directory (additive on top of the ambient set)",
         ),
         // persona
         (
@@ -1610,6 +1697,7 @@ const RESERVED_VARS: &[&str] = &[
     "DONSETCH_CONFIG",
     "DONSETCH_NO_CONFIG_FILE",
     "DONSETCH_PLUGIN",
+    "DONSETCH_DEBUG",
     "BLESS_MCP_FIXTURES",
 ];
 
@@ -1852,44 +1940,35 @@ fn value_of(c: &DonsetchConfig, section: &str, key: &str) -> String {
     }
 }
 
-/// (section, key, current value, origin) for every documented knob.
-/// Origin = "default" | the env var that set it | "file:<path>".
-pub fn origins(c: &DonsetchConfig) -> Vec<(&'static str, &'static str, String, String)> {
+/// (section, key, current value, origin) for every documented knob:
+/// the origin comes straight off each leaf of the merged tree (the
+/// builder stamps which layer won), the value from the typed struct.
+pub fn origins(
+    merged: &config::Map<String, config::Value>,
+    c: &DonsetchConfig,
+) -> Vec<(&'static str, &'static str, String, String)> {
     let mut out = Vec::new();
-    let file = toml_path().map(|p| format!("file:{}", p.display()));
     for (section, key, _, _, _) in fieldbook() {
         let section = *section;
         let key = *key;
-        let mut origin = "default".to_string();
-        // Report the topmost setter: new env names beat legacy names,
-        // legacy names beat the file layer.
-        let s = section.to_uppercase();
-        let k = key.to_uppercase();
-        let env_name = format!("DONSETCH_{s}__{k}");
-        if std::env::var_os(&env_name).is_some() {
-            origin = env_name;
-        } else {
-            for var in LEGACY_VARS {
-                if legacy_target_of(var) == (section, key) && std::env::var_os(var).is_some() {
-                    origin = format!("legacy:{var}");
-                    break;
-                }
-            }
-            if origin == "default"
-                && let Some(file) = &file
-            {
-                origin = file.clone();
-            }
-        }
+        let origin = merged
+            .get(section)
+            .and_then(|v| match &v.kind {
+                config::ValueKind::Table(inner) => inner.get(key),
+                _ => None,
+            })
+            .and_then(config::Value::origin)
+            .map(str::to_string)
+            .unwrap_or_else(|| "default".to_string());
         out.push((section, key, value_of(c, section, key), origin));
     }
     out
 }
 
 /// Human-readable `config show` output: every knob, value, source.
-pub fn show_text(c: &DonsetchConfig) -> String {
+pub fn show_text(loaded: &Loaded) -> String {
     let mut out = String::new();
-    if let Some(path) = toml_path() {
+    if let Some(path) = &loaded.file {
         out.push_str(&format!("config file: {}\n", path.display()));
     } else {
         out.push_str("config file: (none, using env + defaults)\n");
@@ -1902,7 +1981,7 @@ pub fn show_text(c: &DonsetchConfig) -> String {
         ));
     }
     out.push('\n');
-    let rows = origins(c);
+    let rows = origins(&loaded.merged, &loaded.config);
     let mut last_section = "";
     for (section, key, value, origin) in rows {
         if section != last_section {
@@ -2041,10 +2120,13 @@ static CONFIG: OnceLock<DonsetchConfig> = OnceLock::new();
 
 /// Install a validated config (the CLI/MCP entry point does this after
 /// merging CLI flags). Errors are fatal and reported to the caller.
+/// Installing twice in one process is an error, not a silent no-op:
+/// the first install is the contract the whole daemon reads.
 pub fn install(cfg: DonsetchConfig) -> Result<(), ConfigError> {
     validate(&cfg)?;
-    let _ = CONFIG.set(cfg);
-    Ok(())
+    CONFIG
+        .set(cfg)
+        .map_err(|_| ConfigError::Env("config is already installed in this process".into()))
 }
 
 /// The process config, initializing lazily from defaults + env + file.
@@ -2119,6 +2201,243 @@ pub(crate) fn write_private(path: &std::path::Path, bytes: &[u8]) -> std::io::Re
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    fn set_env(name: &str, value: impl AsRef<std::ffi::OsStr>) {
+        unsafe { std::env::set_var(name, value) }
+    }
+
+    fn unset_env(name: &str) {
+        unsafe { std::env::remove_var(name) }
+    }
+
+    /// Snapshot-and-clear every donsetch env var (process-per-test makes
+    /// this safe; the guard restores the shell on drop so the dev's own
+    /// exports never leak into a sibling test process image).
+    struct EnvGuard {
+        saved: Vec<(String, Option<std::ffi::OsString>)>,
+    }
+
+    fn clean_env() -> EnvGuard {
+        let mut saved = Vec::new();
+        let prefixes = [
+            "DONSETCH_",
+            "DONSEEK_",
+            "DONGHOST_",
+            "DONSHEET_",
+            "DONSIFT_",
+            "CLOAKBROWSER_",
+        ];
+        // Snapshot first: mutating the env while iterating vars_os
+        // deadlocks on the env lock.
+        let snapshot: Vec<(String, std::ffi::OsString)> = std::env::vars_os()
+            .filter_map(|(k, v)| {
+                let name = k.to_str()?.to_string();
+                prefixes
+                    .iter()
+                    .any(|p| name.starts_with(p))
+                    .then_some((name, v))
+            })
+            .collect();
+        for (name, v) in snapshot {
+            unset_env(&name);
+            saved.push((name, Some(v)));
+        }
+        EnvGuard { saved }
+    }
+
+    impl Drop for EnvGuard {
+        fn drop(&mut self) {
+            for (name, value) in &self.saved {
+                match value {
+                    Some(v) => set_env(name, v),
+                    None => unset_env(name),
+                }
+            }
+        }
+    }
+
+    fn write_cfg(tmp: &std::path::Path, text: &str) -> std::path::PathBuf {
+        let dir = tmp.join(format!("cfg-{}-{}", std::process::id(), rand_suffix()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("donsetch.toml");
+        std::fs::write(&path, text).unwrap();
+        path
+    }
+
+    fn rand_suffix() -> String {
+        use std::time::{SystemTime, UNIX_EPOCH};
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+            .to_string()
+    }
+
+    /// Presence beats default-equality: a top layer that sets a field to
+    /// its own default is still a setting and must win (the old value-
+    /// difference fold dropped it and lied about the origin).
+    #[test]
+    fn layer_fold_is_by_presence_not_value() {
+        let guard = clean_env();
+        let path = write_cfg(&std::env::temp_dir(), "[mcp]\nanswer_tool = false\n");
+        set_env("DONSETCH_CONFIG", &path);
+        set_env("DONSETCH_MCP__ANSWER_TOOL", "true");
+        let loaded = load().expect("load");
+        assert!(
+            loaded.config.mcp.answer_tool,
+            "env set it true explicitly; presence must beat default-equality"
+        );
+        let rows = origins(&loaded.merged, &loaded.config);
+        let origin = rows
+            .iter()
+            .find(|(s, k, _, _)| *s == "mcp" && *k == "answer_tool")
+            .expect("answer_tool row")
+            .3
+            .clone();
+        assert_eq!(origin, "DONSETCH_MCP__ANSWER_TOOL");
+        drop(guard);
+    }
+
+    /// The documented order is defaults < legacy < file < new env; the
+    /// implementation folded legacy AFTER the file, so a legacy value
+    /// beat the TOML. Pinned now.
+    #[test]
+    fn legacy_layer_loses_to_the_file() {
+        let guard = clean_env();
+        let path = write_cfg(&std::env::temp_dir(), "[fetch]\npdf_max_mb = 44\n");
+        set_env("DONSETCH_CONFIG", &path);
+        set_env("DONSETCH_PDF_MAX_MB", "7");
+        let loaded = load().expect("load");
+        assert_eq!(
+            loaded.config.fetch.pdf_max_mb, 44,
+            "the file layer must beat the legacy env name"
+        );
+        drop(guard);
+    }
+
+    /// Legacy names keep their historical soft semantics: a value
+    /// outside the sane range warns and keeps the default, never a hard
+    /// failure (review finding: both caps used to exit 1).
+    #[test]
+    fn legacy_out_of_range_warns_and_keeps_the_default() {
+        let guard = clean_env();
+        set_env("DONSETCH_NO_CONFIG_FILE", "1");
+        set_env("DONSETCH_WEB_MEMORY_CAP", "100");
+        set_env("DONSETCH_PDF_MAX_MB", "-1");
+        let loaded = load().expect("legacy values must never fail hard");
+        assert_eq!(loaded.config.state.web_memory_cap, 4000);
+        assert_eq!(loaded.config.fetch.pdf_max_mb, 100);
+        assert!(
+            loaded
+                .warnings
+                .iter()
+                .any(|w| w.contains("DONSETCH_WEB_MEMORY_CAP=100"))
+        );
+        assert!(
+            loaded
+                .warnings
+                .iter()
+                .any(|w| w.contains("DONSETCH_PDF_MAX_MB=-1"))
+        );
+        drop(guard);
+    }
+
+    /// proxy.from_environment gates the AMBIENT proxy convention, not
+    /// the config-file slots: an explicit TOML proxy must survive the
+    /// kill switch (the old caller-side gate starved it).
+    #[test]
+    fn from_environment_off_keeps_toml_proxy_slots_alive() {
+        let guard = clean_env();
+        let path = write_cfg(
+            &std::env::temp_dir(),
+            "[proxy]\nhttp = \"http://unlocker.local:3128\"\nfrom_environment = false\n",
+        );
+        set_env("DONSETCH_CONFIG", &path);
+        let loaded = load().expect("load");
+        assert!(!loaded.config.proxy.from_environment);
+        assert_eq!(loaded.config.proxy.http, "http://unlocker.local:3128");
+        // The resolver must see the slot even with the ambient gate off.
+        let picked = crate::transport::proxy::from_env_for("http://example.com");
+        assert!(
+            picked.is_some(),
+            "an explicit TOML proxy must survive from_environment=false"
+        );
+        drop(guard);
+    }
+
+    /// A file that merely exists is not a setter for every key: only the
+    /// keys present in it carry the file origin (the old code stamped
+    /// 72/74 rows as file:).
+    #[test]
+    fn file_origin_reports_only_present_keys() {
+        let guard = clean_env();
+        let path = write_cfg(&std::env::temp_dir(), "[fetch]\nh3 = true\n");
+        set_env("DONSETCH_CONFIG", &path);
+        let loaded = load().expect("load");
+        let rows = origins(&loaded.merged, &loaded.config);
+        let file_rows: Vec<&(_, _, _, _)> =
+            rows.iter().filter(|r| r.3.starts_with("file:")).collect();
+        assert_eq!(file_rows.len(), 1, "exactly one key came from the file");
+        assert_eq!(file_rows[0].0, "fetch");
+        assert_eq!(file_rows[0].1, "h3");
+        let defaulted = rows.iter().filter(|r| !r.3.starts_with("file:")).count();
+        assert!(defaulted >= 70, "everything else stays default-origin");
+        drop(guard);
+    }
+
+    /// The legacy backend mapper dropped the headless variant; it must
+    /// map to BrowserBackend::Headless like every historical spelling.
+    #[test]
+    fn legacy_headless_backend_still_maps() {
+        let guard = clean_env();
+        set_env("DONSETCH_NO_CONFIG_FILE", "1");
+        set_env("DONSETCH_BROWSER_BACKEND", "headless");
+        let loaded = load().expect("load");
+        assert_eq!(loaded.config.browser.backend, BrowserBackend::Headless);
+        assert!(
+            loaded
+                .warnings
+                .iter()
+                .all(|w| !w.contains("unknown browser backend")),
+            "headless is a known backend: {warnings:?}",
+            warnings = loaded.warnings
+        );
+        drop(guard);
+    }
+
+    /// Kill switch wins: DONSETCH_NO_GHOST_POOL must override a slot
+    /// count, exactly like the pre-config behavior.
+    #[test]
+    fn ghost_pool_kill_switch_wins_over_slot_count() {
+        let guard = clean_env();
+        set_env("DONSETCH_NO_CONFIG_FILE", "1");
+        set_env("DONSETCH_NO_GHOST_POOL", "1");
+        set_env("DONSETCH_GHOST_POOL_SLOTS", "4");
+        let loaded = load().expect("load");
+        assert_eq!(
+            loaded.config.browser.pool_slots, 1,
+            "the kill switch must beat the count"
+        );
+        drop(guard);
+    }
+
+    /// Falsy spellings of DONSETCH_NO_CONFIG_FILE mean "the file layer
+    /// is on": only truthy values disable it.
+    #[test]
+    fn no_config_file_falsy_words_still_load_the_file() {
+        for falsy in ["0", "false", "off", "no"] {
+            let guard = clean_env();
+            let path = write_cfg(&std::env::temp_dir(), "[fetch]\nh3 = true\n");
+            set_env("DONSETCH_CONFIG", &path);
+            set_env("DONSETCH_NO_CONFIG_FILE", falsy);
+            let loaded = load().expect("load");
+            assert!(
+                loaded.config.fetch.h3,
+                "DONSETCH_NO_CONFIG_FILE={falsy} must not disable the file layer"
+            );
+            drop(guard);
+        }
+    }
 
     /// Markdown tables must never split a row: raw pipes in defaults
     /// and descriptions are escaped ("\\|"), so a data row has the

--- a/src/crawl/mod.rs
+++ b/src/crawl/mod.rs
@@ -564,7 +564,7 @@ impl Crawler {
 
         // ── Frontier seeding ───────────────────────────────
         let mut queue = FrontierQueue::with_shaper(
-            opts.shape && !crate::config::env_flag("DONSETCH_NO_CRAWL_SHAPE"),
+            opts.shape && crate::config::cfg().fetch.crawl_shape,
             opts.shape_seed.unwrap_or_else(|| {
                 use std::hash::{Hash, Hasher};
                 let mut h = std::collections::hash_map::DefaultHasher::new();

--- a/src/extract/score.rs
+++ b/src/extract/score.rs
@@ -18,7 +18,7 @@ struct Stats {
 pub fn find_main<'a>(doc: &'a Html) -> Option<ElementRef<'a>> {
     let body = doc.select(&scraper::Selector::parse("body").ok()?).next()?;
     let (body_stats, best) = walk(body, 0);
-    if std::env::var_os("DONSIFT_DEBUG").is_some() {
+    if crate::config::cfg().debug.extract {
         eprintln!(
             "[donsift] body stats: text={} link={} punct={} paras={}",
             body_stats.text_len, body_stats.link_text_len, body_stats.punct, body_stats.paras

--- a/src/fetch/bypass.rs
+++ b/src/fetch/bypass.rs
@@ -65,16 +65,6 @@ impl Default for BypassConfig {
     }
 }
 
-#[allow(dead_code)]
-fn env_bool_off(name: &str) -> bool {
-    std::env::var(name)
-        .map(|v| {
-            let v = v.trim().to_ascii_lowercase();
-            matches!(v.as_str(), "0" | "false" | "off" | "no" | "")
-        })
-        .unwrap_or(false)
-}
-
 impl BypassConfig {
     pub fn from_env() -> Self {
         // Historically this read nine env vars directly; the knobs now

--- a/src/fetch/bypass.rs
+++ b/src/fetch/bypass.rs
@@ -65,6 +65,7 @@ impl Default for BypassConfig {
     }
 }
 
+#[allow(dead_code)]
 fn env_bool_off(name: &str) -> bool {
     std::env::var(name)
         .map(|v| {
@@ -76,45 +77,28 @@ fn env_bool_off(name: &str) -> bool {
 
 impl BypassConfig {
     pub fn from_env() -> Self {
-        let mut cfg = Self::default();
-        if env_bool_off("DONSETCH_BYPASS") {
-            cfg.enabled = false;
+        // Historically this read nine env vars directly; the knobs now
+        // live in the layered config ([bypass] section). The clamps are
+        // defense-in-depth: config validation already fails loudly on
+        // out-of-range values.
+        let b = &crate::config::cfg().bypass;
+        Self {
+            enabled: b.enabled,
+            max_daily: b.max_daily.clamp(1, 10_000),
+            timeout: Duration::from_secs(b.timeout_secs.clamp(5, 600)),
+            render: b.render,
+            endpoint: if b.endpoint.trim().is_empty() {
+                PROD_ENDPOINT.to_string()
+            } else {
+                b.endpoint.trim().to_string()
+            },
+            cache_ttl: if !b.cache {
+                Duration::ZERO
+            } else {
+                Duration::from_secs(b.cache_ttl_secs)
+            },
+            cache_max: b.cache_max_entries.clamp(1, 100_000),
         }
-        if let Ok(n) = std::env::var("DONSETCH_BYPASS_MAX_DAILY")
-            && let Ok(n) = n.trim().parse::<u32>()
-        {
-            cfg.max_daily = n.clamp(1, 10_000);
-        }
-        if let Ok(s) = std::env::var("DONSETCH_BYPASS_TIMEOUT_SECS")
-            && let Ok(s) = s.trim().parse::<u64>()
-        {
-            cfg.timeout = Duration::from_secs(s.clamp(5, 600));
-        }
-        if std::env::var("DONSETCH_BYPASS_RENDER").is_ok_and(|v| {
-            let v = v.trim().to_ascii_lowercase();
-            matches!(v.as_str(), "1" | "true" | "on" | "yes")
-        }) {
-            cfg.render = true;
-        }
-        if let Ok(e) = std::env::var("DONSETCH_BYPASS_ENDPOINT")
-            && !e.trim().is_empty()
-        {
-            cfg.endpoint = e.trim().to_string();
-        }
-        if env_bool_off("DONSETCH_BYPASS_CACHE") {
-            cfg.cache_ttl = Duration::ZERO;
-        }
-        if let Ok(n) = std::env::var("DONSETCH_BYPASS_CACHE_TTL_SECS")
-            && let Ok(n) = n.trim().parse::<u64>()
-        {
-            cfg.cache_ttl = Duration::from_secs(n.clamp(0, 31_536_000));
-        }
-        if let Ok(n) = std::env::var("DONSETCH_BYPASS_CACHE_MAX_ENTRIES")
-            && let Ok(n) = n.trim().parse::<u32>()
-        {
-            cfg.cache_max = n.clamp(1, 100_000);
-        }
-        cfg
     }
 }
 
@@ -142,10 +126,14 @@ pub fn parse_key(raw: &str, default_zone: &str) -> Result<(String, String), Bypa
         }
         return Ok((token.to_string(), zone.to_string()));
     }
-    let zone = std::env::var("DONSETCH_UNLOCKER_ZONE")
-        .ok()
-        .filter(|z| !z.trim().is_empty())
-        .unwrap_or_else(|| default_zone.to_string());
+    let zone = {
+        let configured = crate::config::cfg().bypass.zone.trim().to_string();
+        if configured.is_empty() {
+            default_zone.to_string()
+        } else {
+            configured
+        }
+    };
     Ok((raw.trim().to_string(), zone))
 }
 

--- a/src/fetch/client.rs
+++ b/src/fetch/client.rs
@@ -267,8 +267,7 @@ impl Fetcher {
         // and crawl (many pages, same host) where rate limits bite.
 
         loop {
-            let env_proxy = if proxy.is_none() && !crate::config::env_flag("DONSETCH_NO_ENV_PROXY")
-            {
+            let env_proxy = if proxy.is_none() && crate::config::cfg().proxy.from_environment {
                 crate::transport::proxy::from_env_for(&current)
             } else {
                 None
@@ -612,8 +611,7 @@ impl Fetcher {
         // alt-svc that fails vanishes until a header re-vouches).
         if is_https
             && proxy.is_none()
-            && !crate::config::env_flag("DONSETCH_NO_H3")
-            && crate::config::env_flag("DONSETCH_H3")
+            && crate::config::cfg().fetch.h3
             && let Some(h3port) = crate::transport::routes::h3_route(&origin, "direct")
         {
             match crate::transport::h3::h3_fetch_direct(

--- a/src/fetch/client.rs
+++ b/src/fetch/client.rs
@@ -267,7 +267,7 @@ impl Fetcher {
         // and crawl (many pages, same host) where rate limits bite.
 
         loop {
-            let env_proxy = if proxy.is_none() && crate::config::cfg().proxy.from_environment {
+            let env_proxy = if proxy.is_none() {
                 crate::transport::proxy::from_env_for(&current)
             } else {
                 None

--- a/src/fetch/guards.rs
+++ b/src/fetch/guards.rs
@@ -68,7 +68,7 @@ pub fn is_ssrf_resolved_ip(ip: &IpAddr) -> bool {
 /// local services): DONSETCH_ALLOW_PRIVATE_EGRESS must be explicitly
 /// true to disable the SSRF guard chain end to end. Default off.
 pub(crate) fn private_egress_allowed() -> bool {
-    crate::config::env_flag("DONSETCH_ALLOW_PRIVATE_EGRESS")
+    crate::config::cfg().fetch.allow_private_egress
 }
 
 fn is_private_ip(ip: &IpAddr) -> bool {

--- a/src/fetch/shadow.rs
+++ b/src/fetch/shadow.rs
@@ -46,12 +46,12 @@ const BURST_CONCURRENCY: usize = 6;
 const MAX_FAILURES: usize = 3;
 
 fn deadline() -> std::time::Duration {
-    std::env::var("DONSETCH_SHADOW_DEADLINE_MS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .filter(|v| *v > 0)
-        .map(std::time::Duration::from_millis)
-        .unwrap_or(BURST_DEADLINE)
+    let ms = crate::config::cfg().fetch.shadow_deadline_ms;
+    if ms == 0 {
+        BURST_DEADLINE
+    } else {
+        std::time::Duration::from_millis(ms)
+    }
 }
 
 /// Should this host get page-load realism? Route memory policy:
@@ -59,11 +59,10 @@ fn deadline() -> std::time::Duration {
 /// or mixed tier-1 history) marks the host defended enough to be
 /// worth the bytes. Open hosts stay fast and document-only.
 pub fn policy_shadows(state: &GhostState, host: &str) -> bool {
-    if crate::config::env_flag("DONSETCH_NO_SHADOW_FETCH") {
-        return false;
-    }
-    if crate::config::env_flag("DONSETCH_SHADOW_FETCH") {
-        return true;
+    match crate::config::cfg().fetch.shadow_fetch {
+        crate::config::ShadowFetch::Never => return false,
+        crate::config::ShadowFetch::Always => return true,
+        crate::config::ShadowFetch::Auto => {}
     }
     let Some(p) = state.profiles.get(host) else {
         return false;

--- a/src/ghost/cache.rs
+++ b/src/ghost/cache.rs
@@ -328,11 +328,11 @@ fn ewma_update(cur: f32, samples: u32, ok: bool) -> f32 {
 /// persists). ROUTE_MEMORY_READONLY: consult on, record off (debug
 /// and A/B). Both fail closed through crate::config::env_flag.
 fn route_memory_enabled() -> bool {
-    !crate::config::env_flag("DONSETCH_NO_ROUTE_MEMORY")
+    crate::config::cfg().state.route_memory != crate::config::RouteMemory::Off
 }
 
 fn route_memory_readonly() -> bool {
-    crate::config::env_flag("DONSETCH_ROUTE_MEMORY_READONLY")
+    crate::config::cfg().state.route_memory == crate::config::RouteMemory::ReadOnly
 }
 
 // ────────────────────────── constants ──────────────────────────
@@ -1053,8 +1053,8 @@ impl GhostState {
     /// values. Does NOT save: the caller is already inside the
     /// state lock and the outcome record after it saves once.
     pub fn sync_tier1_cookies(&mut self, all: &[CookieRecord]) {
-        if crate::config::env_flag("DONSETCH_NO_COOKIE_VAULT")
-            || crate::config::env_flag("DONSETCH_NO_ROUTE_MEMORY")
+        if !crate::config::cfg().state.cookie_vault
+            || crate::config::cfg().state.route_memory == crate::config::RouteMemory::Off
         {
             return;
         }
@@ -1083,7 +1083,7 @@ impl GhostState {
     /// Cookie count for `donsetch status`: the vault must be
     /// observable, never magic.
     pub fn tier1_cookie_count(&self) -> usize {
-        !crate::config::env_flag("DONSETCH_NO_COOKIE_VAULT") as usize * self.tier1_cookies.len()
+        crate::config::cfg().state.cookie_vault as usize * self.tier1_cookies.len()
     }
 
     pub fn save(&mut self) {
@@ -1111,7 +1111,7 @@ impl GhostState {
         {
             // Allow users to disable disk persistence entirely.
             // In-memory state still works during the session.
-            if std::env::var_os("DONSEEK_NO_DISK_STATE").is_some() {
+            if crate::config::cfg().state.no_disk_state {
                 return;
             }
             let p = path();
@@ -1781,14 +1781,22 @@ mod tests {
     }
 
     #[test]
-    fn note_probe_counts_and_respects_switches() {
+    fn note_probe_counts() {
         let mut state = GhostState::default();
         state.note_probe();
         state.note_probe();
         assert_eq!(state.probes_total, 2);
+    }
+
+    // The readonly kill switch maps through the config layer
+    // (DONSETCH_ROUTE_MEMORY_READONLY); set before the first cfg() touch
+    // so the process-wide config sees it.
+    #[test]
+    fn note_probe_skips_when_readonly() {
         unsafe { std::env::set_var("DONSETCH_ROUTE_MEMORY_READONLY", "1") };
+        let mut state = GhostState::default();
         state.note_probe();
-        assert_eq!(state.probes_total, 2);
+        assert_eq!(state.probes_total, 0);
         unsafe { std::env::remove_var("DONSETCH_ROUTE_MEMORY_READONLY") };
     }
 
@@ -2583,15 +2591,31 @@ mod tests {
         // touched before the flood: it is the first evicted.
         assert!(st.tier1_cookies.iter().any(|c| c.name == "k599"));
         assert!(st.tier1_cookies.iter().all(|c| c.name != "k0"));
-        // Kill switch blocks the sync.
-        unsafe { std::env::set_var("DONSETCH_NO_COOKIE_VAULT", "1") };
-        st.sync_tier1_cookies(&[rec("post", "v", ".x.com", None)]);
-        assert!(st.tier1_cookies.iter().all(|c| c.name != "post"));
-        unsafe { std::env::remove_var("DONSETCH_NO_COOKIE_VAULT") };
         // Roundtrip through serde (persistence shape).
         let json = serde_json::to_string(&st).unwrap();
         let back: GhostState = serde_json::from_str(&json).unwrap();
         assert_eq!(back.tier1_cookies.len(), TIER1_COOKIE_MAX);
+    }
+
+    // The vault kill switch maps through the config layer
+    // (DONSETCH_NO_COOKIE_VAULT); set before the first cfg() touch.
+    #[test]
+    fn tier1_sync_honors_vault_kill_switch() {
+        unsafe { std::env::set_var("DONSETCH_NO_COOKIE_VAULT", "1") };
+        let mut st = GhostState::default();
+        let rec = CookieRecord {
+            name: "post".into(),
+            value: "v".into(),
+            domain: ".x.com".into(),
+            path: "/".into(),
+            expires_at: None,
+            secure: false,
+            http_only: false,
+            same_site: "Lax".into(),
+        };
+        st.sync_tier1_cookies(&[rec]);
+        assert!(st.tier1_cookies.iter().all(|c| c.name != "post"));
+        unsafe { std::env::remove_var("DONSETCH_NO_COOKIE_VAULT") };
     }
 
     #[test]

--- a/src/ghost/cloak.rs
+++ b/src/ghost/cloak.rs
@@ -20,7 +20,6 @@ use tar::Archive;
 const CLOAK_REPOSITORY: &str = "CloakHQ/CloakBrowser";
 const CLOAK_VERSION: &str = "146.0.7680.177.5";
 const CLOAK_SIGNING_KEY: &str = "MKFKwIhUcKWq5xTuNA0Ovg99njcDEcEJvmWYYhApvaU=";
-const CLOAK_DOWNLOAD_OPT_IN: &str = "DONSETCH_CLOAK_AUTO_DOWNLOAD";
 const DOWNLOAD_ATTEMPTS: u8 = 3;
 const MAX_ARCHIVE_BYTES: u64 = 1024 * 1024 * 1024;
 
@@ -44,6 +43,9 @@ impl BrowserBackend {
     }
 }
 
+// Production reads [browser] backend through config; this parser stays
+// for the backend-string tests and documentation.
+#[cfg_attr(not(test), allow(dead_code))]
 fn parse_backend(value: Option<&str>) -> Result<Option<BrowserBackend>, String> {
     match value {
         None | Some("") | Some("auto") => Ok(None),
@@ -60,10 +62,20 @@ fn parse_backend(value: Option<&str>) -> Result<Option<BrowserBackend>, String> 
 /// Invalid values return false here; `resolve_browser` reports the configuration
 /// error when the browser is actually acquired.
 pub fn headless_mode_requested() -> bool {
-    let requested = std::env::var_os("DONSETCH_BROWSER_BACKEND")
-        .or_else(|| std::env::var_os("DONGHOST_BROWSER_BACKEND"))
-        .map(|v| v.to_string_lossy().trim().to_ascii_lowercase());
-    parse_backend(requested.as_deref()).ok().flatten() == Some(BrowserBackend::HeadlessChromium)
+    config_backend() == Some(BrowserBackend::HeadlessChromium)
+}
+
+/// The configured backend ([browser] backend, historically
+/// DONSETCH_BROWSER_BACKEND / DONGHOST_BROWSER_BACKEND), mapped to the
+/// internal backend enum. Auto (and unknown values, which fail config
+/// validation) = no forcing.
+fn config_backend() -> Option<BrowserBackend> {
+    match crate::config::cfg().browser.backend {
+        crate::config::BrowserBackend::Auto => None,
+        crate::config::BrowserBackend::Chromium => Some(BrowserBackend::Chromium),
+        crate::config::BrowserBackend::Headless => Some(BrowserBackend::HeadlessChromium),
+        crate::config::BrowserBackend::Cloak => Some(BrowserBackend::CloakBrowser),
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -104,10 +116,7 @@ pub fn resolve_browser_without_download() -> Result<BrowserResolution, String> {
 }
 
 fn resolve_browser_with_download(allow_download: bool) -> Result<BrowserResolution, String> {
-    let requested = std::env::var_os("DONSETCH_BROWSER_BACKEND")
-        .or_else(|| std::env::var_os("DONGHOST_BROWSER_BACKEND"))
-        .map(|v| v.to_string_lossy().trim().to_ascii_lowercase());
-    let backend = parse_backend(requested.as_deref())?;
+    let backend = config_backend();
 
     if backend == Some(BrowserBackend::CloakBrowser) {
         return resolve_cloak(allow_download);
@@ -135,7 +144,7 @@ fn resolve_browser_with_download(allow_download: bool) -> Result<BrowserResoluti
 fn resolve_chromium(backend: BrowserBackend) -> Result<BrowserResolution, String> {
     let path = super::chromium_binary()?;
     let version = crate::profile::probe_version_string_at_path(&path);
-    let source = if std::env::var_os("DONGHOST_CHROME").is_some() {
+    let source = if !crate::config::cfg().browser.chromium_path.is_empty() {
         "explicit"
     } else {
         "system"
@@ -149,20 +158,27 @@ fn resolve_chromium(backend: BrowserBackend) -> Result<BrowserResolution, String
 }
 
 fn resolve_cloak(allow_download: bool) -> Result<BrowserResolution, String> {
-    let (path, source) = if let Some(raw) = std::env::var_os("CLOAKBROWSER_BINARY_PATH") {
-        let path = PathBuf::from(raw);
-        validate_binary(&path)
-            .map_err(|e| format!("CLOAKBROWSER_BINARY_PATH `{}` invalid: {e}", path.display()))?;
+    let configured_cloak_path = crate::config::cfg().browser.cloak_path.trim().to_string();
+    let (path, source) = if !configured_cloak_path.is_empty() {
+        let path = PathBuf::from(&configured_cloak_path);
+        validate_binary(&path).map_err(|e| {
+            format!(
+                "[browser] cloak_path `{}` invalid (legacy env CLOAKBROWSER_BINARY_PATH): {e}",
+                path.display()
+            )
+        })?;
         (path, "explicit")
     } else {
         let requested = requested_version()?;
         if let Some(path) = cached_binary(&requested) {
             (path, "cache")
         } else if !allow_download || !auto_download_enabled() {
-            return Err(format!(
-                "CloakBrowser binary not found; set CLOAKBROWSER_BINARY_PATH or {}=1 to download the signed public binary",
-                CLOAK_DOWNLOAD_OPT_IN
-            ));
+            return Err(
+                "CloakBrowser binary not found; set browser.cloak_path (legacy env \
+                 CLOAKBROWSER_BINARY_PATH) or browser.cloak_auto_download (legacy \
+                 DONSETCH_CLOAK_AUTO_DOWNLOAD=1) to download the signed public binary"
+                    .into(),
+            );
         } else {
             (install_public_binary()?, "downloaded")
         }
@@ -177,7 +193,9 @@ fn resolve_cloak(allow_download: bool) -> Result<BrowserResolution, String> {
 }
 
 fn auto_download_enabled() -> bool {
-    std::env::var_os(CLOAK_DOWNLOAD_OPT_IN).is_some_and(|v| v == "1")
+    // [browser] cloak_auto_download = true; the legacy
+    // DONSETCH_CLOAK_AUTO_DOWNLOAD=1 opt-in maps through the config layer.
+    crate::config::cfg().browser.cloak_auto_download
 }
 
 fn validate_binary(path: &Path) -> Result<(), String> {
@@ -204,21 +222,28 @@ fn platform_tag() -> Result<&'static str, String> {
         ("linux", "x86_64") => Ok("linux-x64"),
         ("windows", "x86_64") => Ok("windows-x64"),
         (os, arch) => Err(format!(
-            "no public CloakBrowser binary for {os} {arch}; set CLOAKBROWSER_BINARY_PATH"
+            "no public CloakBrowser binary for {os} {arch}; set browser.cloak_path \
+             (legacy env CLOAKBROWSER_BINARY_PATH)"
         )),
     }
 }
 
 fn requested_version() -> Result<String, String> {
-    let Some(raw) = std::env::var_os("CLOAKBROWSER_VERSION") else {
+    let pinned = crate::config::cfg()
+        .browser
+        .cloak_version
+        .trim()
+        .to_string();
+    if pinned.is_empty() {
         return Ok(CLOAK_VERSION.into());
-    };
-    let value = raw.to_string_lossy().trim().to_string();
+    }
+    let value = pinned;
     if valid_version(&value) {
         Ok(value)
     } else {
         Err(format!(
-            "invalid CLOAKBROWSER_VERSION `{value}`; expected a full numeric version"
+            "invalid browser.cloak_version `{value}` (legacy env CLOAKBROWSER_VERSION); \
+             expected a full numeric version"
         ))
     }
 }
@@ -231,10 +256,15 @@ fn valid_version(value: &str) -> bool {
 }
 
 fn cache_dir() -> PathBuf {
-    if let Some(path) = std::env::var_os("CLOAKBROWSER_CACHE_DIR") {
-        PathBuf::from(path)
-    } else {
+    let configured = crate::config::cfg()
+        .browser
+        .cloak_cache_dir
+        .trim()
+        .to_string();
+    if configured.is_empty() {
         crate::paths::cache_dir().join("cloakbrowser")
+    } else {
+        PathBuf::from(configured)
     }
 }
 

--- a/src/ghost/cloak.rs
+++ b/src/ghost/cloak.rs
@@ -643,6 +643,12 @@ mod tests {
         // Dondai's rule: CloakBrowser is not used unless explicitly selected.
         // A stray CLOAKBROWSER_BINARY_PATH (set for another tool) must not
         // switch the backend on its own.
+        //
+        // Isolation note: this test mutates process env and relies on
+        // nextest's process-per-test runner; the process-wide cfg()
+        // OnceLock must never have been touched before this runs
+        // (first cfg() call freezes the config layer for the whole
+        // test process). Keep it out of shared-process runners.
         static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
         let _guard = ENV_LOCK
             .lock()

--- a/src/ghost/manager.rs
+++ b/src/ghost/manager.rs
@@ -30,16 +30,14 @@ use crate::error::FetchError;
 use crate::profile::BrowserProfile;
 
 /// Pool size: default 3 warm slots. Env override
-/// `DONSETCH_GHOST_POOL_SLOTS` clamps to 1..=16; 0 falls back to the
+/// `browser.pool_slots` clamps to 1..=16; 0 falls back to the
 /// default (a zero-slot pool would disable the warm path entirely,
-/// which the kill switch owns); `DONSETCH_NO_GHOST_POOL` forces the
-/// legacy single-slot path.
+/// which the kill switch owns). The legacy `DONSETCH_NO_GHOST_POOL`
+/// kill switch maps to the same single-slot path through the config
+/// layer.
 fn pool_slots(default: usize) -> usize {
-    pool_size(
-        std::env::var_os("DONSETCH_NO_GHOST_POOL").is_some(),
-        std::env::var("DONSETCH_GHOST_POOL_SLOTS").ok().as_deref(),
-        default,
-    )
+    let n = crate::config::cfg().browser.pool_slots;
+    pool_size(n == 1, (n > 1).then(|| n.to_string()).as_deref(), default)
 }
 
 /// Sizing rule: kill switch > explicit > default; explicit clamps
@@ -192,7 +190,7 @@ impl GhostManager {
         // A forced headless backend does not need a virtual display. Avoid
         // starting Xvfb so the selection is explicit in both process and args.
         let (display, xvfb) = if super::cloak::headless_mode_requested() {
-            if std::env::var_os("DONGHOST_DEBUG").is_some() {
+            if crate::config::cfg().debug.ghost {
                 eprintln!("[ghost] headless backend selected, skipping Xvfb");
             }
             (None, None)
@@ -200,7 +198,7 @@ impl GhostManager {
             match super::xvfb::Xvfb::start().await {
                 Ok(xvfb) => {
                     let disp = xvfb.display_env();
-                    if std::env::var_os("DONGHOST_DEBUG").is_some() {
+                    if crate::config::cfg().debug.ghost {
                         eprintln!("[ghost] Xvfb started on {disp}");
                     }
                     (Some(disp), Some(xvfb))
@@ -214,7 +212,7 @@ impl GhostManager {
             }
         } else if is_termux {
             // Termux: no Xvfb needed. Ghost uses --headless=new.
-            if std::env::var_os("DONGHOST_DEBUG").is_some() {
+            if crate::config::cfg().debug.ghost {
                 eprintln!("[ghost] Termux detected, using headless mode (no Xvfb)");
             }
             (None, None)
@@ -305,7 +303,7 @@ impl GhostManager {
             Some(g) => !g.thaw(),
         };
         if need_launch {
-            if std::env::var_os("DONGHOST_DEBUG").is_some() {
+            if crate::config::cfg().debug.ghost {
                 eprintln!("[pool] launch slot {} (thaw fail or empty)", idx);
             }
             if let Some(mut old) = guard.ghost.take() {
@@ -313,7 +311,7 @@ impl GhostManager {
             }
             guard.ghost = Some(Ghost::launch(profile, self.display.as_deref()).await?);
         } else {
-            if std::env::var_os("DONGHOST_DEBUG").is_some() {
+            if crate::config::cfg().debug.ghost {
                 eprintln!("[pool] warm serve slot {}", idx);
             }
             // Warm slot served the job: pool receipt. The kill switch
@@ -364,7 +362,7 @@ impl GhostManager {
                 };
                 if g.is_frozen() {
                     if idle > REAP_AFTER {
-                        if std::env::var_os("DONGHOST_DEBUG").is_some() {
+                        if crate::config::cfg().debug.ghost {
                             eprintln!("[pool] reap slot {}", idx);
                         }
                         if let Some(mut dead) = guard.ghost.take() {

--- a/src/ghost/mod.rs
+++ b/src/ghost/mod.rs
@@ -153,7 +153,7 @@ pub fn default_chrome_args(
 /// Whether sandbox is disabled via explicit opt-in.
 /// Used for testing that default launch is safe.
 pub fn sandbox_opt_in_enabled() -> bool {
-    std::env::var_os("DONGHOST_NO_SANDBOX").is_some_and(|v| v == "1")
+    crate::config::cfg().browser.no_sandbox
 }
 
 /// Resolve the Chromium-family binary used by DonGhost.
@@ -180,6 +180,9 @@ pub fn chrome_binary() -> Result<String, FetchError> {
 }
 
 fn chromium_binary() -> Result<String, String> {
+    if !crate::config::cfg().browser.chromium_path.is_empty() {
+        return Ok(crate::config::cfg().browser.chromium_path.clone());
+    }
     if let Some(p) = std::env::var_os("DONGHOST_CHROME") {
         let path = PathBuf::from(p);
         if !is_executable(&path) {
@@ -639,7 +642,7 @@ impl Ghost {
         // unavailable (e.g. containers without user-namespace support
         // or AppArmor restrictions). Never enabled by default :
         // requires explicit env var and prints a loud warning.
-        if std::env::var_os("DONGHOST_NO_SANDBOX").is_some_and(|v| v == "1") {
+        if crate::config::cfg().browser.no_sandbox {
             eprintln!(
                 "[ghost] WARNING: DONGHOST_NO_SANDBOX=1 : launching Chrome with --no-sandbox and --disable-setuid-sandbox. This disables the Chromium sandbox and is UNSAFE. Only use in isolated containers."
             );
@@ -2024,19 +2027,10 @@ mod sandbox_tests {
     }
 
     #[test]
-    fn sandbox_opt_in_requires_explicit_env() {
-        // Ensure default is safe without env var.
-        // Save and restore to avoid flakiness.
-        let prev = std::env::var_os("DONGHOST_NO_SANDBOX");
-        unsafe { std::env::remove_var("DONGHOST_NO_SANDBOX") };
+    fn sandbox_opt_in_is_config_driven() {
+        // The env mapping (DONGHOST_NO_SANDBOX=1) is covered by the
+        // config-layer tests; here only the runtime default contract.
         assert!(!sandbox_opt_in_enabled());
-        unsafe { std::env::set_var("DONGHOST_NO_SANDBOX", "1") };
-        assert!(sandbox_opt_in_enabled());
-        unsafe { std::env::set_var("DONGHOST_NO_SANDBOX", "0") };
-        assert!(!sandbox_opt_in_enabled());
-        match prev {
-            Some(v) => unsafe { std::env::set_var("DONGHOST_NO_SANDBOX", v) },
-            None => unsafe { std::env::remove_var("DONGHOST_NO_SANDBOX") },
-        }
+        assert!(!crate::config::DonsetchConfig::default().browser.no_sandbox);
     }
 }

--- a/src/ghost/mod.rs
+++ b/src/ghost/mod.rs
@@ -310,7 +310,12 @@ fn playwright_entry_suffixes() -> &'static [&'static str] {
 /// Linux (Playwright honors XDG_CACHE_HOME when set).
 fn playwright_registry_roots() -> Vec<PathBuf> {
     let mut roots = Vec::new();
-    if let Some(ov) = std::env::var_os("PLAYWRIGHT_BROWSERS_PATH") {
+    // The config knob wins when set; otherwise the ambient standard
+    // var still applies (mirror-when-set semantics).
+    let cfg_root = &crate::config::cfg().browser.playwright_path;
+    if !cfg_root.is_empty() {
+        roots.push(PathBuf::from(cfg_root));
+    } else if let Some(ov) = std::env::var_os("PLAYWRIGHT_BROWSERS_PATH") {
         roots.push(PathBuf::from(ov));
     }
     #[cfg(not(windows))]

--- a/src/ghost/mod.rs
+++ b/src/ghost/mod.rs
@@ -180,14 +180,14 @@ pub fn chrome_binary() -> Result<String, FetchError> {
 }
 
 fn chromium_binary() -> Result<String, String> {
-    if !crate::config::cfg().browser.chromium_path.is_empty() {
-        return Ok(crate::config::cfg().browser.chromium_path.clone());
-    }
-    if let Some(p) = std::env::var_os("DONGHOST_CHROME") {
-        let path = PathBuf::from(p);
+    // `browser.chromium_path` already layers the legacy DONGHOST_CHROME
+    // env var, so the config value is the single explicit source here.
+    let configured = &crate::config::cfg().browser.chromium_path;
+    if !configured.is_empty() {
+        let path = PathBuf::from(configured);
         if !is_executable(&path) {
             return Err(format!(
-                "DONGHOST_CHROME is not an executable: {}",
+                "browser.chromium_path (legacy DONGHOST_CHROME) is not an executable: {}",
                 path.display()
             ));
         }

--- a/src/ghost/ops.rs
+++ b/src/ghost/ops.rs
@@ -142,7 +142,7 @@ pub async fn solve(
             }
         }
 
-        if std::env::var_os("DONGHOST_DEBUG").is_some() {
+        if crate::config::cfg().debug.ghost {
             eprintln!(
                 "[ghost] t={:.0?} html={}B verdict={:?} challenged={} streak={}",
                 start.elapsed(),
@@ -281,7 +281,7 @@ pub async fn ghost_fetch(
         html = match ghost.outer_html().await {
             Ok(h) => h,
             Err(e) => {
-                if std::env::var_os("DONGHOST_DEBUG").is_some() {
+                if crate::config::cfg().debug.ghost {
                     eprintln!(
                         "[ghost_fetch] outer_html err at t={:?}: {e}",
                         start.elapsed()
@@ -509,7 +509,7 @@ pub async fn ghost_fetch(
         }
         let dead_threshold = if cur_len < 5000 { 8 } else { 15 };
         if dead_streak >= dead_threshold {
-            if std::env::var_os("DONGHOST_DEBUG").is_some() {
+            if crate::config::cfg().debug.ghost {
                 eprintln!(
                     "[ghost_fetch] dead DOM: static + visible<80 for {dead_streak} polls, exiting early"
                 );
@@ -519,7 +519,7 @@ pub async fn ghost_fetch(
 
         prev_len = cur_len;
 
-        if std::env::var_os("DONGHOST_DEBUG").is_some() {
+        if crate::config::cfg().debug.ghost {
             eprintln!(
                 "[ghost_fetch] t={:.0?} html={}B visible={} challenged=false streak={} dead={}",
                 start.elapsed(),
@@ -545,7 +545,7 @@ pub async fn ghost_fetch(
     // checks visible text first.
     let final_verdict = walls::detect_dom_smart(html.as_bytes());
     if matches!(final_verdict, Verdict::Challenge(_) | Verdict::Blocked) {
-        if std::env::var_os("DONGHOST_DEBUG").is_some() {
+        if crate::config::cfg().debug.ghost {
             eprintln!(
                 "[ghost_fetch] timeout on challenge page ({:?}), flagging as captcha",
                 final_verdict

--- a/src/ghost/probe.rs
+++ b/src/ghost/probe.rs
@@ -51,28 +51,27 @@ const PROBE_STALE_SECS: u64 = 6 * 3600;
 /// Test hooks for the live battery (seconds; the production
 /// defaults above apply when unset). Never documented for users.
 fn scan_interval() -> Duration {
-    std::env::var("DONSETCH_PROBE_SCAN_SECS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .filter(|v| *v > 0)
-        .map(Duration::from_secs)
-        .unwrap_or(SCAN_INTERVAL_SECS_DUR)
+    let secs = crate::config::cfg().browser.probe_scan_secs;
+    if secs == 0 {
+        SCAN_INTERVAL_SECS_DUR
+    } else {
+        Duration::from_secs(secs)
+    }
 }
 
 fn probe_stale_secs() -> u64 {
-    std::env::var("DONSETCH_PROBE_STALE_SECS")
-        .ok()
-        .and_then(|v| v.parse::<u64>().ok())
-        .unwrap_or(PROBE_STALE_SECS)
+    let secs = crate::config::cfg().browser.probe_stale_secs;
+    if secs == 0 { PROBE_STALE_SECS } else { secs }
 }
 
 /// Probing on/off, composed of the dedicated switch and the route
 /// memory switches (a read-only or disabled memory makes probing
 /// pointless).
 fn probes_enabled() -> bool {
-    !crate::config::env_flag("DONSETCH_NO_ROUTE_PROBES")
-        && !crate::config::env_flag("DONSETCH_NO_ROUTE_MEMORY")
-        && !crate::config::env_flag("DONSETCH_ROUTE_MEMORY_READONLY")
+    let c = crate::config::cfg();
+    c.browser.route_probes
+        && c.state.route_memory != crate::config::RouteMemory::Off
+        && c.state.route_memory != crate::config::RouteMemory::ReadOnly
 }
 
 /// Spawn the background prober. Daemon modes only: one-shot CLI

--- a/src/ghost/xvfb.rs
+++ b/src/ghost/xvfb.rs
@@ -28,10 +28,8 @@ mod linux {
     /// multi-daemon hosts (two sessions sharing :99 is supported,
     /// but separate displays are cheaper when both are hot).
     fn display_num() -> u8 {
-        std::env::var_os("DONSETCH_XVFB_DISPLAY")
-            .and_then(|v| v.to_string_lossy().parse::<u8>().ok())
-            .filter(|n| (1..=254).contains(n))
-            .unwrap_or(99)
+        let n = crate::config::cfg().browser.xvfb_display;
+        if (1..=254).contains(&n) { n as u8 } else { 99 }
     }
 
     /// Startup gate so two sessions racing for a shared display
@@ -221,7 +219,7 @@ mod linux {
                 )));
             }
 
-            if std::env::var_os("DONGHOST_DEBUG").is_some() {
+            if crate::config::cfg().debug.ghost {
                 eprintln!("[ghost] Xvfb started on {display}");
             }
             Ok(Self {

--- a/src/handles.rs
+++ b/src/handles.rs
@@ -100,7 +100,7 @@ fn path() -> PathBuf {
 /// resolution (is_handle returns false, so resolve_fetch_url
 /// refuses handles). Default: on.
 pub fn handles_enabled() -> bool {
-    !matches!(std::env::var("DONSETCH_URL_HANDLES").as_deref(), Ok("off"))
+    crate::config::cfg().mcp.url_handles
 }
 
 /// Generate a random, unguessable handle ID: prefix + 8 base62 chars

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 pub mod adapters;
 pub mod auth;
 pub mod cli;
-mod config;
+pub mod config;
 pub mod cpu;
 pub mod crawl;
 pub mod detect;

--- a/src/main.rs
+++ b/src/main.rs
@@ -55,7 +55,7 @@ fn config_cli(args: &[String]) {
             if rest.iter().any(|a| a == "--markdown") {
                 println!("{}", config::show_markdown());
             } else {
-                print!("{}", config::show_text(&loaded.config));
+                print!("{}", config::show_text(&loaded));
             }
         }
         Err(e) => {
@@ -91,6 +91,18 @@ async fn main() {
         unsafe {
             libc::signal(libc::SIGPIPE, libc::SIG_DFL);
         }
+    }
+
+    // Every command hard-fails on a broken config (the lazy fallback
+    // stays for library callers): a user must see the config error,
+    // never a silent run on defaults. `config show` loads itself so
+    // it can print the layers even when env values are bad; help and
+    // version read no config at all.
+    if !matches!(
+        cmd,
+        "config" | "help" | "--help" | "-h" | "version" | "-v" | "--version"
+    ) {
+        load_and_install_config(&args);
     }
 
     match cmd {

--- a/src/main.rs
+++ b/src/main.rs
@@ -124,8 +124,9 @@ async fn main() {
             // Transport selection: the --http flag wins, then the
             // layered config ([transport] kind via TOML or env) for
             // launchers that can't pass flags, then stdio. Host/port:
-            // flags beat the config.
-            load_and_install_config(&args);
+            // flags beat the config. The config is already installed
+            // by the block above; installing twice made install()
+            // fail its one-shot check and the daemon exit.
             #[cfg(feature = "http")]
             if config::cfg().transport.kind == config::TransportKind::Http {
                 let host = config::cfg().transport.host.clone();

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,6 +1,69 @@
 use donsetch::cli;
+use donsetch::config;
 use donsetch::dev;
 use donsetch::mcp;
+
+/// Load the layered config, apply CLI overrides, install it process-wide.
+/// Fatal on any config error: a bad knob must stop the daemon loudly.
+fn load_and_install_config(args: &[String]) -> &'static config::DonsetchConfig {
+    let mut c = match config::load() {
+        Ok(loaded) => {
+            for w in &loaded.warnings {
+                eprintln!("[donsetch config] {w}");
+            }
+            loaded.config
+        }
+        Err(e) => {
+            eprintln!("donsetch: {e}");
+            std::process::exit(1);
+        }
+    };
+    if args.iter().any(|a| a == "--http") {
+        c.transport.kind = config::TransportKind::Http;
+    }
+    if let Some(h) = get_arg_value(args, "--host") {
+        c.transport.host = h;
+    }
+    if let Some(p) = get_arg_value(args, "--port") {
+        match p.parse::<u16>() {
+            Ok(port) if port != 0 => c.transport.port = port,
+            _ => {
+                eprintln!("donsetch: invalid --port {p:?}");
+                std::process::exit(1);
+            }
+        }
+    }
+    if let Err(e) = config::install(c) {
+        eprintln!("donsetch: {e}");
+        std::process::exit(1);
+    }
+    config::cfg()
+}
+
+/// `donsetch config show [--markdown] [--legacy]`
+fn config_cli(args: &[String]) {
+    let rest = &args[1..];
+    if rest.iter().any(|a| a == "--legacy") {
+        println!("{}", config::show_legacy_markdown());
+        return;
+    }
+    match config::load() {
+        Ok(loaded) => {
+            for w in &loaded.warnings {
+                eprintln!("[donsetch config] {w}");
+            }
+            if rest.iter().any(|a| a == "--markdown") {
+                println!("{}", config::show_markdown());
+            } else {
+                print!("{}", config::show_text(&loaded.config));
+            }
+        }
+        Err(e) => {
+            eprintln!("donsetch: {e}");
+            std::process::exit(1);
+        }
+    }
+}
 
 #[tokio::main]
 async fn main() {
@@ -41,23 +104,20 @@ async fn main() {
         "tools" => cli::tool::print_tools_json(),
 
         // ── Management ──
+        "config" => {
+            config_cli(&args);
+            return;
+        }
         "mcp" => {
             // Transport selection: the --http flag wins, then the
-            // DONSETCH_TRANSPORT env (stdio|http) for launchers that
-            // can't pass flags, then stdio. Host/port: flags, then
-            // env, then defaults.
+            // layered config ([transport] kind via TOML or env) for
+            // launchers that can't pass flags, then stdio. Host/port:
+            // flags beat the config.
+            load_and_install_config(&args);
             #[cfg(feature = "http")]
-            let env_http = std::env::var("DONSETCH_TRANSPORT").as_deref() == Ok("http");
-            #[cfg(feature = "http")]
-            if args.iter().any(|a| a == "--http") || env_http {
-                let host = get_arg_value(&args, "--host")
-                    .or_else(|| std::env::var("DONSETCH_HTTP_HOST").ok())
-                    .unwrap_or("127.0.0.1".to_string());
-                let port = get_arg_value(&args, "--port")
-                    .or_else(|| std::env::var("DONSETCH_HTTP_PORT").ok())
-                    .unwrap_or("8765".to_string())
-                    .parse()
-                    .unwrap_or(8765);
+            if config::cfg().transport.kind == config::TransportKind::Http {
+                let host = config::cfg().transport.host.clone();
+                let port = config::cfg().transport.port;
                 eprintln!("[mcp] starting HTTP server on {}:{}", host, port);
                 if let Err(e) = mcp::http::run(host, port).await {
                     eprintln!("mcp HTTP server: {e}");
@@ -70,17 +130,14 @@ async fn main() {
             // through to stdio : fail loudly instead. (The linux-arm64
             // and macOS-x64 prebuilt binaries are core-only.)
             #[cfg(not(feature = "http"))]
-            if args.iter().any(|a| a == "--http")
-                || std::env::var("DONSETCH_TRANSPORT").as_deref() == Ok("http")
-            {
+            if config::cfg().transport.kind == config::TransportKind::Http {
                 eprintln!(
-                    "mcp: HTTP transport requested (--http / DONSETCH_TRANSPORT=http), but this \
+                    "mcp: HTTP transport requested (--http / transport.kind = http), but this \
                      binary was built without the `http` cargo feature. Rebuild with \
                      --features http, or use a prebuilt binary that includes it."
                 );
                 std::process::exit(1);
             }
-            let _ = std::env::var("DONSETCH_TRANSPORT");
             if args.iter().any(|a| a == "--supervised") {
                 // v3 crash-only design: `--supervised` spawns a child
                 // daemon and proxies stdio; a panic-abort (release runs
@@ -190,6 +247,18 @@ async fn route_help(cmd: &str) {
             println!("  No probes, no browser launch : fast.");
             println!("  For full diagnostics, run `donsetch doctor`.");
         }
+        "config" => {
+            println!("Usage: donsetch config show [--markdown] [--legacy]");
+            println!();
+            println!("  show            Print every knob, its current value and where");
+            println!("                  it came from (default / env / file / legacy env).");
+            println!("  --markdown      Print the full knob reference table as markdown");
+            println!("                  (the source of truth for the README).");
+            println!("  --legacy        Print the legacy env var -> key mapping.");
+            println!();
+            println!("  File layer: <config-dir>/donsetch/donsetch.toml, or the path in");
+            println!("  DONSETCH_CONFIG. Skip the file layer with DONSETCH_NO_CONFIG_FILE=1.");
+        }
         "doctor" => {
             println!("Usage: donsetch doctor");
             println!();
@@ -225,18 +294,28 @@ async fn route_help(cmd: &str) {
             println!("  --port PORT         Listen on this port (default: 8765)");
             println!("  --supervised        Run with crash-recovery supervisor (stdio only)");
             println!();
+            println!("Config: layered config = defaults < legacy env < donsetch.toml");
+            println!("(<config-dir>/donsetch/donsetch.toml or DONSETCH_CONFIG=...) <");
+            println!("DONSETCH_<SECTION>__<KEY>. `donsetch config show` prints the");
+            println!("resolved table, `donsetch config show --markdown` the full knob");
+            println!("reference, `donsetch config show --legacy` the old-name map.");
+            println!();
             println!("Stdio mode (default): JSON-RPC over stdin/stdout");
             println!("HTTP mode: JSON-RPC POST at http://HOST:PORT/mcp (plus the");
             println!("            GET SSE stream and DELETE session end required by");
             println!("            streamable-HTTP clients)");
             println!();
-            println!("Environment (flags win over env):");
-            println!("  DONSETCH_TRANSPORT=http       Same as --http (stdio is the default)");
-            println!("  DONSETCH_HTTP_HOST=HOST       Same as --host");
-            println!("  DONSETCH_HTTP_PORT=PORT       Same as --port");
-            println!("  DONSETCH_HTTP_TOKEN=TOKEN     Require Authorization: Bearer TOKEN on /mcp");
-            println!("  DONSETCH_HTTP_TIMEOUT_SECS=N  Per-request timeout (default 300)");
-            println!("  DONSETCH_HTTP_CORS=1          Allow cross-origin requests (default off)");
+            println!("Environment (flags win over the config):");
+            println!("  DONSETCH_TRANSPORT__KIND=http Same as --http (stdio is the default)");
+            println!("  DONSETCH_TRANSPORT__HOST=HOST Same as --host");
+            println!("  DONSETCH_TRANSPORT__PORT=PORT Same as --port");
+            println!("  DONSETCH_TRANSPORT__TOKEN=TOKEN");
+            println!("                                Require Authorization: Bearer TOKEN on /mcp");
+            println!("  DONSETCH_TRANSPORT__TIMEOUT_SECS=N  Per-request timeout (default 300)");
+            println!("  DONSETCH_TRANSPORT__CORS=1    Allow cross-origin requests (default off)");
+            println!();
+            println!("Legacy names (DONSETCH_TRANSPORT, DONSETCH_HTTP_*, ...) still");
+            println!("work and map to the keys above; `donsetch doctor` lists them.");
         }
         "login" => {
             println!("Usage: donsetch login [domain]");
@@ -264,7 +343,6 @@ async fn route_help(cmd: &str) {
 
 /// Helper function to extract argument value from args.
 /// Returns None if the argument is not present or has no value.
-#[cfg(feature = "http")]
 fn get_arg_value(args: &[String], flag: &str) -> Option<String> {
     let mut iter = args.iter().peekable();
     while let Some(arg) = iter.next() {

--- a/src/mcp/compat.rs
+++ b/src/mcp/compat.rs
@@ -118,7 +118,7 @@ pub fn mode_from_params(params: &Value) -> ClientMode {
 /// env flags): only an explicit true value turns it on; unset, empty,
 /// or any other value leaves the handshake in charge.
 pub fn env_override() -> Option<ClientMode> {
-    if crate::config::env_flag("DONSETCH_MCP_TEXT_ONLY") {
+    if crate::config::cfg().mcp.text_only {
         Some(ClientMode::TextOnly)
     } else {
         None
@@ -329,26 +329,30 @@ mod tests {
         assert_eq!(cell.get(), ClientMode::Default);
     }
 
-    // Env-var test: nextest isolates each test in its own process.
+    // Config is frozen at first touch (nextest runs one process per
+    // test), so each of these three arms is its own test with the env
+    // state in place BEFORE the first cfg() call.
     #[test]
-    fn env_override_forces_text_only_for_any_client() {
-        unsafe {
-            std::env::remove_var("DONSETCH_MCP_TEXT_ONLY");
-        }
+    fn text_only_override_off_by_default() {
         assert_eq!(env_override(), None);
+    }
+
+    #[test]
+    fn text_only_override_true_forces_the_fold() {
         unsafe {
             std::env::set_var("DONSETCH_MCP_TEXT_ONLY", "1");
         }
         assert_eq!(env_override(), Some(ClientMode::TextOnly));
         let cell = ModeCell::new();
         assert_eq!(effective(&cell), ClientMode::TextOnly);
+    }
+
+    #[test]
+    fn text_only_override_false_stays_off() {
         // =false must NOT enable it (fail-closed flag parse).
         unsafe {
             std::env::set_var("DONSETCH_MCP_TEXT_ONLY", "false");
         }
         assert_eq!(env_override(), None);
-        unsafe {
-            std::env::remove_var("DONSETCH_MCP_TEXT_ONLY");
-        }
     }
 }

--- a/src/mcp/http.rs
+++ b/src/mcp/http.rs
@@ -63,6 +63,9 @@ const SESSION_TTL: Duration = Duration::from_secs(30 * 60);
 /// Upper bound on tracked sessions; the oldest are evicted beyond it.
 const MAX_SESSIONS: usize = 1024;
 /// Default per-request timeout when DONSETCH_HTTP_TIMEOUT_SECS is unset.
+/// Historical default; the live default lives in config ([transport]
+/// timeout_secs).
+#[allow(dead_code)]
 const DEFAULT_TIMEOUT_SECS: u64 = 300;
 /// The GET /mcp SSE stream closes itself after this long (just inside
 /// SESSION_TTL): an unbounded idle stream would hold graceful shutdown
@@ -99,25 +102,16 @@ struct HttpState {
 pub async fn run(host: String, port: u16) -> Result<(), Box<dyn std::error::Error>> {
     let daemon = Arc::new(Daemon::new().await.map_err(|e| e.to_string())?);
     daemon.start_prober();
-    let auth_token = std::env::var("DONSETCH_HTTP_TOKEN")
-        .ok()
-        .filter(|t| !t.is_empty());
+    let t = crate::config::cfg().transport.clone();
+    let auth_token = (!t.token.trim().is_empty()).then_some(t.token.trim().to_string());
     let auth_enabled = auth_token.is_some();
-    let timeout = Duration::from_secs(
-        std::env::var("DONSETCH_HTTP_TIMEOUT_SECS")
-            .ok()
-            .and_then(|v| v.parse().ok())
-            .unwrap_or(DEFAULT_TIMEOUT_SECS),
-    );
+    let timeout = Duration::from_secs(t.timeout_secs);
 
     // CORS is off by default: MCP clients are processes, not browsers,
     // and a permissive layer would let any webpage open in a local
     // browser POST to a localhost instance and read the responses.
-    // Browser-based clients can opt in with DONSETCH_HTTP_CORS.
-    let cors_enabled = matches!(
-        std::env::var("DONSETCH_HTTP_CORS").as_deref(),
-        Ok("1" | "true" | "on")
-    );
+    // Browser-based clients can opt in with [transport] cors = true.
+    let cors_enabled = t.cors;
     validate_http_config(cors_enabled, auth_enabled)?;
 
     let state = HttpState {

--- a/src/mcp/server/answer_tool.rs
+++ b/src/mcp/server/answer_tool.rs
@@ -51,7 +51,7 @@ pub(super) async fn answer_tool(
 ) -> Value {
     // Kill switch (law 6): honest-off state. tools/list hides the
     // tool too when this is set (see tools::list).
-    if crate::config::env_flag("DONSETCH_NO_ANSWER_TOOL") {
+    if !crate::config::cfg().mcp.answer_tool {
         return tool_error("answer: web_answer is disabled (DONSETCH_NO_ANSWER_TOOL)");
     }
     daemon.refresh_vault().await;

--- a/src/mcp/server/fetch_tool.rs
+++ b/src/mcp/server/fetch_tool.rs
@@ -1498,7 +1498,7 @@ pub(super) async fn ghost_escalate(
             // CDP timeouts on first attempt are transient : the
             // browser was still warming up. Retry once before
             // conceding a permanent failure.
-            if std::env::var_os("DONGHOST_DEBUG").is_some() {
+            if crate::config::cfg().debug.ghost {
                 eprintln!("[ghost_escalate] first attempt failed: {e}, retrying...");
             }
             ops::ghost_fetch(&mut g, url, std::time::Duration::from_secs(20))
@@ -1512,7 +1512,7 @@ pub(super) async fn ghost_escalate(
         &format!("captcha={} dom={}KB", page.captcha, page.html.len() / 1024),
         t1.elapsed().as_millis(),
     );
-    if std::env::var_os("DONGHOST_DEBUG").is_some() {
+    if crate::config::cfg().debug.ghost {
         let safe: String = host
             .chars()
             .map(|c| if c.is_alphanumeric() { c } else { '_' })

--- a/src/mcp/server/mod.rs
+++ b/src/mcp/server/mod.rs
@@ -81,7 +81,7 @@ impl Daemon {
             let sessions = crate::ghost::cache::load_session_cookies();
             fetcher.import_cookies(&sessions).await;
             // Tier-1 jar persistence (v4 phase 1.4), kill-switched.
-            if !crate::config::env_flag("DONSETCH_NO_COOKIE_VAULT") {
+            if crate::config::cfg().state.cookie_vault {
                 let jar = state.lock().await.tier1_cookies.clone();
                 fetcher.import_cookies(&jar).await;
             }
@@ -140,7 +140,7 @@ impl Daemon {
     /// Called once the daemon is inside its runtime; one-shot CLI
     /// paths never call it, so short-lived processes stay clean.
     pub fn start_prober(self: &Arc<Self>) {
-        if crate::config::env_flag("DONSETCH_NO_ROUTE_PROBES") {
+        if !crate::config::cfg().browser.route_probes {
             return;
         }
         let handle = crate::ghost::probe::spawn(Arc::clone(&self.fetcher), Arc::clone(&self.state));
@@ -186,7 +186,7 @@ impl Daemon {
             // Reset is wholesale: keep the tier-1 jar (device /
             // analytics cookies the browser-real daemon already
             // holds) so a login resync does not erase the session.
-            if !crate::config::env_flag("DONSETCH_NO_COOKIE_VAULT") {
+            if crate::config::cfg().state.cookie_vault {
                 cookies.extend(self.state.lock().await.tier1_cookies.clone());
             }
             self.fetcher.reset_to(&cookies).await;

--- a/src/mcp/server/search_tool.rs
+++ b/src/mcp/server/search_tool.rs
@@ -402,7 +402,7 @@ pub(super) async fn search_outcome(
         match byok_search_cached(daemon, query, max, intent).await {
             Ok(out) => return Ok(out),
             Err(e) => {
-                if std::env::var_os("DONSEEK_DEBUG").is_some() {
+                if crate::config::cfg().debug.search {
                     eprintln!("[byok] all providers exhausted, falling back to local: {e}");
                 }
                 // Fall through to local search.
@@ -417,7 +417,7 @@ pub(super) async fn search_outcome(
             // Local failed : if BYOK is configured and we're in
             // local-first mode, try BYOK as a last resort.
             if byok_configured && local_first {
-                if std::env::var_os("DONSEEK_DEBUG").is_some() {
+                if crate::config::cfg().debug.search {
                     eprintln!("[byok] local search failed, trying BYOK fallback: {e}");
                 }
                 match byok_search_cached(daemon, query, max, intent).await {
@@ -506,7 +506,7 @@ pub(crate) fn maybe_pre_solve(daemon: &Arc<Daemon>, top_url: Option<&str>) {
                 return; // not a known wall: the search prewarm covers it
             }
         }
-        if std::env::var_os("DONGHOST_DEBUG").is_some() {
+        if crate::config::cfg().debug.ghost {
             eprintln!(
                 "[pre-solve] kicking background solve for {} ({})",
                 host_str, url_str
@@ -551,7 +551,7 @@ pub(crate) fn maybe_pre_solve(daemon: &Arc<Daemon>, top_url: Option<&str>) {
                 replay_ok,
             );
         }
-        if std::env::var_os("DONGHOST_DEBUG").is_some() {
+        if crate::config::cfg().debug.ghost {
             eprintln!(
                 "[pre-solve] done for {} in {}ms",
                 host_str,

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -67,7 +67,7 @@ pub fn list() -> Value {
 
 /// Kill-switch visibility: a disabled tool is not advertised at all.
 fn tool_visible(name: &str) -> bool {
-    if name == "web_answer" && crate::config::env_flag("DONSETCH_NO_ANSWER_TOOL") {
+    if name == "web_answer" && !crate::config::cfg().mcp.answer_tool {
         return false;
     }
     #[cfg(feature = "rerank")]

--- a/src/memory/model.rs
+++ b/src/memory/model.rs
@@ -71,7 +71,7 @@ pub fn has_model() -> bool {
 
 fn verify_bytes(body: &[u8], sha: &str, size: usize) -> bool {
     if body.len() != size {
-        if std::env::var_os("DONGHOST_DEBUG").is_some() {
+        if crate::config::cfg().debug.ghost {
             eprintln!("[memory] verify: len {} != {}", body.len(), size);
         }
         return false;
@@ -79,7 +79,7 @@ fn verify_bytes(body: &[u8], sha: &str, size: usize) -> bool {
     let mut h = Sha256::new();
     h.update(body);
     let hex: String = h.finalize().iter().map(|b| format!("{:02x}", b)).collect();
-    if std::env::var_os("DONGHOST_DEBUG").is_some() {
+    if crate::config::cfg().debug.ghost {
         eprintln!("[memory] verify: got={} exp={}", hex, sha);
     }
     hex == sha
@@ -154,7 +154,7 @@ fn ensure_file(
         .recv()
         .map_err(|e| format!("memory: download recv for {what}: {e}"))??;
     #[cfg(feature = "rerank")]
-    if std::env::var_os("DONGHOST_DEBUG").is_some() {
+    if crate::config::cfg().debug.ghost {
         let mut h = Sha256::new();
         h.update(&body);
         let debug_sha: String = h.finalize().iter().map(|b| format!("{:02x}", b)).collect();
@@ -226,7 +226,8 @@ pub fn ensure_loaded() -> Result<&'static Arc<Embedder>, String> {
 /// The kill switch: store ingest and store search are both disabled
 /// while the flag is present in the environment.
 pub fn kill_switch() -> bool {
-    std::env::var_os("DONSETCH_NO_WEB_MEMORY").is_some()
+    // True = memory DISABLED; the config field is enable-semantics.
+    !crate::config::cfg().state.web_memory
 }
 
 /// True when the model + tokenizer files are present AND the model

--- a/src/memory/store.rs
+++ b/src/memory/store.rs
@@ -50,13 +50,17 @@ pub struct MemoryHit {
     pub score: f32,
 }
 
-/// Cap from the env when set to >= 256, else the default.
+/// Cap from the layered config ([state] web_memory_cap, historically
+/// DONSETCH_WEB_MEMORY_CAP); validation already enforces 256..=100_000
+/// for explicitly set values.
 pub fn cap() -> usize {
-    std::env::var("DONSETCH_WEB_MEMORY_CAP")
-        .ok()
-        .and_then(|v| v.trim().parse::<usize>().ok())
-        .filter(|v| *v >= 256)
-        .unwrap_or(MAX_ENTRIES_DEFAULT)
+    cap_for(crate::config::cfg())
+}
+
+/// Pure cap logic (tests drive this directly).
+fn cap_for(c: &crate::config::DonsetchConfig) -> usize {
+    let cap = c.state.web_memory_cap;
+    if cap < 256 { MAX_ENTRIES_DEFAULT } else { cap }
 }
 
 pub fn index_path() -> PathBuf {
@@ -358,7 +362,8 @@ pub fn clear() -> Result<(), String> {
 /// The kill switch: the store's ingest and search are both disabled
 /// while the flag is present in the environment.
 pub fn kill_switch() -> bool {
-    std::env::var_os("DONSETCH_NO_WEB_MEMORY").is_some()
+    // True = memory DISABLED; the config field is enable-semantics.
+    !crate::config::cfg().state.web_memory
 }
 
 #[cfg(test)]
@@ -468,19 +473,16 @@ mod tests {
         let _ = std::fs::remove_dir_all(&dir);
     }
 
-    /// The cap floor: junk or tiny values fall back to the default,
-    /// sane values pass through. Mimics the real daemon env.
-    /// SAFETY: nextest runs each test in its own process, so the
-    /// mutations below cannot race a sibling test's environ read.
+    /// The cap floor: sub-256 values are rejected at config load, so
+    /// the runtime only ever sees sane caps; the pure logic keeps the
+    /// historical floor.
     #[test]
-    fn cap_env_floor() {
-        unsafe { std::env::set_var("DONSETCH_WEB_MEMORY_CAP", "1") };
-        assert_eq!(cap(), MAX_ENTRIES_DEFAULT);
-        unsafe { std::env::set_var("DONSETCH_WEB_MEMORY_CAP", "banana") };
-        assert_eq!(cap(), MAX_ENTRIES_DEFAULT);
-        unsafe { std::env::set_var("DONSETCH_WEB_MEMORY_CAP", "300") };
-        assert_eq!(cap(), 300);
-        unsafe { std::env::remove_var("DONSETCH_WEB_MEMORY_CAP") };
-        assert_eq!(cap(), MAX_ENTRIES_DEFAULT);
+    fn cap_config_floor() {
+        let mut c = crate::config::DonsetchConfig::default();
+        c.state.web_memory_cap = 300;
+        assert_eq!(cap_for(&c), 300);
+        let mut bad = crate::config::DonsetchConfig::default();
+        bad.state.web_memory_cap = 1;
+        assert_eq!(cap_for(&bad), MAX_ENTRIES_DEFAULT);
     }
 }

--- a/src/paths.rs
+++ b/src/paths.rs
@@ -16,8 +16,14 @@ use std::path::{Component, Path, PathBuf};
 pub fn cache_dir() -> PathBuf {
     // Test/container override: everything stateful hangs off this
     // one root, so redirecting it isolates a whole daemon cleanly.
+    // The env var is read per call on purpose: tests set it late.
     if let Some(d) = std::env::var_os("DONSETCH_CACHE_DIR").filter(|v| !v.is_empty()) {
         return PathBuf::from(d);
+    }
+    // Layered config fallback ([paths] cache_dir in donsetch.toml).
+    let configured = crate::config::cfg().paths.cache_dir.trim();
+    if !configured.is_empty() {
+        return PathBuf::from(configured);
     }
     dirs::cache_dir()
         .unwrap_or_else(std::env::temp_dir)

--- a/src/pdf/blocks.rs
+++ b/src/pdf/blocks.rs
@@ -56,7 +56,7 @@ pub fn classify(pages: &[PageLines], ordered_by_page: &[Vec<Line>], ctx: &FontCt
         }
         let fusion = pages[pi].fusion.as_ref();
         classify_page_fused(lines, ctx, n_pages > 1, &mut blocks, fusion);
-        if std::env::var("DONSHEET_DEBUG").is_ok() {
+        if crate::config::cfg().debug.pdf {
             eprintln!(
                 "[classify] page {pi}/{} done ({} blocks)",
                 n_pages,

--- a/src/pdf/engine.rs
+++ b/src/pdf/engine.rs
@@ -810,7 +810,7 @@ where
                     } else {
                         m.b.atan2(m.a).to_degrees()
                     };
-                    if std::env::var("DONSHEET_DEBUG_MATRIX").is_ok() && i < 8 {
+                    if crate::config::cfg().debug.pdf_matrix && i < 8 {
                         eprintln!(
                             "[matrix] i={i} a={:.3} b={:.3} c={:.3} d={:.3} angle={angle:.1}",
                             m.a, m.b, m.c, m.d
@@ -911,7 +911,7 @@ where
                     None => Vec::new(),
                 },
             }));
-            if std::env::var("DONSHEET_DEBUG").is_ok() && pi % 50 == 0 {
+            if crate::config::cfg().debug.pdf && pi % 50 == 0 {
                 eprintln!("[engine] page {pi}/{page_count} done");
             }
         }

--- a/src/pdf/layout.rs
+++ b/src/pdf/layout.rs
@@ -138,7 +138,7 @@ pub fn assemble(page: PageChars) -> PageLines {
     let mut cur_bl = f32::NAN;
     let mut cur_size = 0f32;
     // Tolerance: half the smaller font size, at least 1.5pt.
-    let peek = std::env::var("DONSHEET_DEBUG_CHARS").is_ok();
+    let peek = crate::config::cfg().debug.pdf_chars;
     for c in chars {
         if peek {
             eprintln!(
@@ -394,7 +394,7 @@ fn build_line(cluster: &[&PdfChar], page_index: usize) -> Line {
 
     // Collapse runs of spaces and trim.
     let text = collapse_spaces(&text);
-    if std::env::var("DONSHEET_DEBUG_WORDS").is_ok() {
+    if crate::config::cfg().debug.pdf_words {
         eprintln!(
             "[words] {:?} -> {:?}",
             text,

--- a/src/pdf/mod.rs
+++ b/src/pdf/mod.rs
@@ -26,7 +26,6 @@ use crate::extract::metadata::Meta;
 pub use engine::{LoadError, OutlineItem};
 
 /// Hard input ceiling (server-side fetched PDFs can be huge).
-const DEFAULT_MAX_BYTES: usize = 100 * 1024 * 1024;
 
 #[derive(Debug)]
 pub enum PdfFailure {
@@ -114,11 +113,9 @@ fn pdf_date(raw: &Option<String>) -> Option<String> {
 
 /// Parse `bytes` into DonSift blocks with full honesty flags.
 pub fn parse(bytes: &[u8]) -> Result<ParsedPdf, PdfFailure> {
-    let limit = std::env::var("DONSETCH_PDF_MAX_MB")
-        .ok()
-        .and_then(|v| v.parse::<usize>().ok())
-        .map(|mb| mb * 1024 * 1024)
-        .unwrap_or(DEFAULT_MAX_BYTES);
+    // [fetch] pdf_max_mb (legacy DONSETCH_PDF_MAX_MB); validation
+    // enforces 1..=4096 at load, so this is always >= 1 MB.
+    let limit = crate::config::cfg().fetch.pdf_max_mb * 1024 * 1024;
     if bytes.len() > limit {
         return Err(PdfFailure::TooLarge(bytes.len()));
     }
@@ -292,7 +289,7 @@ pub fn parse(bytes: &[u8]) -> Result<ParsedPdf, PdfFailure> {
     let mut decided_hint: Option<&'static str> = None;
     // Per-page OCR confidence for PageMeta (final-text trust).
     let mut ocr_page_conf: std::collections::HashMap<usize, f32> = std::collections::HashMap::new();
-    if std::env::var("DONSHEET_DEBUG").is_ok() {
+    if crate::config::cfg().debug.pdf {
         eprintln!(
             "[ocr] candidates: {:?} (enabled={})",
             needs_ocr,
@@ -314,11 +311,11 @@ pub fn parse(bytes: &[u8]) -> Result<ParsedPdf, PdfFailure> {
                             // First page of a cascaded doc locks the winner.
                             if decided_hint.is_none() {
                                 decided_hint = Some(kind);
-                                if std::env::var("DONSHEET_DEBUG").is_ok() {
+                                if crate::config::cfg().debug.pdf {
                                     eprintln!("[ocr] recognizer locked: {kind}");
                                 }
                             }
-                            if std::env::var("DONSHEET_DEBUG").is_ok() {
+                            if crate::config::cfg().debug.pdf {
                                 eprintln!(
                                     "[ocr] page {pi}: {} lines in {:?}",
                                     olines.len(),
@@ -341,7 +338,7 @@ pub fn parse(bytes: &[u8]) -> Result<ParsedPdf, PdfFailure> {
                             ocr_pages += 1;
                         }
                         Ok((_olines, _kind)) => {
-                            if std::env::var("DONSHEET_DEBUG").is_ok() {
+                            if crate::config::cfg().debug.pdf {
                                 eprintln!(
                                     "[ocr] page {pi}: zero usable lines in {:?}",
                                     t0.elapsed()
@@ -350,7 +347,7 @@ pub fn parse(bytes: &[u8]) -> Result<ParsedPdf, PdfFailure> {
                         }
                         Err(e) => {
                             ocr_failed = true;
-                            if std::env::var("DONSHEET_DEBUG").is_ok() {
+                            if crate::config::cfg().debug.pdf {
                                 eprintln!("[ocr] page {pi} failed: {e}");
                             }
                             break;
@@ -359,7 +356,7 @@ pub fn parse(bytes: &[u8]) -> Result<ParsedPdf, PdfFailure> {
                 }
             }
             Err(e) => {
-                if std::env::var("DONSHEET_DEBUG").is_ok() {
+                if crate::config::cfg().debug.pdf {
                     eprintln!("[ocr] rasterize_pages failed: {e:?}");
                 }
             }
@@ -437,7 +434,7 @@ pub fn parse(bytes: &[u8]) -> Result<ParsedPdf, PdfFailure> {
 
     // Reading order per page. Vertical/rotated pages are an honest
     // flagged lane (best-effort; no column reconstruction in v1).
-    let dbg = std::env::var("DONSHEET_DEBUG").is_ok();
+    let dbg = crate::config::cfg().debug.pdf;
     if dbg {
         eprintln!("[parse] reading order start: {} pages", pages.len());
     }

--- a/src/pdf/ocr.rs
+++ b/src/pdf/ocr.rs
@@ -80,17 +80,16 @@ pub fn ocr_cache_dir() -> PathBuf {
     crate::paths::cache_dir().join("ocr")
 }
 
-/// Master switch. Default ON (lazy); DONSHEET_OCR=off kills the tier.
+/// Master switch. Default ON (lazy); [fetch] ocr = false (legacy
+/// DONSHEET_OCR=off) kills the tier.
 pub fn enabled() -> bool {
-    !matches!(std::env::var("DONSHEET_OCR").as_deref(), Ok("off"))
+    crate::config::cfg().fetch.ocr
 }
 
 /// Max OCR pages per document (giant scans cost; the governor is budget).
 pub fn max_pages() -> usize {
-    std::env::var("DONSHEET_OCR_MAX_PAGES")
-        .ok()
-        .and_then(|v| v.parse().ok())
-        .unwrap_or(25)
+    let n = crate::config::cfg().fetch.ocr_max_pages;
+    if n == 0 { 25 } else { n as usize }
 }
 
 #[cfg(feature = "ocr")]

--- a/src/pdf/rotate.rs
+++ b/src/pdf/rotate.rs
@@ -40,7 +40,7 @@ pub fn canonicalize(pc: &mut PageChars) -> Option<f32> {
         }
         mass[q as usize] += c.size.max(1.0);
     }
-    if std::env::var("DONSHEET_DEBUG_MATRIX").is_ok() {
+    if crate::config::cfg().debug.pdf_matrix {
         for (i, c) in pc.chars.iter().take(6).enumerate() {
             eprintln!(
                 "[rot_dbg] i={i} cp={:?} angle={:.2} size={:.2} rt={}",
@@ -52,7 +52,7 @@ pub fn canonicalize(pc: &mut PageChars) -> Option<f32> {
     if total <= 0.0 {
         return None;
     }
-    if std::env::var("DONSHEET_DEBUG").is_ok() {
+    if crate::config::cfg().debug.pdf {
         eprintln!(
             "[rotate] page {} mass: 0deg={:.0} 90deg={:.0} 180deg={:.0} 270deg={:.0} chars={} total={:.0}",
             pc.index,

--- a/src/persona.rs
+++ b/src/persona.rs
@@ -116,8 +116,13 @@ fn seed_for(host: &str, created_at: u64, generation: u32) -> u64 {
 /// Persona timezone: the operator's own TZ when sane, else UTC.
 /// (Phase 1 lets a declared proxy locale override per persona.)
 fn env_tz() -> String {
-    std::env::var("TZ")
-        .ok()
+    let configured = crate::config::cfg().persona.timezone.trim().to_string();
+    let candidate = if configured.is_empty() {
+        std::env::var("TZ").ok()
+    } else {
+        Some(configured)
+    };
+    candidate
         .map(|t| t.trim().to_string())
         .filter(|t| t.contains('/') && !t.contains(char::is_whitespace))
         .unwrap_or_else(|| "UTC".to_string())
@@ -125,17 +130,25 @@ fn env_tz() -> String {
 
 /// Persona locale: LANG/LC_ALL ("en_US.UTF-8" -> "en-US"), else en-US.
 fn env_locale() -> String {
+    let configured = crate::config::cfg().persona.locale.trim().to_string();
+    let mut sources = Vec::new();
+    if !configured.is_empty() {
+        sources.push(configured.clone());
+    }
     for var in ["LC_ALL", "LANG"] {
         if let Ok(v) = std::env::var(var) {
-            let base = v.split('.').next().unwrap_or("").replace('_', "-");
-            let mut parts = base.split('-');
-            let lang = parts.next().unwrap_or("");
-            if lang.len() >= 2 && lang.len() <= 3 && lang.chars().all(|c| c.is_ascii_lowercase()) {
-                return match parts.next() {
-                    Some(region) if !region.is_empty() => format!("{lang}-{region}"),
-                    _ => lang.to_string(),
-                };
-            }
+            sources.push(v);
+        }
+    }
+    for v in sources {
+        let base = v.split('.').next().unwrap_or("").replace('_', "-");
+        let mut parts = base.split('-');
+        let lang = parts.next().unwrap_or("");
+        if lang.len() >= 2 && lang.len() <= 3 && lang.chars().all(|c| c.is_ascii_lowercase()) {
+            return match parts.next() {
+                Some(region) if !region.is_empty() => format!("{lang}-{region}"),
+                _ => lang.to_string(),
+            };
         }
     }
     "en-US".to_string()

--- a/src/profile/mod.rs
+++ b/src/profile/mod.rs
@@ -555,6 +555,23 @@ fn probe_version_string_at_path_uncached(path: &str) -> Result<String, String> {
 fn spawn_probe_with_timeout(mut cmd: std::process::Command) -> Result<String, String> {
     use std::io::Read;
 
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        unsafe {
+            cmd.pre_exec(|| {
+                // Own process group: the timeout kill must reach the
+                // browser's descendants too, or they inherit the
+                // stdout pipe and hang the reader join forever (the
+                // itoqa-found doctor hang).
+                if libc::setpgid(0, 0) < 0 {
+                    return Err(std::io::Error::last_os_error());
+                }
+                Ok(())
+            });
+        }
+    }
+
     let mut child = cmd
         .spawn()
         .map_err(|e| format!("spawn browser version probe: {e}"))?;
@@ -651,7 +668,14 @@ fn kill_probe_tree(pid: Option<u32>) {
     }
     #[cfg(not(windows))]
     unsafe {
-        libc::kill(pid as i32, libc::SIGKILL);
+        // Kill the WHOLE group: the browser's descendants inherit the
+        // parent's stdout pipe, and only when every write end is dead
+        // does the reader thread see EOF and the join return. Killing
+        // just the parent left the pipe held open and doctor hung
+        // forever (itoqa 2026-09-11). The child runs in its own group
+        // via pre_exec setpgid, so the negative pid hits it and every
+        // descendant, not our own process group.
+        libc::kill(-(pid as i32), libc::SIGKILL);
     }
 }
 
@@ -698,7 +722,29 @@ mod locale_tests {
 
 #[cfg(test)]
 mod probe_tests {
-    use super::{BrowserProfile, Platform, parse_version_major, parse_version_string};
+    use super::{
+        BrowserProfile, Platform, parse_version_major, parse_version_string,
+        spawn_probe_with_timeout,
+    };
+
+    #[cfg(unix)]
+    #[test]
+    fn probe_timeout_kills_descendants_and_returns_bounded() {
+        // A wedged browser's descendant holds the stdout pipe. Pre-fix
+        // this hung FOREVER: the timeout killed only the parent, the
+        // grandchild kept the pipe open, and the stdout join never saw
+        // EOF. Post-fix the whole group dies and the probe fails in
+        // ~PROBE_SPAWN_TIMEOUT. A wild sleep 300 guards the fixture.
+        let mut cmd = std::process::Command::new("sh");
+        cmd.arg("-c")
+            .arg("sleep 300 & wait; echo never")
+            .stdout(std::process::Stdio::piped());
+        let start = std::time::Instant::now();
+        let out = spawn_probe_with_timeout(cmd);
+        assert!(out.is_err(), "a wedged probe must fail, not hang");
+        let secs = start.elapsed().as_secs();
+        assert!(secs < 15, "probe must be bounded, took {secs}s");
+    }
 
     #[test]
     fn brand_lists_match_chrome_151_capture() {

--- a/src/profile/mod.rs
+++ b/src/profile/mod.rs
@@ -722,14 +722,12 @@ mod locale_tests {
 
 #[cfg(test)]
 mod probe_tests {
-    use super::{
-        BrowserProfile, Platform, parse_version_major, parse_version_string,
-        spawn_probe_with_timeout,
-    };
+    use super::{BrowserProfile, Platform, parse_version_major, parse_version_string};
 
     #[cfg(unix)]
     #[test]
     fn probe_timeout_kills_descendants_and_returns_bounded() {
+        use super::spawn_probe_with_timeout;
         // A wedged browser's descendant holds the stdout pipe. Pre-fix
         // this hung FOREVER: the timeout killed only the parent, the
         // grandchild kept the pipe open, and the stdout join never saw

--- a/src/profile/mod.rs
+++ b/src/profile/mod.rs
@@ -363,8 +363,9 @@ fn probe_installed() -> Option<(u32, bool)> {
 /// Windows: read the major version + brand truth from the browser's
 /// own `BLBeacon\version` registry value. The key family decides the
 /// brand: `Software\Google\Chrome` = Google-branded; Chromium/Edge/
-/// Thorium report their own (non-Google) brands. Honours `DONGHOST_CHROME`
-/// by probing the browser family it names first.
+/// Thorium report their own (non-Google) brands. Honours the configured
+/// `browser.chromium_path` (legacy `DONGHOST_CHROME`) by probing the
+/// browser family it names first.
 #[cfg(windows)]
 fn probe_registry() -> Option<(u32, bool)> {
     use windows_sys::Win32::System::Registry as reg;
@@ -376,13 +377,13 @@ fn probe_registry() -> Option<(u32, bool)> {
         ("Software\\Microsoft\\Edge\\BLBeacon", false),
         ("Software\\Thorium\\BLBeacon", false),
     ];
-    // Sort DONGHOST_CHROME's family to the front if it doesn't already
-    // lead : cheap, and makes the explicit choice authoritative.
-    if !crate::config::cfg().browser.chromium_path.is_empty() {
-        return Some(PathBuf::from(&crate::config::cfg().browser.chromium_path));
-    }
-    if let Some(p) = std::env::var_os("DONGHOST_CHROME") {
-        let p = p.to_string_lossy().to_lowercase();
+    // Sort the configured browser's family to the front if it doesn't
+    // already lead : cheap, and makes the explicit choice authoritative.
+    // `browser.chromium_path` already layers the legacy DONGHOST_CHROME
+    // env var, so the config value is the single source here.
+    let configured = &crate::config::cfg().browser.chromium_path;
+    if !configured.is_empty() {
+        let p = configured.to_lowercase();
         for (family, key, branded) in [
             ("thorium", "Software\\Thorium\\BLBeacon", false),
             ("chrome", "Software\\Google\\Chrome\\BLBeacon", true),

--- a/src/profile/mod.rs
+++ b/src/profile/mod.rs
@@ -378,6 +378,9 @@ fn probe_registry() -> Option<(u32, bool)> {
     ];
     // Sort DONGHOST_CHROME's family to the front if it doesn't already
     // lead : cheap, and makes the explicit choice authoritative.
+    if !crate::config::cfg().browser.chromium_path.is_empty() {
+        return Some(PathBuf::from(&crate::config::cfg().browser.chromium_path));
+    }
     if let Some(p) = std::env::var_os("DONGHOST_CHROME") {
         let p = p.to_string_lossy().to_lowercase();
         for (family, key, branded) in [

--- a/src/profile/scorecard.rs
+++ b/src/profile/scorecard.rs
@@ -73,7 +73,7 @@ pub async fn capture(fetcher: &Fetcher) -> Result<FingerprintSnapshot, String> {
     // Operator debug: when DONSETCH_DEBUG_ECHO=1 the RAW echo lands
     // in /tmp/ for offline diffing against the evergreen ghost
     // capture (/tmp/ghost-echo-blob.json). Off by default.
-    if crate::config::env_flag("DONSETCH_DEBUG_ECHO") {
+    if crate::config::cfg().debug.echo_scorecard {
         let _ = std::fs::write("/tmp/tier1-echo-raw.json", &out.body);
     }
     parse_echo(&out.body, fetcher.profile().name)

--- a/src/search/byok/brightdata.rs
+++ b/src/search/byok/brightdata.rs
@@ -43,10 +43,16 @@ pub(crate) fn parse_key(key: &str) -> Result<(String, String), String> {
         }
         return Ok((token.to_string(), zone.to_string()));
     }
-    let zone = std::env::var("DONSETCH_BRIGHTDATA_ZONE")
-        .ok()
-        .filter(|z| !z.trim().is_empty())
-        .unwrap_or_else(|| DEFAULT_ZONE.to_string());
+    let configured = crate::config::cfg()
+        .search
+        .brightdata_zone
+        .trim()
+        .to_string();
+    let zone = if configured.is_empty() {
+        DEFAULT_ZONE.to_string()
+    } else {
+        configured
+    };
     Ok((key.trim().to_string(), zone))
 }
 

--- a/src/search/byok/mod.rs
+++ b/src/search/byok/mod.rs
@@ -240,7 +240,7 @@ impl ByokSearcher {
                         // Try the next provider, and if all are
                         // empty, fall back to local search.
                         last_error = format!("{provider}: empty results");
-                        if std::env::var_os("DONSEEK_DEBUG").is_some() {
+                        if crate::config::cfg().debug.search {
                             eprintln!("[byok] {provider} returned 0 results, trying next");
                         }
                         continue;
@@ -272,7 +272,7 @@ impl ByokSearcher {
                 }
                 Err(key_error) => {
                     // Log the error for debugging.
-                    if std::env::var_os("DONSEEK_DEBUG").is_some() {
+                    if crate::config::cfg().debug.search {
                         eprintln!(
                             "[byok] {provider} key={}... {}",
                             key.chars().take(8).collect::<String>(),

--- a/src/search/byok/plugin.rs
+++ b/src/search/byok/plugin.rs
@@ -406,7 +406,7 @@ fn parse_envelope(
             Some(u) if is_http_url(u) => u.to_string(),
             Some(u) => {
                 dropped += 1;
-                if std::env::var_os("DONSEEK_DEBUG").is_some() {
+                if crate::config::cfg().debug.search {
                     eprintln!("[plugin] {plugin_name}: dropped result with bad url: {u:?}");
                 }
                 continue;
@@ -439,7 +439,7 @@ fn parse_envelope(
             score,
         });
     }
-    if results.len() > MAX_RESULTS && std::env::var_os("DONSEEK_DEBUG").is_some() {
+    if results.len() > MAX_RESULTS && crate::config::cfg().debug.search {
         eprintln!(
             "[plugin] {plugin_name}: truncated {} results to {MAX_RESULTS}",
             results.len()
@@ -541,7 +541,7 @@ pub(crate) async fn run_plugin(
     match status {
         Ok(code) if code.success() => match parse_envelope(&body, name) {
             Ok((hits, degraded, dropped)) => {
-                if dropped > 0 && std::env::var_os("DONSEEK_DEBUG").is_some() {
+                if dropped > 0 && crate::config::cfg().debug.search {
                     eprintln!("[plugin] {name}: dropped {dropped} invalid result entries");
                 }
                 let ms = started.elapsed().as_millis() as u64;
@@ -595,8 +595,36 @@ fn spawn_plugin(name: &str, def: &PluginDef) -> Result<tokio::process::Child, St
     cmd.args(&def.cmd[1..])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .env("DONSETCH_PLUGIN", "1")
+        .stderr(Stdio::piped());
+    // The child inherits the ambient env by default, which must not
+    // carry the proxy convention when the operator disabled it, and
+    // must carry the config-file proxy slots when they are set.
+    let cfg = crate::config::cfg();
+    if !cfg.proxy.from_environment {
+        for var in [
+            "HTTP_PROXY",
+            "http_proxy",
+            "HTTPS_PROXY",
+            "https_proxy",
+            "ALL_PROXY",
+            "all_proxy",
+            "NO_PROXY",
+            "no_proxy",
+        ] {
+            cmd.env_remove(var);
+        }
+    }
+    for (name, val) in [
+        ("HTTP_PROXY", &cfg.proxy.http),
+        ("HTTPS_PROXY", &cfg.proxy.https),
+        ("ALL_PROXY", &cfg.proxy.all),
+        ("NO_PROXY", &cfg.proxy.no_proxy),
+    ] {
+        if !val.is_empty() {
+            cmd.env(name, val);
+        }
+    }
+    cmd.env("DONSETCH_PLUGIN", "1")
         .env("DONSETCH_PLUGIN_NAME", name)
         .current_dir(std::env::temp_dir())
         .kill_on_drop(true);

--- a/src/search/engines.rs
+++ b/src/search/engines.rs
@@ -168,7 +168,7 @@ pub fn parse(engine: &str, html: &str) -> Vec<Hit> {
     // search.yahoo.com/search pagination links, undecoded
     // r.search.yahoo.com redirects, bing.com/ck/a stubs).
     hits.retain(|h| !is_serp_url(&h.url));
-    if hits.is_empty() && std::env::var_os("DONSEEK_DEBUG").is_some() {
+    if hits.is_empty() && crate::config::cfg().debug.search {
         let dump = std::env::temp_dir().join(format!("donseek_debug_{engine}.html"));
         let dump = dump.to_string_lossy().into_owned();
         let _ = std::fs::write(&dump, html);

--- a/src/search/engines/google_wml.rs
+++ b/src/search/engines/google_wml.rs
@@ -52,10 +52,15 @@ pub fn profile_user_agent(id: Option<&str>) -> Option<&'static str> {
 }
 
 pub fn configured_user_agent() -> Option<&'static str> {
-    match std::env::var("DONSETCH_GOOGLE_PROFILE") {
-        Ok(id) => profile_user_agent(Some(&id)),
-        Err(std::env::VarError::NotPresent) => profile_user_agent(None),
-        Err(_) => None,
+    let id = crate::config::cfg()
+        .search
+        .google_profile
+        .trim()
+        .to_string();
+    if id.is_empty() {
+        profile_user_agent(None)
+    } else {
+        profile_user_agent(Some(&id))
     }
 }
 

--- a/src/search/enrich.rs
+++ b/src/search/enrich.rs
@@ -87,10 +87,11 @@ impl Searcher {
         const ENRICH_TOP: usize = 5;
         const ENRICH_TIMEOUT: Duration = Duration::from_secs(4);
 
-        // Kill switch (v4 phase 2.1): with DONSETCH_NO_PREWARM=1 no
-        // prewarm fetch ever goes on the wire, so servers see no
-        // burst at all. The honest-off state of the layer.
-        if crate::config::env_flag("DONSETCH_NO_PREWARM") {
+        // Kill switch (v4 phase 2.1): with prewarm disabled ([fetch]
+        // prewarm = false; historically DONSETCH_NO_PREWARM) no prewarm
+        // fetch ever goes on the wire, so servers see no burst at all.
+        // The honest-off state of the layer.
+        if !crate::config::cfg().fetch.prewarm {
             return;
         }
         let n = results.len().min(ENRICH_TOP);
@@ -229,7 +230,7 @@ impl Searcher {
     /// design (the provider's own ranking stands); parking is the
     /// point. Same kill switch as the inline pass.
     pub fn spawn_prewarm(self: &std::sync::Arc<Self>, results: &[Merged]) {
-        if results.is_empty() || crate::config::env_flag("DONSETCH_NO_PREWARM") {
+        if results.is_empty() || !crate::config::cfg().fetch.prewarm {
             return;
         }
         let mut owned = results.to_vec();

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -675,13 +675,13 @@ impl Searcher {
                 .filter_map(|(_, r)| r.as_ref().ok())
                 .map(|(h, _, _, _)| h.len())
                 .sum::<usize>();
-        let force_lane = std::env::var_os("DONSEEK_FORCE_GHOST_LANE").is_some();
+        let force_lane = crate::config::cfg().search.ghost_lane == crate::config::GhostLane::Always;
         let google_http_ok = outcomes
             .iter()
             .chain(&retry_outcomes)
             .any(|(engine, result)| engine_name(engine) == "google" && result.is_ok());
         let lane_permitted = self.ghost.is_some()
-            && std::env::var_os("DONSEEK_NO_GHOST_LANES").is_none()
+            && crate::config::cfg().search.ghost_lane != crate::config::GhostLane::Never
             && !self.quarantined("google_ghost");
         let lane_outcomes: Vec<(String, EngineResult)> = if lane_permitted
             && google_ghost_wanted(force_lane, google_http_ok, retry_ok, retry_hits)
@@ -834,7 +834,7 @@ impl Searcher {
         // SERP fragments. Bounded additive nudge, then re-sort.
         // DONSEEK_NO_TOPUP is the A/B kill switch for benching.
         #[cfg(feature = "rerank")]
-        if std::env::var_os("DONSEEK_NO_TOPUP").is_none() {
+        if crate::config::cfg().search.rerank_topup {
             let q = query.to_string();
             let mut owned = std::mem::take(&mut results);
             results = run_blocking_ranking(move || {

--- a/src/search/rerank.rs
+++ b/src/search/rerank.rs
@@ -79,6 +79,9 @@ mod inner {
     enum ThreadOverride<'a> {
         Unset,
         Value(&'a str),
+        /// Unreachable through the config (validation rejects
+        /// non-numeric values at load); kept for the pure-machinery tests.
+        #[cfg_attr(not(test), allow(dead_code))]
         InvalidUnicode,
     }
 
@@ -136,11 +139,15 @@ mod inner {
     fn configured_intra_threads() -> ThreadSelection {
         let effective = std::thread::available_parallelism().ok().map(|n| n.get());
         let physical = num_cpus::get_physical();
-        let raw = std::env::var("DONSEEK_RERANK_THREADS");
-        let override_value = match raw.as_deref() {
-            Ok(raw) => ThreadOverride::Value(raw),
-            Err(std::env::VarError::NotPresent) => ThreadOverride::Unset,
-            Err(std::env::VarError::NotUnicode(_)) => ThreadOverride::InvalidUnicode,
+        // Source: [search] rerank_threads in the layered config
+        // (historically DONSEEK_RERANK_THREADS). 0 = auto; unparsable
+        // values are already rejected at config load, and legacy env
+        // values warn there.
+        let configured = crate::config::cfg().search.rerank_threads;
+        let override_value = if configured == 0 {
+            ThreadOverride::Unset
+        } else {
+            ThreadOverride::Value(Box::leak(configured.to_string().into_boxed_str()))
         };
         let (selection, warning) = select_intra_threads(override_value, effective, physical);
         if let Some(warning) = warning {

--- a/src/transport/h3.rs
+++ b/src/transport/h3.rs
@@ -163,7 +163,7 @@ async fn h3_fetch_inner(
     // packet leaves.
     let resumed = crate::transport::routes::load_h3_session(authority, egress);
     if let Some(bytes) = &resumed {
-        if std::env::var_os("DONGHOST_DEBUG").is_some() {
+        if crate::config::cfg().debug.ghost {
             eprintln!("[h3] session resume armed ({} bytes)", bytes.len());
         }
         cfg.enable_early_data();
@@ -398,11 +398,11 @@ async fn h3_fetch_inner(
             }
             let _ = conn.close(true, 0, b"");
             if let Some(sess) = conn.session() {
-                if std::env::var_os("DONGHOST_DEBUG").is_some() {
+                if crate::config::cfg().debug.ghost {
                     eprintln!("[h3] session saved {} bytes", sess.len());
                 }
                 crate::transport::routes::save_h3_session(authority, egress, sess);
-            } else if std::env::var_os("DONGHOST_DEBUG").is_some() {
+            } else if crate::config::cfg().debug.ghost {
                 eprintln!("[h3] no session ticket before close");
             }
             QUIC_TOTAL_CONN.fetch_add(1, Ordering::Relaxed);
@@ -482,7 +482,7 @@ pub async fn h3_fetch_direct(
     user_headers: Vec<(String, String)>,
     timeout: Option<Duration>,
 ) -> Result<(H3Out, QuicStats), FetchError> {
-    if std::env::var_os("DONGHOST_DEBUG").is_some() {
+    if crate::config::cfg().debug.ghost {
         eprintln!("[h3] attempt {host}:{port}{path}");
     }
     let profile = crate::profile::BrowserProfile::chrome_150(crate::profile::Platform::host());
@@ -513,7 +513,7 @@ pub async fn h3_fetch_direct(
         timeout,
     };
     let (out, stats) = h3_fetch_heat(&req, &profile).await?;
-    if std::env::var_os("DONGHOST_DEBUG").is_some() {
+    if crate::config::cfg().debug.ghost {
         eprintln!(
             "[h3] stats {}:{} early={} resumed={} hs_ms={} total_ms={} pkts_in={} pkts_out={}",
             host,

--- a/src/transport/proxy.rs
+++ b/src/transport/proxy.rs
@@ -663,11 +663,16 @@ pub fn from_env_for(url: &str) -> Option<Proxy> {
     };
     let env_val = match explicit {
         Some(v) => v.to_string(),
-        None => std::env::var(env_name)
+        // The ambient env layer is gated by proxy.from_environment:
+        // explicit [proxy] slots stay live even when the ambient
+        // convention is disabled (the gate must never starve a TOML
+        // proxy).
+        None if crate::config::cfg().proxy.from_environment => std::env::var(env_name)
             .or_else(|_| std::env::var(env_name.to_lowercase()))
             .or_else(|_| std::env::var("ALL_PROXY"))
             .or_else(|_| std::env::var("all_proxy"))
             .ok()?,
+        None => return None,
     };
     let env_val = env_val.trim();
     if env_val.is_empty() {

--- a/src/transport/proxy.rs
+++ b/src/transport/proxy.rs
@@ -23,9 +23,14 @@ const PROXY_TIMEOUT: Duration = Duration::from_secs(12);
 /// suffix match: "example.com" matches "foo.example.com".
 /// "*" disables all proxying.
 fn no_proxy_match(host: &str) -> bool {
-    let no_proxy = std::env::var("NO_PROXY")
-        .or_else(|_| std::env::var("no_proxy"))
-        .unwrap_or_default();
+    let cfg = crate::config::cfg();
+    let no_proxy = if !cfg.proxy.no_proxy.is_empty() {
+        cfg.proxy.no_proxy.clone()
+    } else {
+        std::env::var("NO_PROXY")
+            .or_else(|_| std::env::var("no_proxy"))
+            .unwrap_or_default()
+    };
     if no_proxy.is_empty() {
         return false;
     }
@@ -591,10 +596,13 @@ pub fn load_config_verbose() -> (Vec<Proxy>, usize) {
     parse_lines_verbose(&content)
 }
 
-/// Load proxies from `DONSEEK_PROXIES` env var (comma-separated).
+/// Load the configured proxy pool: `[proxy] pool` in the layered config
+/// (comma-separated). Historically the `DONSEEK_PROXIES` env var.
 pub fn load_env() -> Vec<Proxy> {
-    let raw = std::env::var("DONSEEK_PROXIES").unwrap_or_default();
-    raw.split(',')
+    crate::config::cfg()
+        .proxy
+        .pool
+        .iter()
         .filter_map(|s| Proxy::parse(s.trim()).ok())
         .collect()
 }
@@ -632,22 +640,35 @@ pub fn from_env_for(url: &str) -> Option<Proxy> {
         return None;
     }
 
-    // Scheme-specific env var, then ALL_PROXY as fallback.
-    // Check uppercase first, then lowercase (curl convention).
+    // Resolution order: the explicit config slot ([proxy] https or
+    // [proxy] http) beats the ambient env var of the same scheme, which
+    // beats the config "all" slot, which beats ALL_PROXY (curl
+    // convention, lowercase variants included).
     // Note (Q2): non-http(s) schemes fall into the HTTP_PROXY arm. DonSeTch
     // never dials non-http(s) URLs (the URL gate rejects them first), so
     // curl's "ALL_PROXY covers unknown schemes" rule is dormant here; the
     // ALL_PROXY fallback below already covers both http and https.
-    let env_name = if scheme == "https" {
-        "HTTPS_PROXY"
+    let cfg = crate::config::cfg();
+    let (cfg_slot, env_name) = if scheme == "https" {
+        (&cfg.proxy.https, "HTTPS_PROXY")
     } else {
-        "HTTP_PROXY"
+        (&cfg.proxy.http, "HTTP_PROXY")
     };
-    let env_val = std::env::var(env_name)
-        .or_else(|_| std::env::var(env_name.to_lowercase()))
-        .or_else(|_| std::env::var("ALL_PROXY"))
-        .or_else(|_| std::env::var("all_proxy"))
-        .ok()?;
+    let explicit = if !cfg_slot.trim().is_empty() {
+        Some(cfg_slot.trim())
+    } else if !cfg.proxy.all.trim().is_empty() {
+        Some(cfg.proxy.all.trim())
+    } else {
+        None
+    };
+    let env_val = match explicit {
+        Some(v) => v.to_string(),
+        None => std::env::var(env_name)
+            .or_else(|_| std::env::var(env_name.to_lowercase()))
+            .or_else(|_| std::env::var("ALL_PROXY"))
+            .or_else(|_| std::env::var("all_proxy"))
+            .ok()?,
+    };
     let env_val = env_val.trim();
     if env_val.is_empty() {
         return None;

--- a/src/transport/routes.rs
+++ b/src/transport/routes.rs
@@ -211,7 +211,7 @@ pub fn h3_route(origin: &str, egress: &str) -> Option<u16> {
         }
         Some(entry.h3_port)
     });
-    if std::env::var_os("DONGHOST_DEBUG").is_some() {
+    if crate::config::cfg().debug.ghost {
         eprintln!("[routes] h3_route({origin}) = {hit:?}");
     }
     hit
@@ -248,7 +248,7 @@ pub fn record_h3(origin: &str, port: u16, ma_secs: u64, egress: &str) {
                     && cur.egress == fresh.egress
                     && cur.valid_until_ms + PERSIST_GRACE_MS >= fresh.valid_until_ms =>
             {
-                if std::env::var_os("DONGHOST_DEBUG").is_some() {
+                if crate::config::cfg().debug.ghost {
                     eprintln!(
                         "[routes] absorb {origin} eg={egress} skip (vouch not materially newer)"
                     );
@@ -257,7 +257,7 @@ pub fn record_h3(origin: &str, port: u16, ma_secs: u64, egress: &str) {
             }
             _ => {}
         }
-        if std::env::var_os("DONGHOST_DEBUG").is_some() {
+        if crate::config::cfg().debug.ghost {
             eprintln!("[routes] absorb {origin} eg={egress} record (ma={ma_secs})");
         }
         mem.routes.insert(origin.to_string(), fresh);
@@ -271,7 +271,7 @@ pub fn record_h3(origin: &str, port: u16, ma_secs: u64, egress: &str) {
 /// recorded; None when no QUIC-v1 h3 candidate parses or the
 /// bookkeeping is switched off (DONSETCH_NO_ALT_SVC).
 pub fn absorb_alt_svc(origin: &str, value: &str, egress: &str) -> Option<(u16, u64)> {
-    if crate::config::env_flag("DONSETCH_NO_ALT_SVC") {
+    if !crate::config::cfg().fetch.alt_svc {
         return None;
     }
     let (port, ma) = parse_h3_candidate(value)?;
@@ -289,7 +289,7 @@ pub fn drop_h3(origin: &str) {
 
 pub fn save_h3_session(origin: &str, egress: &str, session: &[u8]) {
     with(|mem| {
-        if std::env::var_os("DONGHOST_DEBUG").is_some() {
+        if crate::config::cfg().debug.ghost {
             eprintln!(
                 "[routes] save_h3_session key={origin} eg={egress} n={} match={}",
                 mem.routes.len(),
@@ -309,7 +309,7 @@ pub fn save_h3_session(origin: &str, egress: &str, session: &[u8]) {
 }
 
 pub fn load_h3_session(origin: &str, egress: &str) -> Option<Vec<u8>> {
-    let dbg = std::env::var_os("DONGHOST_DEBUG").is_some();
+    let dbg = crate::config::cfg().debug.ghost;
     let result: Result<Vec<u8>, &str> = with(|mem| {
         let st = match mem.routes.get(origin) {
             Some(s) => s,
@@ -513,17 +513,21 @@ mod tests {
             "a materially fresher vouch must extend the record on disk"
         );
 
-        // The switch DONSETCH_NO_ALT_SVC shuts the bookkeeping up
-        // entirely: absorbs still parse, they just do not record.
+        unsafe { std::env::remove_var("DONSETCH_CACHE_DIR") };
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    // The DONSETCH_NO_ALT_SVC switch shuts the bookkeeping up entirely:
+    // absorbs still parse, they just do not record. Config freezes at
+    // first touch, so the switch must be in place before the first
+    // cfg() read (nextest isolates each test in its own process).
+    #[test]
+    fn absorb_kill_switch_parses_but_never_records() {
         unsafe { std::env::set_var("DONSETCH_NO_ALT_SVC", "1") };
         assert_eq!(
             absorb_alt_svc("skip.test", "h3=\":443\"; ma=900", "direct"),
             None
         );
-        unsafe { std::env::remove_var("DONSETCH_NO_ALT_SVC") };
-
-        unsafe { std::env::remove_var("DONSETCH_CACHE_DIR") };
-        let _ = std::fs::remove_dir_all(&dir);
     }
 
     // Issue #175 part 2: routes.json never grows past ROWS_MAX and

--- a/src/transport/tls.rs
+++ b/src/transport/tls.rs
@@ -305,10 +305,20 @@ fn env_roots_fingerprint() -> Vec<(std::path::PathBuf, u64, u64)> {
 }
 
 fn env_root_paths() -> Vec<std::path::PathBuf> {
-    std::env::vars_os()
-        .filter_map(|(k, v)| (k == "SSL_CERT_FILE" || k == "SSL_CERT_DIR").then_some(v))
-        .map(std::path::PathBuf::from)
-        .collect()
+    let cfg = crate::config::cfg();
+    let mut out = Vec::new();
+    if !cfg.tls.cert_file.trim().is_empty() {
+        out.push(std::path::PathBuf::from(&cfg.tls.cert_file));
+    }
+    if !cfg.tls.cert_dir.trim().is_empty() {
+        out.push(std::path::PathBuf::from(&cfg.tls.cert_dir));
+    }
+    for (k, v) in std::env::vars_os() {
+        if k == "SSL_CERT_FILE" || k == "SSL_CERT_DIR" {
+            out.push(std::path::PathBuf::from(v));
+        }
+    }
+    out
 }
 
 fn read_env_roots() -> Vec<X509> {

--- a/tests/daemon_boot_stays_alive.rs
+++ b/tests/daemon_boot_stays_alive.rs
@@ -1,0 +1,63 @@
+//! The daemon boot contract: `donsetch mcp --supervised` must stay
+//! alive and answer an initialize, not exit during startup. The
+//! config consolidation wave installed the layered config once for
+//! every command and the mcp arm installed it again; the second
+//! install hit the one-shot check and exited the daemon before the
+//! first byte. This test drives the real binary over stdio and pins
+//! both the response and the absence of the double-install error.
+
+use std::io::{BufRead, BufReader, Write};
+use std::process::{Command, Stdio};
+use std::sync::mpsc;
+use std::time::Duration;
+
+#[test]
+fn mcp_daemon_boots_and_answers_initialize() {
+    // A one-shot MCP client over stdio.
+    let mut child = Command::new(env!("CARGO_BIN_EXE_donsetch"))
+        .arg("mcp")
+        .arg("--supervised")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("daemon spawns");
+    let mut stdin = child.stdin.take().unwrap();
+    let stdout = child.stdout.take().unwrap();
+    let stderr = child.stderr.take().unwrap();
+
+    stdin
+        .write_all(
+            b"{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"initialize\",\"params\":{\"protocolVersion\":\"2024-11-05\",\"capabilities\":{},\"clientInfo\":{\"name\":\"boot-probe\",\"version\":\"0\"}}}\n",
+        )
+        .unwrap();
+    stdin.flush().unwrap();
+
+    // The response must arrive while the process is still alive:
+    // a process that exited at startup serves EOF, not a result.
+    let (tx, rx) = mpsc::channel();
+    std::thread::spawn(move || {
+        let mut line = String::new();
+        let mut reader = BufReader::new(stdout);
+        let _ = reader.read_line(&mut line);
+        let _ = tx.send(line);
+    });
+    let answer = rx
+        .recv_timeout(Duration::from_secs(20))
+        .expect("the daemon must answer initialize");
+    assert!(
+        answer.contains("\"id\":1") && answer.contains("\"result\""),
+        "unexpected initialize answer: {answer}"
+    );
+
+    // The regression signature: the double install error killed the
+    // daemon. It must not appear anywhere on stderr.
+    drop(stdin);
+    let mut err_text = String::new();
+    let _ = BufReader::new(stderr).read_line(&mut err_text);
+    let _ = child.wait();
+    assert!(
+        !err_text.contains("already installed"),
+        "double-install regression: {err_text}"
+    );
+}

--- a/tests/daemon_boot_stays_alive.rs
+++ b/tests/daemon_boot_stays_alive.rs
@@ -6,22 +6,38 @@
 //! first byte. This test drives the real binary over stdio and pins
 //! both the response and the absence of the double-install error.
 
-use std::io::{BufRead, BufReader, Write};
+use std::io::{BufRead, BufReader, Read, Write};
 use std::process::{Command, Stdio};
 use std::sync::mpsc;
 use std::time::Duration;
 
-#[test]
-fn mcp_daemon_boots_and_answers_initialize() {
-    // A one-shot MCP client over stdio.
-    let mut child = Command::new(env!("CARGO_BIN_EXE_donsetch"))
-        .arg("mcp")
+fn hermetic_command() -> Command {
+    // The child must not inherit a developer's real config: a real
+    // donsetch.toml with [transport] kind = "http" (or
+    // DONSETCH_TRANSPORT=http) would boot an HTTP server instead of
+    // the stdio daemon this test drives. DONSETCH_NO_CONFIG_FILE=1
+    // skips the file layer; every other DONSETCH_* var goes too,
+    // including DONSETCH_CONFIG (NO_CONFIG_FILE + CONFIG = a hard
+    // conflict error that would kill the boot for the wrong reason).
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_donsetch"));
+    cmd.arg("mcp")
         .arg("--supervised")
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped())
-        .spawn()
-        .expect("daemon spawns");
+        .env("DONSETCH_NO_CONFIG_FILE", "1");
+    for (k, _) in std::env::vars_os() {
+        if k.to_string_lossy().starts_with("DONSETCH_") {
+            cmd.env_remove(&k);
+        }
+    }
+    cmd
+}
+
+#[test]
+fn mcp_daemon_boots_and_answers_initialize() {
+    // A one-shot MCP client over stdio.
+    let mut child = hermetic_command().spawn().expect("daemon spawns");
     let mut stdin = child.stdin.take().unwrap();
     let stdout = child.stdout.take().unwrap();
     let stderr = child.stderr.take().unwrap();
@@ -51,10 +67,11 @@ fn mcp_daemon_boots_and_answers_initialize() {
     );
 
     // The regression signature: the double install error killed the
-    // daemon. It must not appear anywhere on stderr.
+    // daemon. It must not appear anywhere on stderr. Read to EOF so
+    // a first-line warning can never mask a later line.
     drop(stdin);
     let mut err_text = String::new();
-    let _ = BufReader::new(stderr).read_line(&mut err_text);
+    let _ = BufReader::new(stderr).read_to_string(&mut err_text);
     let _ = child.wait();
     assert!(
         !err_text.contains("already installed"),


### PR DESCRIPTION
Closes #193.

One typed config in `src/config.rs`: 13 sections, four layers, later wins.

- compiled defaults (a bare `donsetch mcp` stays the law)
- legacy env names, exact historical trigger semantics preserved in a custom source (`legacy_layer()`), deprecated, cut at the v4 release
- `donsetch.toml` via `DONSETCH_CONFIG` or the config dir; `DONSETCH_NO_CONFIG_FILE=1` skips it; setting both is an error; unknown TOML keys and bad values are hard errors naming the file
- `DONSETCH_<SECTION>__<KEY>` env names, strict (bad bool/int fatal, unknown var warns)

Surface: `donsetch config show` with per-knob origins, `--markdown` reference table, `--legacy` old-name map, doctor warns about deprecated vars active in the shell with key mappings. ~90 scattered env reads converted to the struct; every converted read keeps its behavior.

Two bugs the fixture gate caught during the pass, now fixed with regression coverage: the memory kill_switch enable/disable inversion (web_memory dropped from tools/list), and unescaped pipes splitting the markdown reference table. Env-switching tests split to fit the frozen-once config under nextest.

Gate x2 green: 1154 passed + 1 skipped. Live battery against the real binary: all four layer origins visible, loud errors on bad file/value/range/conflict, doctor legacy listing, daemon boot off a TOML (`debug.ghost`), tier-1 live fetch.

Left for review per #193: the layering order, the DONSEEK_RERANK_THREADS graceful exception, the legacy cut at v4, and the plugin/fixture surfaces touched nowhere else.