### PR TITLE
fix(search): cache BYOK results so repeat queries stop re-billing the provider (#195)

### DIFF
--- a/src/mcp/server/search_tool.rs
+++ b/src/mcp/server/search_tool.rs
@@ -399,20 +399,8 @@ pub(super) async fn search_outcome(
 
     // BYOK-first mode: try providers, fall back to local.
     if byok_configured && !local_first {
-        match daemon.byok.search(query, max, intent).await {
-            Ok(out) => {
-                let mut out = out;
-                // Issue #190: site: queries dawn on BYOK results too,
-                // and prewarm only the rows that survive the filter.
-                crate::search::site_filter(query, &mut out.results);
-                // v4 phase 2.1: the warm handoff is not a local-search
-                // privilege. Provider results carry their own titles
-                // and snippets, so the reply does not wait: prewarm
-                // fires detached and parks bodies while the model
-                // reads the results (law 5: zero added latency).
-                daemon.searcher.spawn_prewarm(&out.results);
-                return Ok(out);
-            }
+        match byok_search_cached(daemon, query, max, intent).await {
+            Ok(out) => return Ok(out),
             Err(e) => {
                 if std::env::var_os("DONSEEK_DEBUG").is_some() {
                     eprintln!("[byok] all providers exhausted, falling back to local: {e}");
@@ -432,17 +420,8 @@ pub(super) async fn search_outcome(
                 if std::env::var_os("DONSEEK_DEBUG").is_some() {
                     eprintln!("[byok] local search failed, trying BYOK fallback: {e}");
                 }
-                match daemon.byok.search(query, max, intent).await {
-                    Ok(out) => {
-                        // Issue #190: the site: scan has to reach the
-                        // fallback path too, or the local-first mode
-                        // leaks rows off-domain.
-                        let mut out = out;
-                        crate::search::site_filter(query, &mut out.results);
-                        // Same detached prewarm as the BYOK-first path.
-                        daemon.searcher.spawn_prewarm(&out.results);
-                        Ok(out)
-                    }
+                match byok_search_cached(daemon, query, max, intent).await {
+                    Ok(out) => Ok(out),
                     Err(e2) => Err(SearchFailure {
                         cause: format!("local ({e}); byok ({e2})"),
                         byok_tried: true,
@@ -458,6 +437,34 @@ pub(super) async fn search_outcome(
             }
         }
     }
+}
+
+/// One BYOK acquisition with the shared search cache wrapped around
+/// it (issue #195). A repeat query inside the TTL is served from the
+/// cache with `cached: true` and never re-bills the provider; a fresh
+/// result is stored before it is filtered/prewarmed, so the cache
+/// holds the provider's full top slice exactly like the local path.
+/// Used by both BYOK entry points (BYOK-first and the local-first
+/// fallback) so caching cannot drift between them.
+async fn byok_search_cached(
+    daemon: &Arc<Daemon>,
+    query: &str,
+    max: usize,
+    intent: Option<Intent>,
+) -> Result<crate::search::SearchOutcome, String> {
+    let resolved = intent.unwrap_or_else(|| crate::search::intent::detect(query));
+    if let Some(hit) = daemon.searcher.byok_cache_get(query, resolved, max) {
+        return Ok(hit);
+    }
+    let mut out = daemon.byok.search(query, max, intent).await?;
+    // Store the provider's own top slice before site: filtering, so a
+    // later hit filters on serve exactly as the miss path does.
+    daemon.searcher.byok_cache_put(query, &out);
+    // Issue #190: site: queries reach BYOK results too, and prewarm
+    // only the rows that survive the filter (law 5: zero added latency).
+    crate::search::site_filter(query, &mut out.results);
+    daemon.searcher.spawn_prewarm(&out.results);
+    Ok(out)
 }
 
 /// Search failure → structured error: every engine (and BYOK if

--- a/src/search/mod.rs
+++ b/src/search/mod.rs
@@ -115,6 +115,14 @@ fn norm_query(q: &str) -> String {
         .join(" ")
 }
 
+/// Cache key for BYOK provider results (issue #195). The `byok|`
+/// prefix keeps them out of the local path's `query|intent` slot, so
+/// switching the `default` between local and a provider can never
+/// serve one path's results under the other's name.
+fn byok_cache_key(query: &str, intent: Intent) -> String {
+    format!("byok|{}|{}", norm_query(query), intent.code())
+}
+
 /// Whether a failure `status` reflects the engine actually behaving
 /// badly (worth quarantining via `record_outcome` and eroding trust
 /// via `bump_trust`), as opposed to infra noise -- a dead egress
@@ -247,6 +255,78 @@ impl Searcher {
     /// by the fetch tool.
     pub fn prewarms(&self) -> &std::sync::Arc<std::sync::Mutex<PrewarmCache>> {
         &self.prewarms
+    }
+
+    /// Issue #195: serve a repeat BYOK query from the same TTL'd
+    /// cache the local path uses, so a metered provider is not
+    /// re-billed for an identical query inside the freshness window.
+    /// Returns a `cached: true` outcome (provider recovered from the
+    /// stored report) when a fresh entry exists. BYOK entries live in
+    /// their own key namespace so a `default` switch between local and
+    /// a provider never cross-serves one for the other.
+    pub fn byok_cache_get(
+        &self,
+        query: &str,
+        intent: Intent,
+        max_results: usize,
+    ) -> Option<SearchOutcome> {
+        let t0 = Instant::now();
+        let key = byok_cache_key(query, intent);
+        let cache = self
+            .cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let (at, cached, _total, report) = cache.get(&key)?;
+        if at.elapsed() >= cache_ttl(intent, query) {
+            return None;
+        }
+        // The provider name is the engine label the BYOK path stored.
+        let provider = report.first().map(|r| r.engine.clone());
+        let mut results: Vec<Merged> = cached
+            .iter()
+            .take(max_results.clamp(1, 12))
+            .cloned()
+            .collect();
+        site_filter(query, &mut results);
+        Some(SearchOutcome {
+            results,
+            // BYOK results are provider-ranked and never flagged weak,
+            // matching the live BYOK path.
+            weak: false,
+            intent,
+            report: report.clone(),
+            cached: true,
+            elapsed: t0.elapsed(),
+            provider,
+            reranked: false,
+        })
+    }
+
+    /// Issue #195: persist a fresh BYOK outcome under the BYOK key
+    /// namespace, TTL'd like the local cache. Skips an empty result
+    /// set (the provider path errors on empty, so this is defensive).
+    pub fn byok_cache_put(&self, query: &str, out: &SearchOutcome) {
+        if out.results.is_empty() {
+            return;
+        }
+        let key = byok_cache_key(query, out.intent);
+        let mut cache = self
+            .cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // LRU-ish cap, same rule as the local write path.
+        if cache.len() >= 500
+            && let Some(oldest) = cache
+                .iter()
+                .max_by_key(|(_, (at, _, _, _))| at.elapsed())
+                .map(|(k, _)| k.clone())
+        {
+            cache.remove(&oldest);
+        }
+        let results: Vec<Merged> = out.results.iter().take(12).cloned().collect();
+        let total = results.len();
+        cache.insert(key, (Instant::now(), results, total, out.report.clone()));
+        save_cache_disk(&cache);
     }
 
     /// Proxy preflight: probe every proxy at startup so
@@ -997,6 +1077,109 @@ impl Drop for InflightGuard<'_> {
 mod tests {
     use super::render::clip_snippet;
     use super::*;
+
+    fn test_searcher() -> Searcher {
+        // Hermetic: point disk cache/health at a throwaway dir so the
+        // real user cache is neither read nor polluted, then clear the
+        // in-memory map so the entry set is exactly what the test puts
+        // (robust even if a sibling test changed the env first).
+        static SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let dir = std::env::temp_dir().join(format!(
+            "donsetch-byok-cache-{}-{}",
+            std::process::id(),
+            SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        ));
+        let _ = std::fs::create_dir_all(&dir);
+        unsafe { std::env::set_var("DONSETCH_CACHE_DIR", &dir) };
+        let fetcher = Fetcher::new(crate::profile::BrowserProfile::host_default()).unwrap();
+        let s = Searcher::new(fetcher, EgressPool::new(Vec::new()));
+        s.cache
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .clear();
+        s
+    }
+
+    fn byok_outcome(provider: &str, urls: &[&str]) -> SearchOutcome {
+        let results = urls
+            .iter()
+            .enumerate()
+            .map(|(i, u)| Merged {
+                title: format!("t{i}"),
+                url: (*u).to_string(),
+                snippet: "s".into(),
+                sources: vec![(provider.to_string(), i)],
+                score: 1.0 - i as f64 * 0.1,
+                published: None,
+            })
+            .collect::<Vec<_>>();
+        let report = vec![EngineReport {
+            engine: provider.to_string(),
+            profile: None,
+            status: "ok".into(),
+            hits: results.len(),
+            ms: 12,
+            egress: "byok".into(),
+        }];
+        SearchOutcome {
+            results,
+            weak: false,
+            intent: Intent::Web,
+            report,
+            cached: false,
+            elapsed: Duration::ZERO,
+            provider: Some(provider.to_string()),
+            reranked: false,
+        }
+    }
+
+    // Issue #195: a repeat BYOK query must be served from the cache
+    // (cached: true, provider preserved), never re-billing the
+    // provider. The store/serve roundtrip is the mechanism the wiring
+    // in search_tool relies on.
+    #[test]
+    fn byok_results_roundtrip_the_cache_with_provider_and_cached_flag() {
+        let s = test_searcher();
+        // Cold: nothing cached, so a caller must go bill the provider.
+        assert!(s.byok_cache_get("quic test 42", Intent::Web, 3).is_none());
+
+        let out = byok_outcome("tinyfish", &["https://a.test/", "https://b.test/"]);
+        s.byok_cache_put("quic test 42", &out);
+
+        // Warm: served from cache, marked cached, provider intact.
+        let hit = s
+            .byok_cache_get("quic test 42", Intent::Web, 3)
+            .expect("a fresh BYOK entry must hit");
+        assert!(hit.cached, "a served BYOK cache entry must report cached");
+        assert_eq!(hit.provider.as_deref(), Some("tinyfish"));
+        assert!(!hit.weak);
+        assert_eq!(hit.results.len(), 2);
+        assert_eq!(hit.results[0].url, "https://a.test/");
+    }
+
+    // The BYOK namespace must not collide with the local path: a
+    // provider result must never be served for a local-default query
+    // of the same text/intent, nor vice versa.
+    #[test]
+    fn byok_cache_is_isolated_from_the_local_namespace() {
+        let s = test_searcher();
+        let out = byok_outcome("serper", &["https://only-byok.test/"]);
+        s.byok_cache_put("shared query", &out);
+        // The local cache key (query|intent) is a different slot, so a
+        // local read finds nothing the BYOK write left behind.
+        let local_key = format!("{}|{}", norm_query("shared query"), Intent::Web.code());
+        assert!(
+            !s.cache
+                .lock()
+                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                .contains_key(&local_key),
+            "a BYOK write must not populate the local cache slot"
+        );
+        // And the BYOK read still finds its own entry.
+        assert!(s.byok_cache_get("shared query", Intent::Web, 5).is_some());
+        // A different intent is a different entry (miss).
+        assert!(s.byok_cache_get("shared query", Intent::News, 5).is_none());
+    }
 
     #[test]
     fn regression_unavailable_google_does_not_stop_other_assignments() {


### PR DESCRIPTION
Closes #195.

## The bug

The local search path reads and writes a TTL'd result cache and reports `meta.cached = true` on a repeat. The BYOK path did neither — `search_outcome` called `daemon.byok.search(...)` and returned without ever consulting or populating the cache. So `meta.cached` was `false` on every call, and a **metered provider was re-billed for every identical query** inside the freshness window (30 min web / 5 min news / 15 min code).

Reproduction from the issue:

```
$ donsetch search "cache test 42" --json | jq -c '{provider:.meta.provider, cached:.meta.cached}'
{"provider":"tinyfish","cached":false}
$ donsetch search "cache test 42" --json | jq -c '{provider:.meta.provider, cached:.meta.cached}'
{"provider":"tinyfish","cached":false}   # ← should be cached:true, no provider call
```

## The fix

BYOK results now ride the **same** cache, TTL and disk file as local results, in their own key namespace:

- `Searcher::byok_cache_get` / `byok_cache_put` key entries as `byok|<norm_query>|<intent>` (local uses `<norm_query>|<intent>`). The extra segment isolates the two paths — flipping `default` between local and a provider can never cross-serve. `cache_ttl(intent, query)` is applied identically; on a hit the outcome carries `cached = true` and the provider recovered from the stored report, which `render_meta` already surfaces as `meta.cached` / `meta.provider`.
- `byok_search_cached` wraps **both** BYOK entry points (BYOK-first and the local-first fallback) so caching can't drift between them: read the cache first (a hit returns without calling the provider), else call the provider, store the full top slice **before** `site:` filtering, then filter and prewarm exactly as the old code did.

No change to the cache tuple or the on-disk format — byok entries are the same shape and round-trip through `load_cache_disk` unchanged (its `rsplit_once('|')` still parses the intent and never lands a byok row in a local slot).

Now the second call returns `{"provider":"tinyfish","cached":true}` with no provider request.

## Verification

New unit tests pin the roundtrip (`cached=true`, provider preserved, `weak=false`) and namespace isolation (a byok write never populates the local slot; a different intent misses). Full `cargo nextest run` **1107/1107** (1 skipped); `clippy --all-targets` and `fmt --check` clean.

The tests are hermetic: the search cache persists via `paths::cache_dir()` (honors `DONSETCH_CACHE_DIR`), so the test harness points it at a throwaway dir and clears the in-memory map after construction — otherwise a `byok_cache_put` would pollute the real user cache and a later process-isolated run would load it.

## Known limits, left out by scope (all strict improvements over caching nothing)

- Two identical BYOK queries **in flight at once** still both bill — the local path has single-flight admission, BYOK does not. Sequential repeats (the issue) are fully covered; concurrent single-flight would be a separate enhancement.
- A provider result flagged `degraded` is cached for the TTL like any other (the local path has an `ok_engines>=2 && total>=8` poisoning guard that has no BYOK equivalent).
- An entry stored at `max=3` re-served at `max=10` returns the 3 the provider was billed for (local always merges 12; BYOK can't without billing for more).

Happy to also just document a cache-bypass instead if that matches the BYOK contract you intend — but caching with the local TTL semantics seemed to be the ask.

https://claude.ai/code/session_01Vg2CMnuvDevTxCpmJGbnRU