### PR TITLE
fix(config): preserve browser override presence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,10 @@ channel until the v4.0.0 release train.
   text tokens retain their exact historical value instead of being trimmed
   into disabled authentication. CORS/auth validation also runs before daemon
   work.
+- Browser path overrides now preserve source presence across the typed config:
+  legacy empty values keep their historical override semantics, while modern
+  empty values reset to discovery or ambient defaults. Explicit Chromium,
+  CloakBrowser and Playwright paths remain literal.
 - The supervisor's replay now survives a crash loop: the bytes
   replayed into a replacement were cleared from the unacked
   history, so a second silent death dropped them (reported by

--- a/src/config.rs
+++ b/src/config.rs
@@ -269,6 +269,41 @@ pub struct Loaded {
     pub merged: config::Map<String, config::Value>,
 }
 
+impl Loaded {
+    fn origin_of(&self, path: &str) -> Option<&str> {
+        let (section, key) = path.split_once('.')?;
+        self.merged
+            .get(section)
+            .and_then(|value| match &value.kind {
+                config::ValueKind::Table(inner) => inner.get(key),
+                _ => None,
+            })
+            .and_then(config::Value::origin)
+    }
+
+    /// Legacy optional browser strings used presence semantics: even an
+    /// empty value was supplied. Modern/file empty strings instead clear a
+    /// lower override and restore discovery or the documented default.
+    fn browser_string_is_supplied(&self, path: &str, value: &str, legacy_name: &str) -> bool {
+        !value.is_empty() || self.origin_of(path) == Some(legacy_name)
+    }
+
+    /// A configured mirror wins by presence, including an explicit empty
+    /// reset. Only an absent config leaf falls back to the ambient OS value.
+    fn mirrored_os(
+        &self,
+        path: &str,
+        configured: &str,
+        ambient_name: &str,
+    ) -> Option<std::ffi::OsString> {
+        if self.origin_of(path).is_some() || !configured.is_empty() {
+            Some(configured.into())
+        } else {
+            std::env::var_os(ambient_name)
+        }
+    }
+}
+
 /// Load the layered config from defaults + env + TOML file and validate it.
 pub fn load() -> Result<Loaded, ConfigError> {
     let mut warnings = Vec::new();
@@ -2159,38 +2194,75 @@ pub(crate) fn legacy_target_of(name: &str) -> (&'static str, &'static str) {
 // The global
 // ---------------------------------------------------------------------------
 
-static CONFIG: OnceLock<DonsetchConfig> = OnceLock::new();
+static CONFIG: OnceLock<Loaded> = OnceLock::new();
 
-/// Install a validated config (the CLI/MCP entry point does this after
-/// merging CLI flags). Errors are fatal and reported to the caller.
+fn install_loaded_inner(loaded: Loaded) -> Result<(), ConfigError> {
+    validate(&loaded.config)?;
+    CONFIG
+        .set(loaded)
+        .map_err(|_| ConfigError::Env("config is already installed in this process".into()))
+}
+
+/// Install a validated programmatic config. Errors are fatal and reported to
+/// the caller.
 /// Installing twice in one process is an error, not a silent no-op:
 /// the first install is the contract the whole daemon reads.
 pub fn install(cfg: DonsetchConfig) -> Result<(), ConfigError> {
-    validate(&cfg)?;
-    CONFIG
-        .set(cfg)
-        .map_err(|_| ConfigError::Env("config is already installed in this process".into()))
+    install_loaded_inner(Loaded {
+        config: cfg,
+        warnings: Vec::new(),
+        file: None,
+        merged: config::Map::new(),
+    })
+}
+
+/// Install the exact layered snapshot returned by [`load`]. Keeping its
+/// origins beside the typed config preserves source-sensitive compatibility
+/// without re-reading legacy environment variables in runtime consumers.
+pub fn install_loaded(loaded: Loaded) -> Result<(), ConfigError> {
+    install_loaded_inner(loaded)
 }
 
 /// The process config, initializing lazily from defaults + env + file.
 ///
 /// Errors at this path cannot be fatal (no caller context), so the error
 /// and the default config are reported to stderr and the default is used;
-/// the binary entry points call `load()` + `install()` first so real users
-/// always get the loud path.
-pub fn cfg() -> &'static DonsetchConfig {
+/// the binary entry points call `load()` + `install_loaded()` first so real
+/// users always get the loud path.
+fn installed() -> &'static Loaded {
     CONFIG.get_or_init(|| match load() {
         Ok(loaded) => {
             for w in &loaded.warnings {
                 eprintln!("[donsetch config] {w}");
             }
-            loaded.config
+            loaded
         }
         Err(e) => {
             eprintln!("[donsetch config] {e}; using defaults");
-            DonsetchConfig::default()
+            Loaded {
+                config: DonsetchConfig::default(),
+                warnings: Vec::new(),
+                file: None,
+                merged: config::Map::new(),
+            }
         }
     })
+}
+
+pub fn cfg() -> &'static DonsetchConfig {
+    &installed().config
+}
+
+pub(crate) fn browser_string_is_supplied(path: &str, value: &str, legacy_name: &str) -> bool {
+    installed().browser_string_is_supplied(path, value, legacy_name)
+}
+
+pub(crate) fn mirrored_os(
+    path: &str,
+    configured: &str,
+    ambient_name: &str,
+) -> Option<std::ffi::OsString> {
+    installed().mirrored_os(path, configured, ambient_name)
 }
 
 // ---------------------------------------------------------------------------
@@ -2355,6 +2427,81 @@ mod tests {
             loaded.config.fetch.pdf_max_mb, 44,
             "the file layer must beat the legacy env name"
         );
+        drop(guard);
+    }
+
+    #[test]
+    fn browser_strings_distinguish_legacy_presence_modern_reset_and_ambient_fallback() {
+        let guard = clean_env();
+        let playwright = std::env::var_os("PLAYWRIGHT_BROWSERS_PATH");
+        set_env("DONSETCH_NO_CONFIG_FILE", "1");
+        set_env("PLAYWRIGHT_BROWSERS_PATH", "/ambient/playwright");
+
+        let fields = [
+            (
+                "browser.chromium_path",
+                "DONGHOST_CHROME",
+                "DONSETCH_BROWSER__CHROMIUM_PATH",
+            ),
+            (
+                "browser.cloak_path",
+                "CLOAKBROWSER_BINARY_PATH",
+                "DONSETCH_BROWSER__CLOAK_PATH",
+            ),
+            (
+                "browser.cloak_version",
+                "CLOAKBROWSER_VERSION",
+                "DONSETCH_BROWSER__CLOAK_VERSION",
+            ),
+            (
+                "browser.cloak_cache_dir",
+                "CLOAKBROWSER_CACHE_DIR",
+                "DONSETCH_BROWSER__CLOAK_CACHE_DIR",
+            ),
+        ];
+
+        let absent = load().expect("absent browser overrides");
+        for (path, legacy, _) in fields {
+            assert!(!absent.browser_string_is_supplied(path, "", legacy));
+        }
+        assert_eq!(
+            absent.mirrored_os("browser.playwright_path", "", "PLAYWRIGHT_BROWSERS_PATH"),
+            Some("/ambient/playwright".into()),
+            "an absent config mirror must use the ambient OS value"
+        );
+
+        for (_, legacy, _) in fields {
+            set_env(legacy, "");
+        }
+        let legacy_empty = load().expect("empty legacy browser overrides");
+        for (path, legacy, _) in fields {
+            assert!(
+                legacy_empty.browser_string_is_supplied(path, "", legacy),
+                "{legacy}=empty was historically present"
+            );
+        }
+
+        for (_, _, modern) in fields {
+            set_env(modern, "");
+        }
+        set_env("DONSETCH_BROWSER__PLAYWRIGHT_PATH", "");
+        let reset = load().expect("modern empty reset");
+        for (path, legacy, _) in fields {
+            assert!(
+                !reset.browser_string_is_supplied(path, "", legacy),
+                "a modern empty {path} must clear the lower legacy override"
+            );
+        }
+        assert_eq!(
+            reset.mirrored_os("browser.playwright_path", "", "PLAYWRIGHT_BROWSERS_PATH"),
+            Some(std::ffi::OsString::new()),
+            "an explicit empty mirror must reset, not revive, the ambient value"
+        );
+
+        match playwright {
+            Some(value) => set_env("PLAYWRIGHT_BROWSERS_PATH", value),
+            None => unset_env("PLAYWRIGHT_BROWSERS_PATH"),
+        }
         drop(guard);
     }
 

