### PR TITLE
fix(http): fail closed on ambiguous bearer tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -170,6 +170,11 @@ channel until the v4.0.0 release train.
 
 ### Fixed
 
+- HTTP bearer configuration now fails closed: modern TOML/env tokens reject
+  whitespace and non-visible bytes without echoing the secret, while legacy
+  text tokens retain their exact historical value instead of being trimmed
+  into disabled authentication. CORS/auth validation also runs before daemon
+  work.
 - The supervisor's replay now survives a crash loop: the bytes
   replayed into a replacement were cleared from the unacked
   history, so a second silent death dropped them (reported by

--- a/src/config.rs
+++ b/src/config.rs
@@ -324,12 +324,19 @@ pub fn load() -> Result<Loaded, ConfigError> {
     // Validate the file layer on its own so unknown keys and bad types
     // fail loudly with the file path attached, exactly once.
     if let Some(file) = &file_layer {
-        deserialize_layer_table(file).map_err(|m| ConfigError::File {
-            path: file_path
-                .as_ref()
-                .map(|p| p.display().to_string())
-                .unwrap_or_default(),
-            message: m.to_string(),
+        let path = file_path
+            .as_ref()
+            .map(|p| p.display().to_string())
+            .unwrap_or_default();
+        let source = deserialize_layer_table(file).map_err(|message| ConfigError::File {
+            path: path.clone(),
+            message: message.to_string(),
+        })?;
+        validate_modern_http_token(&source.transport.token).map_err(|message| {
+            ConfigError::File {
+                path,
+                message: message.to_string(),
+            }
         })?;
     }
 
@@ -506,13 +513,17 @@ fn legacy_layer() -> (VMap, Vec<String>) {
         }
         None => {}
     }
-    if let Some(v) = std::env::var_os("DONSETCH_HTTP_TOKEN") {
-        put(
+    match std::env::var("DONSETCH_HTTP_TOKEN") {
+        Ok(value) => put(
             &mut m,
             "transport.token",
-            v.to_string_lossy().into_owned().into(),
+            value.into(),
             "DONSETCH_HTTP_TOKEN",
-        );
+        ),
+        Err(std::env::VarError::NotUnicode(_)) => {
+            warnings.push("ignoring DONSETCH_HTTP_TOKEN: not valid UTF-8".into())
+        }
+        Err(std::env::VarError::NotPresent) => {}
     }
     match int_env("DONSETCH_HTTP_TIMEOUT_SECS") {
         Some(n) => put_num(
@@ -1150,7 +1161,7 @@ pub(crate) fn fieldbook() -> &'static Fieldbook {
             "token",
             FieldKind::Str,
             "(empty)",
-            "HTTP bearer token; empty = token auth off",
+            "HTTP bearer token; empty = auth off; modern values use visible ASCII without whitespace",
         ),
         (
             "transport",
@@ -1743,7 +1754,7 @@ fn new_env_layer() -> (VMap, Vec<String>, Vec<String>) {
     let mut errors = Vec::new();
 
     for (name, value) in std::env::vars_os() {
-        let (Some(name), Some(value)) = (name.to_str(), value.to_str()) else {
+        let Some(name) = name.to_str() else {
             continue;
         };
         if !name.starts_with("DONSETCH_") || name == "DONSETCH_" {
@@ -1772,6 +1783,18 @@ fn new_env_layer() -> (VMap, Vec<String>, Vec<String>) {
             ));
             continue;
         };
+        let Some(value) = value.to_str() else {
+            if (section, key) == ("transport", "token") {
+                errors.push(format!("{name}: {MODERN_HTTP_TOKEN_REQUIREMENT}"));
+            }
+            continue;
+        };
+        if (section, key) == ("transport", "token")
+            && let Err(message) = validate_modern_http_token(value)
+        {
+            errors.push(format!("{name}: {message}"));
+            continue;
+        }
         let vkind = match kind {
             FieldKind::Str => config::ValueKind::String(value.to_string()),
             FieldKind::Bool => match boolish(value) {
@@ -1850,6 +1873,28 @@ fn validate(c: &DonsetchConfig) -> Result<(), ConfigError> {
     }
     if c.search.rerank_threads > 64 {
         return err("search.rerank_threads must be 0 (auto) or 1..=64".into());
+    }
+    Ok(())
+}
+
+/// Resolve the exact bearer-token contract used by the HTTP transport.
+/// Empty means auth off; every non-empty loaded value remains auth-on and is
+/// compared byte-for-byte for backward compatibility.
+pub(crate) fn configured_http_token(token: &str) -> Option<&str> {
+    (!token.is_empty()).then_some(token)
+}
+
+/// Modern sources are strict: an explicit empty string disables auth, while
+/// configured tokens must fit safely and unambiguously in an HTTP header.
+/// Never include the token itself in the error returned to diagnostics.
+const MODERN_HTTP_TOKEN_REQUIREMENT: &str =
+    "transport.token must be empty or contain only visible ASCII without whitespace";
+
+fn validate_modern_http_token(token: &str) -> Result<(), &'static str> {
+    if configured_http_token(token)
+        .is_some_and(|token| !token.bytes().all(|byte| byte.is_ascii_graphic()))
+    {
+        return Err(MODERN_HTTP_TOKEN_REQUIREMENT);
     }
     Ok(())
 }
@@ -2430,6 +2475,95 @@ mod tests {
             );
             drop(guard);
         }
+    }
+
+    #[test]
+    fn modern_http_tokens_are_strict_and_errors_never_echo_them() {
+        let guard = clean_env();
+        let file_secret = "file token sentinel";
+        let path = write_cfg(
+            &std::env::temp_dir(),
+            &format!("[transport]\ntoken = {file_secret:?}\n"),
+        );
+        set_env("DONSETCH_CONFIG", &path);
+        let error = load()
+            .err()
+            .expect("whitespace token must fail")
+            .to_string();
+        assert!(error.contains("transport.token"), "{error}");
+        assert!(!error.contains(file_secret), "file token leaked: {error}");
+
+        unset_env("DONSETCH_CONFIG");
+        set_env("DONSETCH_NO_CONFIG_FILE", "1");
+        let env_secret = "environment token sentinel";
+        set_env("DONSETCH_TRANSPORT__TOKEN", env_secret);
+        let error = load()
+            .err()
+            .expect("whitespace token must fail")
+            .to_string();
+        assert!(error.contains("DONSETCH_TRANSPORT__TOKEN"), "{error}");
+        assert!(!error.contains(env_secret), "env token leaked: {error}");
+
+        set_env("DONSETCH_TRANSPORT__TOKEN", "   ");
+        assert!(
+            load().is_err(),
+            "whitespace-only token must not disable auth"
+        );
+
+        set_env("DONSETCH_TRANSPORT__TOKEN", "Abc-._~+/=:");
+        let loaded = load().expect("visible ASCII token");
+        assert_eq!(loaded.config.transport.token, "Abc-._~+/=:");
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStringExt;
+
+            set_env(
+                "DONSETCH_TRANSPORT__TOKEN",
+                std::ffi::OsString::from_vec(b"modern-\xff-token".to_vec()),
+            );
+            let error = load().err().expect("non-UTF-8 token must fail").to_string();
+            assert!(error.contains("DONSETCH_TRANSPORT__TOKEN"), "{error}");
+            assert!(error.contains("visible ASCII"), "{error}");
+        }
+        drop(guard);
+    }
+
+    #[test]
+    fn legacy_http_token_value_survives_and_modern_empty_can_disable_auth() {
+        let guard = clean_env();
+        set_env("DONSETCH_NO_CONFIG_FILE", "1");
+        set_env("DONSETCH_HTTP_TOKEN", " padded legacy token ");
+        let loaded = load().expect("legacy token");
+        assert_eq!(
+            configured_http_token(&loaded.config.transport.token),
+            Some(" padded legacy token ")
+        );
+
+        set_env("DONSETCH_TRANSPORT__TOKEN", "");
+        let loaded = load().expect("modern empty override");
+        assert_eq!(loaded.config.transport.token, "");
+        assert_eq!(configured_http_token(&loaded.config.transport.token), None);
+
+        #[cfg(unix)]
+        {
+            use std::os::unix::ffi::OsStringExt;
+
+            unset_env("DONSETCH_TRANSPORT__TOKEN");
+            set_env(
+                "DONSETCH_HTTP_TOKEN",
+                std::ffi::OsString::from_vec(b"legacy-\xff-token".to_vec()),
+            );
+            let loaded = load().expect("legacy non-UTF-8 keeps its historical fallback");
+            assert_eq!(configured_http_token(&loaded.config.transport.token), None);
+            assert!(
+                loaded
+                    .warnings
+                    .iter()
+                    .any(|warning| warning == "ignoring DONSETCH_HTTP_TOKEN: not valid UTF-8")
+            );
+        }
+        drop(guard);
     }
 
     /// Markdown tables must never split a row: raw pipes in defaults

--- a/src/mcp/http.rs
+++ b/src/mcp/http.rs
@@ -100,10 +100,8 @@ struct HttpState {
 
 /// Run the HTTP MCP server until SIGTERM/SIGINT.
 pub async fn run(host: String, port: u16) -> Result<(), Box<dyn std::error::Error>> {
-    let daemon = Arc::new(Daemon::new().await.map_err(|e| e.to_string())?);
-    daemon.start_prober();
     let t = crate::config::cfg().transport.clone();
-    let auth_token = (!t.token.trim().is_empty()).then_some(t.token.trim().to_string());
+    let auth_token = crate::config::configured_http_token(&t.token).map(str::to_owned);
     let auth_enabled = auth_token.is_some();
     let timeout = Duration::from_secs(t.timeout_secs);
 
@@ -113,6 +111,11 @@ pub async fn run(host: String, port: u16) -> Result<(), Box<dyn std::error::Erro
     // Browser-based clients can opt in with [transport] cors = true.
     let cors_enabled = t.cors;
     validate_http_config(cors_enabled, auth_enabled)?;
+
+    // Configuration must fail before daemon construction starts background
+    // work or touches persistent state.
+    let daemon = Arc::new(Daemon::new().await.map_err(|e| e.to_string())?);
+    daemon.start_prober();
 
     let state = HttpState {
         daemon: Arc::clone(&daemon),
@@ -588,9 +591,22 @@ mod tests {
     fn token_ok_no_token_configured_allows_all() {
         assert!(token_ok(None, &HeaderMap::new()));
         assert!(token_ok(None, &headers_with_bearer(Some("anything"))));
-        // run() filters empty env tokens, but the pure function still
-        // treats a configured (even empty) token as auth-on.
+        // The pure matcher treats Some as auth-on; configured_http_token is
+        // the single boundary that maps an exact empty value to None.
         assert!(!token_ok(Some(""), &HeaderMap::new()));
+    }
+
+    #[test]
+    fn legacy_token_is_compared_without_trimming() {
+        let expected = crate::config::configured_http_token(" padded token ");
+        assert!(token_ok(
+            expected,
+            &headers_with_bearer(Some(" padded token "))
+        ));
+        assert!(!token_ok(
+            expected,
+            &headers_with_bearer(Some("padded token"))
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Reject ambiguous modern `transport.token` values from TOML and `DONSETCH_TRANSPORT__TOKEN`; whitespace-only and non-UTF-8 values now fail configuration loading instead of silently disabling authentication.
- Preserve the legacy `DONSETCH_HTTP_TOKEN` contract: exact non-empty UTF-8 values remain authentication-on and are compared without trimming, while an exact empty value remains authentication-off.
- Validate the auth/CORS combination before daemon construction starts background work or touches persistent state.
- Keep the token contract centralized and ensure diagnostics never echo the configured secret.

## Type

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — deps, CI, tooling
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only

## Checks

- [x] `cargo nextest run --cargo-profile ci --features ocr,rerank,http` passes (1,156 passed, 1 skipped)
- [x] `cargo clippy --all-targets --features ocr,rerank,http -- -Dwarnings` passes (zero warnings)
- [x] `cargo fmt --all -- --check` passes
- [ ] CI is green on all 3 platforms (Linux, macOS, Windows)

## Breaking changes

None for valid configurations. Modern token values containing whitespace, non-visible bytes, or non-UTF-8 data now fail explicitly instead of being normalized or ignored.

## Test plan

- TOML and modern-env tokens containing whitespace are rejected without appearing in the error text.
- A whitespace-only modern token cannot collapse to authentication-off.
- Non-UTF-8 modern env values fail closed on Unix.
- Visible-ASCII modern tokens load unchanged.
- Legacy padded UTF-8 tokens retain exact-match behavior; a higher-precedence explicit modern empty token still disables auth.
- Legacy non-UTF-8 values retain their historical ignored fallback and emit only a static warning.
- HTTP bearer matching verifies the exact legacy value rather than a trimmed form.
- The complete CI-profile Nextest suite, Clippy with HTTP enabled, formatting, and diff checks pass locally.
