### PR TITLE
fix(profile): bound browser version probe lifecycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ channel until the v4.0.0 release train.
 - `donsetch config show` redacts bearer tokens and credential-bearing proxy
   values, including proxy pools, while still showing whether each field is
   configured and where its value came from.
+- Browser version probes now apply one deadline to process exit and bounded
+  stdout capture, terminate inherited-pipe descendants on Unix and Windows,
+  and cap captured output at 64 KiB.
 - Every runtime env read now flows through the typed config. The old
   env names keep their exact historical trigger semantics and still
   work, but they are deprecated and will be removed at the v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,7 +85,7 @@ rerank = ["dep:ort", "dep:tokenizers", "dep:ndarray", "dep:num_cpus", "reqwest/b
 http = ["dep:axum", "dep:tower-http"]
 
 [target.'cfg(windows)'.dependencies]
-windows-sys = { version = "0.61", features = ["Win32_System_JobObjects", "Win32_System_Threading", "Win32_Security", "Win32_Foundation", "Win32_System_Console", "Win32_System_Registry"] }
+windows-sys = { version = "0.61", features = ["Win32_System_JobObjects", "Win32_System_Threading", "Win32_Security", "Win32_Foundation", "Win32_System_Console", "Win32_System_Registry", "Win32_System_Pipes"] }
 
 [dev-dependencies]
 rcgen = "0.14"

--- a/src/ghost/proc.rs
+++ b/src/ghost/proc.rs
@@ -42,7 +42,7 @@ pub struct Proc {
     #[cfg(windows)]
     proc_handle: fnd::HANDLE,
     #[cfg(windows)]
-    job: fnd::HANDLE,
+    job: KillOnCloseJob,
 }
 
 // ntdll process suspend/resume : always loaded, linked directly.
@@ -51,6 +51,74 @@ pub struct Proc {
 unsafe extern "system" {
     fn NtSuspendProcess(proc_handle: fnd::HANDLE) -> i32;
     fn NtResumeProcess(proc_handle: fnd::HANDLE) -> i32;
+}
+
+/// Owned Windows Job Object that terminates every assigned process when the
+/// handle closes. Both long-lived ghosts and short browser probes use this
+/// primitive so job creation, assignment, and teardown have one owner.
+#[cfg(windows)]
+pub(crate) struct KillOnCloseJob {
+    handle: fnd::HANDLE,
+}
+
+#[cfg(windows)]
+impl KillOnCloseJob {
+    pub(crate) fn new() -> Result<Self, String> {
+        unsafe {
+            let handle = job::CreateJobObjectW(std::ptr::null(), std::ptr::null());
+            if handle.is_null() {
+                return Err(format!("CreateJobObjectW failed: {}", fnd::GetLastError()));
+            }
+
+            let mut info: job::JOBOBJECT_EXTENDED_LIMIT_INFORMATION = std::mem::zeroed();
+            info.BasicLimitInformation.LimitFlags = job::JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
+            if job::SetInformationJobObject(
+                handle,
+                job::JobObjectExtendedLimitInformation,
+                &info as *const _ as *const _,
+                std::mem::size_of_val(&info) as u32,
+            ) == 0
+            {
+                let error = fnd::GetLastError();
+                fnd::CloseHandle(handle);
+                return Err(format!("SetInformationJobObject failed: {error}"));
+            }
+            Ok(Self { handle })
+        }
+    }
+
+    pub(crate) fn assign(&self, process: fnd::HANDLE) -> Result<(), u32> {
+        if unsafe { job::AssignProcessToJobObject(self.handle, process) } == 0 {
+            Err(unsafe { fnd::GetLastError() })
+        } else {
+            Ok(())
+        }
+    }
+
+    fn terminate(&self) {
+        unsafe {
+            job::TerminateJobObject(self.handle, 1);
+        }
+    }
+
+    fn raw(&self) -> fnd::HANDLE {
+        self.handle
+    }
+}
+
+#[cfg(windows)]
+impl Drop for KillOnCloseJob {
+    fn drop(&mut self) {
+        unsafe {
+            fnd::CloseHandle(self.handle);
+        }
+    }
+}
+
+#[cfg(windows)]
+pub(crate) fn resume_process(process: fnd::HANDLE) -> Result<(), i32> {
+    let status = unsafe { NtResumeProcess(process) };
+    if status < 0 { Err(status) } else { Ok(()) }
 }
 
 impl Proc {
@@ -84,7 +152,6 @@ impl Proc {
 
     #[cfg(windows)]
     unsafe fn from_child_win(child: &Child) -> Result<Self, FetchError> {
-        use std::mem;
         let pid = child.id().unwrap_or(0);
 
         // SAFETY: all FFI calls in this function target well-documented
@@ -115,49 +182,28 @@ impl Proc {
             }
 
             // Job Object: kernel kills the whole tree if donsetch dies.
-            let job_h = job::CreateJobObjectW(std::ptr::null(), std::ptr::null());
-            if job_h.is_null() {
-                fnd::CloseHandle(proc_handle);
-                return Err(FetchError::ghost(format!(
-                    "CreateJobObjectW failed: {}",
-                    fnd::GetLastError()
-                )));
-            }
-            let mut info: job::JOBOBJECT_EXTENDED_LIMIT_INFORMATION = mem::zeroed();
-            info.BasicLimitInformation.LimitFlags = job::JOB_OBJECT_LIMIT_KILL_ON_JOB_CLOSE;
-            if job::SetInformationJobObject(
-                job_h,
-                job::JobObjectExtendedLimitInformation,
-                &info as *const _ as *const _,
-                mem::size_of::<job::JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as u32,
-            ) == 0
-            {
-                fnd::CloseHandle(proc_handle);
-                fnd::CloseHandle(job_h);
-                return Err(FetchError::ghost(format!(
-                    "SetInformationJobObject failed: {}",
-                    fnd::GetLastError()
-                )));
-            }
+            let job = match KillOnCloseJob::new() {
+                Ok(job) => job,
+                Err(error) => {
+                    fnd::CloseHandle(proc_handle);
+                    return Err(FetchError::ghost(error));
+                }
+            };
             // Assign the child to the job. On Win8+ nested jobs are
             // allowed, so this succeeds even if the process is already
             // in a job. If it fails we don't abort : freeze/thaw/kill
             // still work via the process handle; only the death-reap
             // safety net is lost.
-            if job::AssignProcessToJobObject(job_h, proc_handle) == 0 {
+            if let Err(error) = job.assign(proc_handle) {
                 // Non-fatal for the fetch itself, but the job is now empty:
                 // KILL_ON_JOB_CLOSE has nothing to kill, so the browser tree
                 // outlives donsetch and orphaned Chrome processes pile up.
                 // Warn unconditionally : silent degradation is what hid this.
                 eprintln!(
-                    "[ghost] AssignProcessToJobObject failed: {} : browser tree will not be reaped on exit, leaving orphaned Chrome processes",
-                    fnd::GetLastError()
+                    "[ghost] AssignProcessToJobObject failed: {error} : browser tree will not be reaped on exit, leaving orphaned Chrome processes"
                 );
             }
-            Ok(Self {
-                proc_handle,
-                job: job_h,
-            })
+            Ok(Self { proc_handle, job })
         }
     }
 
@@ -188,7 +234,7 @@ impl Proc {
         unsafe {
             for pid in self.job_pids() {
                 if let Ok(h) = open_for_suspend(pid) {
-                    NtResumeProcess(h);
+                    let _ = resume_process(h);
                     fnd::CloseHandle(h);
                 }
             }
@@ -202,9 +248,9 @@ impl Proc {
             libc::kill(-self.pid, libc::SIGKILL);
         }
         #[cfg(windows)]
-        unsafe {
+        {
             // Kills every process in the job : the whole tree.
-            job::TerminateJobObject(self.job, 1);
+            self.job.terminate();
         }
     }
 
@@ -228,7 +274,7 @@ impl Proc {
 
         let ok = unsafe {
             job::QueryInformationJobObject(
-                self.job,
+                self.job.raw(),
                 job::JobObjectBasicProcessIdList,
                 buf.as_mut_ptr() as *mut _,
                 buf_size as u32,
@@ -293,7 +339,6 @@ impl Drop for Proc {
         #[cfg(windows)]
         unsafe {
             fnd::CloseHandle(self.proc_handle);
-            fnd::CloseHandle(self.job);
         }
         #[cfg(not(windows))]
         {

--- a/src/profile/mod.rs
+++ b/src/profile/mod.rs
@@ -549,89 +549,12 @@ fn probe_version_string_at_path_uncached(path: &str) -> Result<String, String> {
     spawn_probe_with_timeout(cmd)
 }
 
-/// Run the built `--version` command, read its stdout, and return it.
-/// Never runs longer than `PROBE_SPAWN_TIMEOUT`; on timeout, kills the
-/// whole process tree.
-fn spawn_probe_with_timeout(mut cmd: std::process::Command) -> Result<String, String> {
-    use std::io::Read;
+mod version_probe;
 
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt;
-        unsafe {
-            cmd.pre_exec(|| {
-                // Own process group: the timeout kill must reach the
-                // browser's descendants too, or they inherit the
-                // stdout pipe and hang the reader join forever (the
-                // itoqa-found doctor hang).
-                if libc::setpgid(0, 0) < 0 {
-                    return Err(std::io::Error::last_os_error());
-                }
-                Ok(())
-            });
-        }
-    }
-
-    let mut child = cmd
-        .spawn()
-        .map_err(|e| format!("spawn browser version probe: {e}"))?;
-
-    // Read stdout on a side thread so we can still enforce the timeout
-    // if the browser never exits (the read would otherwise block us).
-    let pid = child.id();
-    let pipe = match child.stdout.take() {
-        Some(p) => p,
-        None => {
-            // Can't happen (stdout is always piped above), but never
-            // leave a spawned child running on the early-out path.
-            let _ = child.kill();
-            let _ = child.wait();
-            return Err("browser version probe had no stdout pipe".into());
-        }
-    };
-    let stdout = std::thread::spawn(move || {
-        let mut buf = String::new();
-        let mut rd = pipe;
-        let _ = rd.read_to_string(&mut buf);
-        buf
-    });
-
-    let deadline = std::time::Instant::now() + PROBE_SPAWN_TIMEOUT;
-    let mut reaped: Option<std::process::ExitStatus> = None;
-    while reaped.is_none() {
-        match child.try_wait() {
-            Ok(Some(status)) => reaped = Some(status),
-            Ok(None) => {}
-            Err(_) => break,
-        }
-        if reaped.is_none() && std::time::Instant::now() >= deadline {
-            // Wedged browser : kill the whole tree, not just the parent.
-            kill_probe_tree(Some(pid));
-            let _ = child.kill();
-            reaped = child.wait().ok();
-            break;
-        }
-        if reaped.is_none() {
-            std::thread::sleep(std::time::Duration::from_millis(25));
-        }
-    }
-    if reaped.is_none() {
-        // Err branch above killed nothing; be safe.
-        let _ = child.kill();
-        let _ = child.wait();
-    }
-    let out = stdout.join().unwrap_or_default();
-    match reaped {
-        Some(status) if status.success() => {
-            // "Chromium 151.0.7922.108\n" -> "151.0.7922.108".
-            // The banner word varies per build (Chromium, Chrome,
-            // Edge, CloakBrowser); the dotted token is the truth.
-            parse_version_string(&out)
-                .ok_or_else(|| format!("browser version probe returned no version token: {out:?}"))
-        }
-        Some(status) => Err(format!("browser version probe exited with {status}")),
-        None => Err("browser version probe did not exit".into()),
-    }
+/// Capture stdout and process completion under one post-spawn deadline.
+/// OS spawn and teardown latency are not a hard real-time guarantee.
+fn spawn_probe_with_timeout(cmd: std::process::Command) -> Result<String, String> {
+    version_probe::run(cmd, PROBE_SPAWN_TIMEOUT)
 }
 
 /// Parse the first full dotted Chromium version from a version banner.
@@ -652,33 +575,6 @@ pub(crate) fn parse_version_string(line: &str) -> Option<String> {
         }
     })
 }
-/// Kill the probe process and its children (Windows: taskkill /T so
-/// the whole tree dies; Unix: kill the process group-less child : its
-/// renderers exit when the browser dies).
-fn kill_probe_tree(pid: Option<u32>) {
-    let Some(pid) = pid else { return };
-    #[cfg(windows)]
-    {
-        // taskkill /T /F kills the process and all descendants.
-        let _ = std::process::Command::new("taskkill")
-            .args(["/T", "/F", "/PID", &pid.to_string()])
-            .stdout(std::process::Stdio::null())
-            .stderr(std::process::Stdio::null())
-            .status();
-    }
-    #[cfg(not(windows))]
-    unsafe {
-        // Kill the WHOLE group: the browser's descendants inherit the
-        // parent's stdout pipe, and only when every write end is dead
-        // does the reader thread see EOF and the join return. Killing
-        // just the parent left the pipe held open and doctor hung
-        // forever (itoqa 2026-09-11). The child runs in its own group
-        // via pre_exec setpgid, so the negative pid hits it and every
-        // descendant, not our own process group.
-        libc::kill(-(pid as i32), libc::SIGKILL);
-    }
-}
-
 /// Parse the first plausible major version out of a `<name> <major>` line.
 pub(crate) fn parse_version_major(line: &str) -> Option<u32> {
     let line = line.trim();

--- a/src/profile/version_probe.rs
+++ b/src/profile/version_probe.rs
@@ -1,0 +1,451 @@
+//! Bounded browser version-probe capture.
+//!
+//! One deadline covers both process completion and stdout capture. Once the
+//! direct child exits, all bytes it wrote are already in the pipe; descendants
+//! may still own inherited write handles, so EOF is not a completion signal.
+
+use std::io::{self, Read};
+use std::process::{Child, ChildStdout, Command, ExitStatus, Stdio};
+use std::time::{Duration, Instant};
+
+const OUTPUT_LIMIT: usize = 64 * 1024;
+const POLL_INTERVAL: Duration = Duration::from_millis(10);
+
+pub(super) fn run(mut cmd: Command, timeout: Duration) -> Result<String, String> {
+    cmd.stdout(Stdio::piped()).stderr(Stdio::null());
+    let mut tree = ProbeTree::prepare(&mut cmd)?;
+    let mut child = cmd
+        .spawn()
+        .map_err(|e| format!("spawn browser version probe: {e}"))?;
+    // Process creation and teardown are OS operations and are not promised to
+    // be hard real-time. Everything after spawn shares this deadline.
+    let deadline = Instant::now() + timeout;
+
+    let result = (|| {
+        tree.attach_and_resume(&child)?;
+        let mut pipe = child
+            .stdout
+            .take()
+            .ok_or("browser version probe had no stdout pipe")?;
+        prepare_pipe(&pipe).map_err(|e| format!("prepare browser version pipe: {e}"))?;
+        capture(&mut child, &mut pipe, deadline)
+    })();
+
+    // This also cleans up descendants after the direct child has exited.
+    drop(tree);
+    let _ = child.kill();
+    let _ = child.wait();
+    result
+}
+
+fn capture(child: &mut Child, pipe: &mut ChildStdout, deadline: Instant) -> Result<String, String> {
+    let mut output = Vec::new();
+    let mut eof = false;
+    let mut status: Option<ExitStatus> = None;
+    let mut buffer = [0_u8; 4096];
+
+    loop {
+        if Instant::now() >= deadline {
+            return Err(
+                "browser version probe timed out before process exit or output completion".into(),
+            );
+        }
+
+        // Observe exit before the final drain. If exit became visible after a
+        // WouldBlock result, using that stale result could miss bytes written
+        // by the child immediately before it exited.
+        if status.is_none() {
+            status = child
+                .try_wait()
+                .map_err(|e| format!("wait browser version probe: {e}"))?;
+        }
+
+        let mut made_progress = false;
+        let mut drained = eof;
+        if !eof {
+            match read_available(pipe, &mut buffer) {
+                Ok(0) => {
+                    eof = true;
+                    drained = true;
+                }
+                Ok(count) => {
+                    if count > OUTPUT_LIMIT.saturating_sub(output.len()) {
+                        return Err(format!(
+                            "browser version probe exceeded {OUTPUT_LIMIT} output bytes"
+                        ));
+                    }
+                    output.extend_from_slice(&buffer[..count]);
+                    made_progress = true;
+                }
+                Err(error) if error.kind() == io::ErrorKind::WouldBlock => drained = true,
+                Err(error) if error.kind() == io::ErrorKind::Interrupted => continue,
+                Err(error) => return Err(format!("read browser version pipe: {error}")),
+            }
+        }
+
+        // An exited direct child cannot write more. Parse once every byte
+        // currently readable has been drained; waiting for EOF
+        // would let an unrelated inherited handle hold the probe hostage.
+        if drained && let Some(status) = status {
+            if !status.success() {
+                return Err(format!("browser version probe exited with {status}"));
+            }
+            let text = std::str::from_utf8(&output)
+                .map_err(|_| "browser version probe returned invalid UTF-8")?;
+            return super::parse_version_string(text)
+                .ok_or_else(|| "browser version probe returned no version token".into());
+        }
+
+        if !made_progress {
+            std::thread::sleep(
+                POLL_INTERVAL.min(deadline.saturating_duration_since(Instant::now())),
+            );
+        }
+    }
+}
+
+#[cfg(unix)]
+fn prepare_pipe(pipe: &ChildStdout) -> io::Result<()> {
+    use std::os::fd::AsRawFd;
+
+    let fd = pipe.as_raw_fd();
+    // SAFETY: `fd` remains owned by `pipe`; preserve all existing status bits.
+    unsafe {
+        let flags = libc::fcntl(fd, libc::F_GETFL);
+        if flags < 0 || libc::fcntl(fd, libc::F_SETFL, flags | libc::O_NONBLOCK) < 0 {
+            return Err(io::Error::last_os_error());
+        }
+    }
+    Ok(())
+}
+
+#[cfg(windows)]
+fn prepare_pipe(_: &ChildStdout) -> io::Result<()> {
+    // Rust 1.98 (the pinned toolchain) creates the parent's Windows pipe end
+    // for asynchronous I/O. That keeps PeekNamedPipe below non-blocking; the
+    // Windows lifecycle tests guard this implementation-level dependency.
+    Ok(())
+}
+
+#[cfg(not(any(unix, windows)))]
+fn prepare_pipe(_: &ChildStdout) -> io::Result<()> {
+    Err(io::ErrorKind::Unsupported.into())
+}
+
+#[cfg(unix)]
+fn read_available(pipe: &mut ChildStdout, buffer: &mut [u8]) -> io::Result<usize> {
+    pipe.read(buffer)
+}
+
+#[cfg(windows)]
+fn read_available(pipe: &mut ChildStdout, buffer: &mut [u8]) -> io::Result<usize> {
+    use std::os::windows::io::AsRawHandle;
+    use windows_sys::Win32::{Foundation, System::Pipes::PeekNamedPipe};
+
+    let mut available = 0_u32;
+    // SAFETY: this function is the only reader. It reads no more than the
+    // number of bytes observed as available on this pipe.
+    unsafe {
+        if PeekNamedPipe(
+            pipe.as_raw_handle(),
+            std::ptr::null_mut(),
+            0,
+            std::ptr::null_mut(),
+            &mut available,
+            std::ptr::null_mut(),
+        ) == 0
+        {
+            let error = Foundation::GetLastError();
+            if error == Foundation::ERROR_BROKEN_PIPE {
+                return Ok(0);
+            }
+            return Err(io::Error::from_raw_os_error(error as i32));
+        }
+    }
+    if available == 0 {
+        return Err(io::ErrorKind::WouldBlock.into());
+    }
+    let count = buffer.len().min(available as usize);
+    pipe.read(&mut buffer[..count])
+}
+
+#[cfg(not(any(unix, windows)))]
+fn read_available(_: &mut ChildStdout, _: &mut [u8]) -> io::Result<usize> {
+    Err(io::ErrorKind::Unsupported.into())
+}
+
+struct ProbeTree {
+    #[cfg(unix)]
+    pid: Option<u32>,
+    #[cfg(windows)]
+    job: crate::ghost::proc::KillOnCloseJob,
+}
+
+impl ProbeTree {
+    fn prepare(cmd: &mut Command) -> Result<Self, String> {
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::CommandExt;
+            cmd.process_group(0);
+            Ok(Self { pid: None })
+        }
+
+        #[cfg(windows)]
+        {
+            use std::os::windows::process::CommandExt;
+            use windows_sys::Win32::System::Threading;
+
+            // `Command` does not retain the initial thread handle. Suspending
+            // closes the race in which descendants could escape before the
+            // process is assigned to the kill-on-close Job Object.
+            cmd.creation_flags(Threading::CREATE_SUSPENDED | Threading::CREATE_NO_WINDOW);
+            crate::ghost::proc::KillOnCloseJob::new().map(|job| Self { job })
+        }
+
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = cmd;
+            Err("version probe unsupported on this platform".into())
+        }
+    }
+
+    fn attach_and_resume(&mut self, child: &Child) -> Result<(), String> {
+        #[cfg(unix)]
+        {
+            self.pid = Some(child.id());
+            Ok(())
+        }
+
+        #[cfg(windows)]
+        {
+            use std::os::windows::io::AsRawHandle;
+
+            self.job
+                .assign(child.as_raw_handle())
+                .map_err(|error| format!("assign suspended probe to Job Object: {error}"))?;
+            crate::ghost::proc::resume_process(child.as_raw_handle())
+                .map_err(|status| format!("resume probe process: NTSTATUS {status:#x}"))
+        }
+
+        #[cfg(not(any(unix, windows)))]
+        {
+            let _ = child;
+            Err("version probe unsupported on this platform".into())
+        }
+    }
+}
+
+impl Drop for ProbeTree {
+    fn drop(&mut self) {
+        #[cfg(unix)]
+        if let Some(pid) = self.pid {
+            // SAFETY: the command was put in a fresh process group; the
+            // negative PID therefore cannot address our own group.
+            unsafe {
+                libc::kill(-(pid as i32), libc::SIGKILL);
+            }
+        }
+    }
+}
+
+#[cfg(all(test, unix))]
+mod tests {
+    use super::*;
+
+    fn script(source: &str) -> Command {
+        let mut cmd = Command::new("sh");
+        cmd.args(["-c", source]);
+        cmd
+    }
+
+    #[test]
+    fn exited_parent_output_is_complete_without_descendant_eof() {
+        let start = Instant::now();
+        assert_eq!(
+            run(
+                script("sleep 30 & printf 'Chromium 151.0.0.0\\n'; exit 0"),
+                Duration::from_millis(250),
+            )
+            .unwrap(),
+            "151.0.0.0"
+        );
+        assert!(start.elapsed() < Duration::from_secs(3));
+    }
+
+    #[test]
+    fn live_parent_and_closed_stdout_both_remain_bounded() {
+        for source in ["sleep 30", "exec 1>&-; sleep 30"] {
+            let start = Instant::now();
+            let error = run(script(source), Duration::from_millis(250)).unwrap_err();
+            assert!(error.contains("timed out"), "{error}");
+            assert!(start.elapsed() < Duration::from_secs(3));
+        }
+    }
+
+    #[test]
+    fn bounded_capture_handles_valid_invalid_and_failed_output() {
+        assert_eq!(
+            run(
+                script("printf 'Chromium 151.0.0.0\\n'"),
+                Duration::from_secs(2)
+            )
+            .unwrap(),
+            "151.0.0.0"
+        );
+        assert!(
+            run(script("printf 'not a version'"), Duration::from_secs(2))
+                .unwrap_err()
+                .contains("no version")
+        );
+        assert!(
+            run(
+                script("printf 'Chromium 151.0.0.0\\n'; exit 2"),
+                Duration::from_secs(2)
+            )
+            .unwrap_err()
+            .contains("exited")
+        );
+        assert!(
+            run(script("printf '\\377'"), Duration::from_secs(2))
+                .unwrap_err()
+                .contains("invalid UTF-8")
+        );
+    }
+
+    #[test]
+    fn output_limit_accepts_the_boundary_and_rejects_more() {
+        let exact = "printf 'Chromium 151.0.0.0\\n'; \
+                     dd if=/dev/zero bs=65517 count=1 2>/dev/null";
+        assert_eq!(
+            run(script(exact), Duration::from_secs(2)).unwrap(),
+            "151.0.0.0"
+        );
+
+        let oversized = "printf 'Chromium 151.0.0.0\\n'; \
+                         dd if=/dev/zero bs=65518 count=1 2>/dev/null";
+        let error = run(script(oversized), Duration::from_secs(2)).unwrap_err();
+        assert!(error.contains("65536"), "{error}");
+
+        let error = run(script("yes 'Chromium 151.0.0.0'"), Duration::from_secs(2)).unwrap_err();
+        assert!(error.contains("65536"), "{error}");
+    }
+
+    #[test]
+    fn successful_probe_reaps_a_descendant_that_closed_stdout() {
+        let pid_file = std::env::temp_dir().join(format!(
+            "donsetch-version-probe-descendant-{}.pid",
+            std::process::id()
+        ));
+        let mut cmd = script(
+            "sleep 30 >/dev/null 2>&1 & \
+             echo $! > \"$DONSETCH_PROBE_PID_FILE\"; \
+             printf 'Chromium 151.0.0.0\\n'",
+        );
+        cmd.env("DONSETCH_PROBE_PID_FILE", &pid_file);
+
+        assert_eq!(run(cmd, Duration::from_secs(2)).unwrap(), "151.0.0.0");
+        let pid: i32 = std::fs::read_to_string(&pid_file)
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap();
+        let _ = std::fs::remove_file(pid_file);
+
+        let deadline = Instant::now() + Duration::from_secs(1);
+        while unsafe { libc::kill(pid, 0) } == 0 && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert_ne!(
+            unsafe { libc::kill(pid, 0) },
+            0,
+            "descendant {pid} survived"
+        );
+    }
+}
+
+#[cfg(all(test, windows))]
+mod windows_tests {
+    use super::*;
+
+    fn fixture(role: &str) -> Command {
+        let mut cmd = Command::new(std::env::current_exe().unwrap());
+        cmd.args([
+            "--exact",
+            "profile::version_probe::windows_tests::fixture_process",
+            "--nocapture",
+        ])
+        .env("DONSETCH_REVIEW_PROBE_ROLE", role);
+        cmd
+    }
+
+    #[test]
+    // These descendants deliberately outlive the fixture parent: the tests
+    // below verify that closing the probe's Job Object reaps them instead.
+    #[allow(clippy::zombie_processes)]
+    fn fixture_process() {
+        let Ok(role) = std::env::var("DONSETCH_REVIEW_PROBE_ROLE") else {
+            return;
+        };
+        match role.as_str() {
+            "descendant" => std::thread::sleep(Duration::from_secs(30)),
+            "parent-exits" => {
+                let _descendant = fixture("descendant")
+                    .stdout(Stdio::inherit())
+                    .spawn()
+                    .unwrap();
+                println!("Chromium 151.0.0.0");
+            }
+            "parent-waits" => {
+                fixture("descendant")
+                    .stdout(Stdio::inherit())
+                    .status()
+                    .unwrap();
+            }
+            "detached" => {
+                let _descendant = fixture("descendant").stdout(Stdio::null()).spawn().unwrap();
+                println!("Chromium 151.0.0.0");
+            }
+            "flood" => {
+                use std::io::Write;
+                let mut stdout = std::io::stdout().lock();
+                loop {
+                    stdout.write_all(&[b'x'; 4096]).unwrap();
+                }
+            }
+            "valid" => println!("Chromium 151.0.0.0"),
+            _ => panic!("unknown fixture role"),
+        }
+    }
+
+    #[test]
+    fn job_accepts_exited_parent_output_and_bounds_a_live_parent() {
+        let start = Instant::now();
+        assert_eq!(
+            run(fixture("parent-exits"), Duration::from_secs(10)).unwrap(),
+            "151.0.0.0"
+        );
+        assert!(start.elapsed() < Duration::from_secs(5));
+
+        let start = Instant::now();
+        let error = run(fixture("parent-waits"), Duration::from_millis(500)).unwrap_err();
+        assert!(error.contains("timed out"), "{error}");
+        assert!(start.elapsed() < Duration::from_secs(5));
+    }
+
+    #[test]
+    fn job_capture_accepts_finite_output_and_bounds_floods() {
+        assert_eq!(
+            run(fixture("valid"), Duration::from_secs(10)).unwrap(),
+            "151.0.0.0"
+        );
+        assert!(
+            run(fixture("flood"), Duration::from_secs(10))
+                .unwrap_err()
+                .contains("65536")
+        );
+        assert_eq!(
+            run(fixture("detached"), Duration::from_secs(10)).unwrap(),
+            "151.0.0.0"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Completes the browser version-probe timeout started in `cf83850` during #196. A probe whose parent exited while a descendant retained stdout could leave the reader join blocked past the advertised deadline; continuous output was also unbounded.

- apply one post-spawn deadline to both child completion and stdout EOF
- replace the blocking reader-thread join with bounded, non-blocking capture
- cap probe output at 64 KiB
- contain descendants in a Unix process group or the existing Windows kill-on-close Job Object abstraction
- assign the Windows process while suspended, before descendants can escape the Job Object
- cover both event orders: a live parent and a parent that exits while a descendant retains stdout

## Type

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — deps, CI, tooling
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only

## Checks

- [x] `cargo nextest run --cargo-profile ci --features ocr,rerank,http` passes: 1158 passed, 1 skipped
- [x] `cargo clippy --all-targets --features ocr,rerank,http -- -Dwarnings` passes
- [x] `cargo fmt --all -- --check` passes
- [ ] CI is green on all platforms

## Breaking changes

None. Successful version parsing and the three-second public timeout are unchanged.

## Test plan

- parent remains alive with stdout open, or closes stdout before exiting
- parent exits while a descendant retains stdout
- valid output, invalid output, invalid UTF-8, and non-zero exit
- exact 64 KiB boundary, 64 KiB + 1, and an infinite output stream
- successful parent with a detached descendant verifies process-tree cleanup
- existing public-wrapper descendant timeout regression
- Windows Job Object fixtures compile for MSVC; runtime execution remains Windows CI-authoritative

The capture loop now waits for process exit and pipe EOF under the same deadline. Teardown closes the process-tree container and reaps the direct child. Windows Job Object creation and teardown are shared with DonGhost rather than maintained as a second implementation.