--- a/src/ghost/cloak.rs
+++ b/src/ghost/cloak.rs
@@ -144,7 +144,12 @@ fn resolve_browser_with_download(allow_download: bool) -> Result<BrowserResoluti
 fn resolve_chromium(backend: BrowserBackend) -> Result<BrowserResolution, String> {
     let path = super::chromium_binary()?;
     let version = crate::profile::probe_version_string_at_path(&path);
-    let source = if !crate::config::cfg().browser.chromium_path.is_empty() {
+    let configured = &crate::config::cfg().browser.chromium_path;
+    let source = if crate::config::browser_string_is_supplied(
+        "browser.chromium_path",
+        configured,
+        "DONGHOST_CHROME",
+    ) {
         "explicit"
     } else {
         "system"
@@ -158,9 +163,13 @@ fn resolve_chromium(backend: BrowserBackend) -> Result<BrowserResolution, String
 }
 
 fn resolve_cloak(allow_download: bool) -> Result<BrowserResolution, String> {
-    let configured_cloak_path = crate::config::cfg().browser.cloak_path.trim().to_string();
-    let (path, source) = if !configured_cloak_path.is_empty() {
-        let path = PathBuf::from(&configured_cloak_path);
+    let configured_cloak_path = &crate::config::cfg().browser.cloak_path;
+    let (path, source) = if crate::config::browser_string_is_supplied(
+        "browser.cloak_path",
+        configured_cloak_path,
+        "CLOAKBROWSER_BINARY_PATH",
+    ) {
+        let path = PathBuf::from(configured_cloak_path);
         validate_binary(&path).map_err(|e| {
             format!(
                 "[browser] cloak_path `{}` invalid (legacy env CLOAKBROWSER_BINARY_PATH): {e}",
@@ -229,15 +238,17 @@ fn platform_tag() -> Result<&'static str, String> {
 }
 
 fn requested_version() -> Result<String, String> {
-    let pinned = crate::config::cfg()
-        .browser
-        .cloak_version
-        .trim()
-        .to_string();
-    if pinned.is_empty() {
+    let configured = &crate::config::cfg().browser.cloak_version;
+    if !crate::config::browser_string_is_supplied(
+        "browser.cloak_version",
+        configured,
+        "CLOAKBROWSER_VERSION",
+    ) {
         return Ok(CLOAK_VERSION.into());
     }
-    let value = pinned;
+    // Version is text, not a path: historical behavior trimmed it before
+    // validating the full dotted numeric form.
+    let value = configured.trim().to_string();
     if valid_version(&value) {
         Ok(value)
     } else {
@@ -256,15 +267,15 @@ fn valid_version(value: &str) -> bool {
 }
 
 fn cache_dir() -> PathBuf {
-    let configured = crate::config::cfg()
-        .browser
-        .cloak_cache_dir
-        .trim()
-        .to_string();
-    if configured.is_empty() {
-        crate::paths::cache_dir().join("cloakbrowser")
-    } else {
+    let configured = &crate::config::cfg().browser.cloak_cache_dir;
+    if crate::config::browser_string_is_supplied(
+        "browser.cloak_cache_dir",
+        configured,
+        "CLOAKBROWSER_CACHE_DIR",
+    ) {
         PathBuf::from(configured)
+    } else {
+        crate::paths::cache_dir().join("cloakbrowser")
     }
 }
 

--- a/src/ghost/mod.rs
+++ b/src/ghost/mod.rs
@@ -183,7 +183,11 @@ fn chromium_binary() -> Result<String, String> {
     // `browser.chromium_path` already layers the legacy DONGHOST_CHROME
     // env var, so the config value is the single explicit source here.
     let configured = &crate::config::cfg().browser.chromium_path;
-    if !configured.is_empty() {
+    if crate::config::browser_string_is_supplied(
+        "browser.chromium_path",
+        configured,
+        "DONGHOST_CHROME",
+    ) {
         let path = PathBuf::from(configured);
         if !is_executable(&path) {
             return Err(format!(
@@ -313,10 +317,13 @@ fn playwright_registry_roots() -> Vec<PathBuf> {
     // The config knob wins when set; otherwise the ambient standard
     // var still applies (mirror-when-set semantics).
     let cfg_root = &crate::config::cfg().browser.playwright_path;
-    if !cfg_root.is_empty() {
-        roots.push(PathBuf::from(cfg_root));
-    } else if let Some(ov) = std::env::var_os("PLAYWRIGHT_BROWSERS_PATH") {
-        roots.push(PathBuf::from(ov));
+    if let Some(root) = crate::config::mirrored_os(
+        "browser.playwright_path",
+        cfg_root,
+        "PLAYWRIGHT_BROWSERS_PATH",
+    ) && !root.is_empty()
+    {
+        roots.push(PathBuf::from(root));
     }
     #[cfg(not(windows))]
     if let Some(home) = std::env::var_os("HOME").map(PathBuf::from) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,18 +6,19 @@ use donsetch::mcp;
 /// Load the layered config, apply CLI overrides, install it process-wide.
 /// Fatal on any config error: a bad knob must stop the daemon loudly.
 fn load_and_install_config(args: &[String]) -> &'static config::DonsetchConfig {
-    let mut c = match config::load() {
+    let mut loaded = match config::load() {
         Ok(loaded) => {
             for w in &loaded.warnings {
                 eprintln!("[donsetch config] {w}");
             }
-            loaded.config
+            loaded
         }
         Err(e) => {
             eprintln!("donsetch: {e}");
             std::process::exit(1);
         }
     };
+    let c = &mut loaded.config;
     if args.iter().any(|a| a == "--http") {
         c.transport.kind = config::TransportKind::Http;
     }
@@ -33,7 +34,7 @@ fn load_and_install_config(args: &[String]) -> &'static config::DonsetchConfig {
             }
         }
     }
-    if let Err(e) = config::install(c) {
+    if let Err(e) = config::install_loaded(loaded) {
         eprintln!("donsetch: {e}");
         std::process::exit(1);
     }


### PR DESCRIPTION
## Summary

- preserve the winning config origin in the installed singleton so legacy browser overrides retain presence semantics
- distinguish absent overrides, legacy empty values, and modern empty resets
- keep Chromium, CloakBrowser, and Playwright paths literal
- document the behavior under Unreleased

## Type

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — deps, CI, tooling
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only

## Checks

- [x] `cargo nextest run --cargo-profile ci --features ocr,rerank` (1,149 passed, 1 skipped)
- [x] `cargo clippy --all-targets --features ocr,rerank -- -Dwarnings`
- [x] `cargo fmt --all -- --check`
- [x] CI is green on Linux, macOS, and Windows

## Breaking changes

None. Existing legacy presence semantics are restored; modern empty values remain the explicit reset form.

## Test plan

- cover absent browser overrides falling back to discovery or ambient values
- cover legacy empty values remaining explicitly supplied
- cover modern empty values clearing lower-precedence legacy overrides
- cover an explicit empty Playwright value suppressing the ambient mirror

