### PR TITLE
build: Windows cross-check from Linux, `just win-check`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ V4 work in progress on `master`. Nothing below ships through a release
 channel until the v4.0.0 release train.
 
 ### Added
+- `just win-check`: type-checks the crate for `x86_64-pc-windows-gnu`
+  from Linux (clippy, no linkage), both `--no-default-features` and
+  the full feature set, so `#[cfg(windows)]` breakage from a
+  Linux-only change surfaces before the push instead of in Windows
+  CI. Needs mingw-w64; see CONTRIBUTING.md.
 - `web_screenshot` MCP tool: a rendered PNG of a page through the
   existing tier-2 browser (url, full_page, wait_ms). The capture is
   in-process only; the MCP result carries an image content block and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -25,6 +25,51 @@ All three must pass before a PR can merge. CI runs the same checks on Linux, mac
 
 The same tasks are wrapped as [`just`](https://just.systems) recipes — `just test`, `just lint`, `just fmt-check`, `just smoke`.
 
+### Verifying Windows compilation from Linux
+
+Linux-only changes regularly broke Windows CI in `cfg`-gated code that never
+compiled locally. `just win-check` type-checks the whole crate for
+`x86_64-pc-windows-gnu` without linking — both ends of the feature matrix
+(full `ocr,rerank,http` and `--no-default-features`), all targets,
+`-Dwarnings` — so those breaks surface before the push. It is not part of
+`just all` because it needs a cross toolchain on top of the normal build
+prerequisites (NASM, CMake and libclang are already required above). On
+Debian/Ubuntu:
+
+```bash
+sudo apt install mingw-w64 pkg-config
+rustup target add x86_64-pc-windows-gnu
+```
+
+On other distros install the equivalents: the x86_64 mingw-w64 cross
+toolchain (gcc and g++) and pkg-config. If you skipped the normal
+prerequisites, add NASM, CMake and libclang (`nasm cmake libclang-dev` on
+Debian/Ubuntu).
+
+Per recipe:
+
+- **`win-check-core`** (`--no-default-features`): `mingw-w64` (cross
+  gcc/g++), `nasm` + `cmake` (BoringSSL build), `libclang-dev`
+  (bindgen for boring-sys), and the `x86_64-pc-windows-gnu` rustup
+  target. Run this one first; it is the cheaper half.
+- **`win-check-full`** (`ocr,rerank,http`): all of the above plus
+  `pkg-config` — the ort binary downloader builds a host-side
+  `openssl-sys`, which needs pkg-config to find the system OpenSSL
+  headers (`libssl-dev`, usually already present).
+- **`win-check`** runs both.
+
+The first run compiles BoringSSL for the mingw target (a few minutes); warm
+runs take seconds. The recipe's comments in the Justfile explain the three
+environment workarounds it applies. Windows CI proper stays authoritative —
+it builds the msvc target and links — but `win-check` catches the common
+case. Type-checking is the ceiling here: an actual `cargo build` for
+`x86_64-pc-windows-gnu` fails to link even with `--no-default-features`
+(BoringSSL), so do not expect a runnable binary out of the cross setup. The
+common case is code under `#[cfg(windows)]` or `#[cfg(unix)]` that no longer compiles
+on the other side. Note that rustc reports the first error it hits, so the
+message can differ from the Windows CI log for the same break (a missing
+import surfaces before a type mismatch on the same line, for instance).
+
 ### Windows
 
 The recipes are POSIX shell (`2>/dev/null`, `head -c`, `cd fuzz && …`) and `just` runs them with `sh`,

--- a/Justfile
+++ b/Justfile
@@ -77,6 +77,43 @@ fmt-check:
 lint:
     cargo clippy --profile ci --all-targets --features ocr,rerank,http -- -Dwarnings
 
+# Windows cross-check from Linux: type-checks every cfg(windows)
+# path with the full feature set — the exact breakage a Linux-only
+# change ships to Windows CI. No linkage, so no MSVC/mingw runtime
+# is exercised; three env crumbs make the deps graph cross-buildable:
+#   ASM_NASM        BoringSSL links crypto against Threads::Threads;
+#                   CMake 3.28 leaks -pthread into the NASM command
+#                   line, and nasm reads it as -p thread (pre-include
+#                   file "thread"). The wrapper strips the flag.
+#   BINDGEN_…       libclang parsing the mingw headers needs GCC's
+#                   private include dir (mm_malloc.h lives there).
+#   ORT_SKIP_DOWNLOAD  pyke ships no ONNX prebuilts for windows-gnu;
+#                   ort-sys then defers its error to link time, which
+#                   a check never reaches. Windows CI proper uses the
+#                   msvc prebuilts, so this gap is cross-check-only.
+# Prereqs (Debian/Ubuntu): mingw-w64 nasm cmake libclang-dev
+# pkg-config, plus `rustup target add x86_64-pc-windows-gnu`.
+win-check: win-check-core win-check-full
+
+_win-check-prereqs:
+    @command -v x86_64-w64-mingw32-gcc >/dev/null || { echo "win-check: missing cross toolchain — sudo apt install mingw-w64 nasm cmake libclang-dev pkg-config && rustup target add x86_64-pc-windows-gnu"; exit 1; }
+    @rustup target list --installed | grep -q '^x86_64-pc-windows-gnu$' || { echo "win-check: missing rustup target — rustup target add x86_64-pc-windows-gnu"; exit 1; }
+
+win-check-full: _win-check-prereqs
+    ASM_NASM="{{justfile_directory()}}/scripts/nasm-no-pthread.sh" \
+    BINDGEN_EXTRA_CLANG_ARGS_x86_64_pc_windows_gnu="-I$(x86_64-w64-mingw32-gcc -print-file-name=include)" \
+    ORT_SKIP_DOWNLOAD=1 \
+    cargo clippy --target x86_64-pc-windows-gnu --all-targets --features ocr,rerank,http -- -Dwarnings
+
+# The no-features half of the matrix: a feature-gated `use` can
+# satisfy a cfg(windows) path that the core build then lacks, so
+# full-feature green does not imply core green. Cheaper than the
+# full half (no ort download step), so it is the one to run first.
+win-check-core: _win-check-prereqs
+    ASM_NASM="{{justfile_directory()}}/scripts/nasm-no-pthread.sh" \
+    BINDGEN_EXTRA_CLANG_ARGS_x86_64_pc_windows_gnu="-I$(x86_64-w64-mingw32-gcc -print-file-name=include)" \
+    cargo clippy --target x86_64-pc-windows-gnu --no-default-features --all-targets -- -Dwarnings
+
 # Full suite, full feature set, fail-fast. The cargo profile is
 # pinned via CLI: nextest 0.9.x ignores the config-level key, and an
 # unpinned run compiles the debug graph (the 110G/21G recidivism).

--- a/scripts/nasm-no-pthread.sh
+++ b/scripts/nasm-no-pthread.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# NASM wrapper for cross-compiling BoringSSL to x86_64-pc-windows-gnu on Linux.
+#
+# BoringSSL's CMakeLists links crypto against Threads::Threads. CMake 3.28's
+# FindThreads leaks the -pthread interface compile option into the ASM_NASM
+# language, and nasm parses "-pthread" as "-p thread" — pre-include a file
+# named "thread" — failing with "unable to open include file `thread'".
+# Strip the flag; everything else passes through untouched.
+#
+# Used via the ASM_NASM environment variable, which CMake consults when
+# detecting the NASM compiler (see the win-check recipe in the Justfile).
+for arg do
+  shift
+  [ "$arg" = "-pthread" ] || set -- "$@" "$arg"
+done
+exec nasm "$@"


### PR DESCRIPTION
## Summary

#196 broke Windows twice in one day, both times in `cfg`-gated code that never compiles on a Linux box. This adds `just win-check`: clippy for `x86_64-pc-windows-gnu` run from Linux, no linkage, at both ends of the feature matrix (`win-check-core` with `--no-default-features`, `win-check-full` with `ocr,rerank,http`), `--all-targets`, `-Dwarnings`. Both halves fail on the two commits that broke Windows today. Not part of `just all`, since it needs a mingw cross toolchain on top of the normal prerequisites; CONTRIBUTING.md has the install lines for Debian/Ubuntu and the distro-neutral equivalents. Three environment workarounds make the cross dependency graph buildable (nasm `-pthread` leak from CMake 3.28, mingw-GCC include dir for bindgen, no ONNX prebuilts for windows-gnu); each is explained inline in the Justfile. Type-checking is the ceiling: a cross `cargo build` fails to link in BoringSSL even featureless, so Windows CI proper stays authoritative.

## Type

- [ ] `feat` — new feature
- [ ] `fix` — bug fix
- [ ] `docs` — documentation only
- [x] `chore` — deps, CI, tooling
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only

## Checks

- [x] `cargo test --features ocr,rerank` passes (622+ tests)
- [x] `cargo clippy --all-targets --features ocr,rerank -- -Dwarnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes
- [ ] CI is green on all 3 platforms (Linux, macOS, Windows)

No Rust source changes: Justfile, CONTRIBUTING.md, CHANGELOG.md and one POSIX shell script. The three local checks are unaffected by this PR; CI ticked once it reports.

## Breaking changes

None. New recipes only; `just all`, `just lint` and CI are untouched.

## Test plan

On WSL2 Ubuntu 24.04 (mingw-w64 13, cmake 3.28.3, nasm 2.16.01, rustc 1.98.1):

- `just win-check` green on the branch head, both halves. First run compiles BoringSSL for the mingw target (a few minutes), warm runs take seconds.
- Regression check against the two real breaks. Checked out each commit detached, ran both halves with the same env and flags (wrapper copied to `/tmp`, since those commits predate it):
  - `55bda0b`: both halves fail with `error[E0433]: cannot find type PathBuf` at `src/profile/mod.rs:382`, the Windows-only path that `0462816` fixed.
  - `f3b6005`: both halves fail with `unused import: spawn_probe_with_timeout` at `src/profile/mod.rs:727` in the lib test target, the break that `dfbf38c` fixed. `--all-targets` and `-Dwarnings` are load-bearing there: the code is in a test, and without `-Dwarnings` an unused import is only a warning.
- One nuance for anyone comparing against the Windows CI log: rustc reports the first error it hits, so the message can differ for the same line. `55bda0b` also had a type mismatch on that line, but name resolution fails first, so the cross-check shows E0433. Same break, different first symptom.
- Missing-toolchain path: with `x86_64-w64-mingw32-gcc` absent, `just win-check-core` prints the install hint and exits 1 before cargo runs.
- Not verified on macOS. The recipe is POSIX shell and the workarounds are toolchain-level, so it should work with a Homebrew `mingw-w64`, but nobody has run it there.

Not in this PR: a Dockerfile wrapping `win-check`, for anyone who would rather not install mingw locally. Happy to add one if wanted.
