### PR TITLE
fix(config): validate TOML before overrides

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,10 @@ channel until the v4.0.0 release train.
   text tokens retain their exact historical value instead of being trimmed
   into disabled authentication. CORS/auth validation also runs before daemon
   work.
+- Typed config validation now rejects an out-of-policy TOML value with
+  file attribution even when a valid higher-precedence env value would
+  otherwise hide it; legacy out-of-range values remain warning-only.
+
 - The supervisor's replay now survives a crash loop: the bytes
   replayed into a replacement were cleared from the unacked
   history, so a second silent death dropped them (reported by

--- a/src/config.rs
+++ b/src/config.rs
@@ -321,14 +321,19 @@ pub fn load() -> Result<Loaded, ConfigError> {
         return Err(ConfigError::Env(e.clone()));
     }
 
-    // Validate the file layer on its own so unknown keys and bad types
-    // fail loudly with the file path attached, exactly once.
+    // Validate the file layer on its own so unknown keys, bad types and
+    // out-of-policy values fail loudly with the file path attached,
+    // exactly once.
     if let Some(file) = &file_layer {
         let path = file_path
             .as_ref()
             .map(|p| p.display().to_string())
             .unwrap_or_default();
         let source = deserialize_layer_table(file).map_err(|message| ConfigError::File {
+            path: path.clone(),
+            message: message.to_string(),
+        })?;
+        validate(&source).map_err(|message| ConfigError::File {
             path: path.clone(),
             message: message.to_string(),
         })?;
@@ -2338,6 +2343,51 @@ mod tests {
             .3
             .clone();
         assert_eq!(origin, "DONSETCH_FETCH__PREWARM");
+        drop(guard);
+    }
+
+    #[test]
+    fn invalid_file_value_is_not_hidden_by_valid_env_override() {
+        let guard = clean_env();
+        let path = write_cfg(&std::env::temp_dir(), "[transport]\nport = 0\n");
+        set_env("DONSETCH_CONFIG", &path);
+        set_env("DONSETCH_TRANSPORT__PORT", "4321");
+
+        let err = match load() {
+            Err(err) => err,
+            Ok(_) => panic!("the invalid file layer must fail before the env override"),
+        };
+        match err {
+            ConfigError::File {
+                path: reported,
+                message,
+            } => {
+                assert_eq!(reported, path.display().to_string());
+                assert!(
+                    message.contains("transport.port = 0"),
+                    "wrong file error: {message}"
+                );
+            }
+            other => panic!("the error must be attributed to the file, got {other}"),
+        }
+        drop(guard);
+    }
+
+    #[test]
+    fn valid_file_value_is_overridden_by_new_env_with_env_origin() {
+        let guard = clean_env();
+        let path = write_cfg(&std::env::temp_dir(), "[transport]\nport = 1234\n");
+        set_env("DONSETCH_CONFIG", &path);
+        set_env("DONSETCH_TRANSPORT__PORT", "4321");
+
+        let loaded = load().expect("both modern sources are valid");
+        assert_eq!(loaded.config.transport.port, 4321);
+        let origin = origins(&loaded.merged, &loaded.config)
+            .into_iter()
+            .find(|(section, key, _, _)| *section == "transport" && *key == "port")
+            .expect("transport.port row")
+            .3;
+        assert_eq!(origin, "DONSETCH_TRANSPORT__PORT");
         drop(guard);
     }
 


### PR DESCRIPTION
## Summary

Validate the deserialized TOML source before applying higher-precedence environment overrides. Invalid strict file values can no longer be hidden by valid environment overrides. The fix reuses the existing validation source of truth, preserves valid precedence and provenance, keeps legacy values permissive, and is documented under Unreleased.

## Type

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — deps, CI, tooling
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only

## Checks

- [x] targeted config validation tests
- [x] `cargo clippy --profile ci --all-targets --features ocr,rerank,http -- -Dwarnings`
- [x] `cargo fmt --all -- --check`
- [x] CI is green on Linux, macOS, and Windows

## Breaking changes

None. Modern TOML and environment sources remain strict; legacy values remain warning-only when invalid.

## Test plan

- prove an invalid TOML port is rejected even when a valid modern environment value would override it
- prove the error retains file-path attribution
- prove a valid TOML value is still overridden with environment provenance
- verify invalid legacy values remain warning-only
