### PR TITLE
fix(search): consume typed reranker thread config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -176,6 +176,9 @@ channel until the v4.0.0 release train.
 
 ### Fixed
 
+- The ONNX reranker now consumes the validated `search.rerank_threads` value
+  directly instead of leaking and reparsing a string, and reports configured
+  values as coming from the layered config. `0 = auto` behavior is unchanged.
 - HTTP bearer configuration now fails closed: modern TOML/env tokens reject
   whitespace and non-visible bytes without echoing the secret, while legacy
   text tokens retain their exact historical value instead of being trimmed

--- a/src/search/rerank.rs
+++ b/src/search/rerank.rs
@@ -34,9 +34,6 @@ mod inner {
     /// Max sequence length for the MiniLM cross-encoder.
     const MAX_SEQ_LEN: usize = 512;
 
-    /// ONNX Runtime accepts the thread count as a C `int`.
-    const MAX_INTRA_THREADS: usize = i32::MAX as usize;
-
     const MODEL_URL: &str = "https://huggingface.co/Xenova/ms-marco-MiniLM-L-6-v2/resolve/main/onnx/model_quantized.onnx";
     const MODEL_SHA256: &str = "e9d8ebf845c413e981c175bfe49a3bfa9b3dcce2a3ba54875ee5df5a58639fbe";
     const TOKENIZER_URL: &str =
@@ -53,7 +50,7 @@ mod inner {
 
     #[derive(Clone, Copy, Debug, PartialEq, Eq)]
     enum ThreadSelection {
-        Environment {
+        Configured {
             threads: usize,
         },
         Automatic {
@@ -70,32 +67,10 @@ mod inner {
     impl ThreadSelection {
         fn threads(self) -> Option<usize> {
             match self {
-                Self::Environment { threads } | Self::Automatic { threads, .. } => Some(threads),
+                Self::Configured { threads } | Self::Automatic { threads, .. } => Some(threads),
                 Self::OnnxDefault { .. } => None,
             }
         }
-    }
-
-    enum ThreadOverride<'a> {
-        Unset,
-        Value(&'a str),
-        /// Unreachable through the config (validation rejects
-        /// non-numeric values at load); kept for the pure-machinery tests.
-        #[cfg_attr(not(test), allow(dead_code))]
-        InvalidUnicode,
-    }
-
-    fn parse_intra_threads(raw: &str) -> Result<usize, String> {
-        let raw = raw.trim();
-        let threads = raw.parse::<usize>().map_err(|_| {
-            format!("DONSEEK_RERANK_THREADS must be an integer between 1 and {MAX_INTRA_THREADS}")
-        })?;
-        if !(1..=MAX_INTRA_THREADS).contains(&threads) {
-            return Err(format!(
-                "DONSEEK_RERANK_THREADS must be an integer between 1 and {MAX_INTRA_THREADS}"
-            ));
-        }
-        Ok(threads)
     }
 
     fn automatic_intra_threads(effective: Option<usize>, physical: usize) -> ThreadSelection {
@@ -113,60 +88,39 @@ mod inner {
     }
 
     fn select_intra_threads(
-        override_value: ThreadOverride<'_>,
+        configured: u32,
         effective: Option<usize>,
         physical: usize,
-    ) -> (ThreadSelection, Option<String>) {
-        match override_value {
-            ThreadOverride::Value(raw) => match parse_intra_threads(raw) {
-                Ok(threads) => (ThreadSelection::Environment { threads }, None),
-                Err(e) => (
-                    automatic_intra_threads(effective, physical),
-                    Some(format!("{e}; using automatic selection")),
-                ),
-            },
-            ThreadOverride::InvalidUnicode => (
-                automatic_intra_threads(effective, physical),
-                Some(
-                    "DONSEEK_RERANK_THREADS must contain valid UTF-8; using automatic selection"
-                        .to_string(),
-                ),
-            ),
-            ThreadOverride::Unset => (automatic_intra_threads(effective, physical), None),
+    ) -> ThreadSelection {
+        if configured == 0 {
+            automatic_intra_threads(effective, physical)
+        } else {
+            ThreadSelection::Configured {
+                threads: configured as usize,
+            }
         }
     }
 
     fn configured_intra_threads() -> ThreadSelection {
         let effective = std::thread::available_parallelism().ok().map(|n| n.get());
         let physical = num_cpus::get_physical();
-        // Source: [search] rerank_threads in the layered config
-        // (historically DONSEEK_RERANK_THREADS). 0 = auto; unparsable
-        // values are already rejected at config load, and legacy env
-        // values warn there.
+        // Values have already been parsed and validated by the process-wide
+        // layered config. 0 = auto; every nonzero value is explicit.
         let configured = crate::config::cfg().search.rerank_threads;
-        let override_value = if configured == 0 {
-            ThreadOverride::Unset
-        } else {
-            ThreadOverride::Value(Box::leak(configured.to_string().into_boxed_str()))
-        };
-        let (selection, warning) = select_intra_threads(override_value, effective, physical);
-        if let Some(warning) = warning {
-            eprintln!("[rerank] invalid configuration: {warning}");
-        }
-        selection
+        select_intra_threads(configured, effective, physical)
     }
 
-    fn log_thread_selection(selection: ThreadSelection) {
+    fn thread_selection_log(selection: ThreadSelection) -> String {
         match selection {
-            ThreadSelection::Environment { threads } => eprintln!(
-                "[rerank] ONNX intra-op threads: {} (source: DONSEEK_RERANK_THREADS)",
+            ThreadSelection::Configured { threads } => format!(
+                "[rerank] ONNX intra-op threads: {} (source: layered config)",
                 threads
             ),
             ThreadSelection::Automatic {
                 threads,
                 effective,
                 physical,
-            } => eprintln!(
+            } => format!(
                 "[rerank] ONNX intra-op threads: {} (source: automatic, effective: {}, physical: {})",
                 threads, effective, physical
             ),
@@ -174,16 +128,20 @@ mod inner {
                 effective,
                 physical,
             } => match effective {
-                Some(effective) => eprintln!(
+                Some(effective) => format!(
                     "[rerank] ONNX intra-op threads: default (effective: {effective}, physical: {})",
                     physical
                 ),
-                None => eprintln!(
+                None => format!(
                     "[rerank] ONNX intra-op threads: default (effective parallelism unavailable, physical: {})",
                     physical
                 ),
             },
         }
+    }
+
+    fn log_thread_selection(selection: ThreadSelection) {
+        eprintln!("{}", thread_selection_log(selection));
     }
 
     /// Returns the cache directory for reranker model files.
@@ -769,27 +727,9 @@ mod inner {
         }
 
         #[test]
-        fn rerank_threads_accepts_positive_integers() {
-            assert_eq!(parse_intra_threads("1").unwrap(), 1);
-            assert_eq!(parse_intra_threads("2").unwrap(), 2);
-            assert_eq!(parse_intra_threads(" 64 ").unwrap(), 64);
-            assert_eq!(
-                parse_intra_threads(&MAX_INTRA_THREADS.to_string()).unwrap(),
-                MAX_INTRA_THREADS
-            );
-        }
-
-        #[test]
-        fn rerank_threads_rejects_invalid_values() {
-            for raw in ["", "0", "-1", "1.5", "two", "2147483648"] {
-                assert!(parse_intra_threads(raw).is_err(), "accepted {raw:?}");
-            }
-        }
-
-        #[test]
         fn rerank_threads_auto_clamps_constrained_processes() {
             assert_eq!(
-                automatic_intra_threads(Some(2), 8),
+                select_intra_threads(0, Some(2), 8),
                 ThreadSelection::Automatic {
                     threads: 2,
                     effective: 2,
@@ -802,10 +742,10 @@ mod inner {
         #[test]
         fn rerank_threads_auto_preserves_unconstrained_onnx_default() {
             for selection in [
-                automatic_intra_threads(Some(8), 4),
-                automatic_intra_threads(Some(4), 4),
-                automatic_intra_threads(None, 8),
-                automatic_intra_threads(Some(0), 8),
+                select_intra_threads(0, Some(8), 4),
+                select_intra_threads(0, Some(4), 4),
+                select_intra_threads(0, None, 8),
+                select_intra_threads(0, Some(0), 8),
             ] {
                 assert_eq!(selection.threads(), None);
                 assert!(matches!(selection, ThreadSelection::OnnxDefault { .. }));
@@ -813,33 +753,18 @@ mod inner {
         }
 
         #[test]
-        fn rerank_threads_environment_override_wins() {
-            let (selection, warning) = select_intra_threads(ThreadOverride::Value("1"), Some(2), 8);
-            assert_eq!(selection.threads(), Some(1));
-            assert!(matches!(
-                selection,
-                ThreadSelection::Environment { threads: 1 }
-            ));
-            assert_eq!(warning, None);
-        }
-
-        #[test]
-        fn rerank_threads_invalid_override_falls_back_to_auto() {
-            for override_value in [
-                ThreadOverride::Value("invalid"),
-                ThreadOverride::InvalidUnicode,
-            ] {
-                let (selection, warning) = select_intra_threads(override_value, Some(2), 8);
-                assert_eq!(selection.threads(), Some(2));
-                assert!(matches!(selection, ThreadSelection::Automatic { .. }));
-                assert!(warning.is_some());
+        fn rerank_threads_configured_value_wins() {
+            for configured in [1, 2, 64] {
+                let selection = select_intra_threads(configured, Some(1), 8);
+                assert_eq!(selection.threads(), Some(configured as usize));
+                assert!(matches!(selection, ThreadSelection::Configured { .. }));
+                assert_eq!(
+                    thread_selection_log(selection),
+                    format!(
+                        "[rerank] ONNX intra-op threads: {configured} (source: layered config)"
+                    )
+                );
             }
-
-            let (selection, warning) =
-                select_intra_threads(ThreadOverride::Value("invalid"), Some(8), 4);
-            assert_eq!(selection.threads(), None);
-            assert!(matches!(selection, ThreadSelection::OnnxDefault { .. }));
-            assert!(warning.is_some());
         }
     }
 }


### PR DESCRIPTION
## Summary

Consume the validated `search.rerank_threads` integer directly when initializing the ONNX reranker. This removes an initialization-only string leak and reparse, preserves `0 = auto`, reports configured values as coming from layered config, and documents the fix under Unreleased.

## Type

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — deps, CI, tooling
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only

## Checks

- [x] full test and lint matrix passed in CI for the code commit
- [x] `cargo test --profile ci --features rerank --lib rerank_threads` (3 passed)
- [x] `cargo clippy --profile ci --lib --features rerank -- -Dwarnings`
- [x] `cargo fmt --all -- --check`
- [x] CI is green on Linux, macOS, and Windows

## Breaking changes

None.

## Test plan

- verify automatic selection clamps constrained processes
- verify unconstrained hosts preserve the ONNX default
- verify configured values `1`, `2`, and `64`
- verify the log reports `source: layered config`
