### PR TITLE
fix(config): reject ambiguous modern env input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -181,6 +181,12 @@ channel until the v4.0.0 release train.
   text tokens retain their exact historical value instead of being trimmed
   into disabled authentication. CORS/auth validation also runs before daemon
   work.
+- Modern `DONSETCH_<SECTION>__<KEY>` variables now fail loudly when a
+  recognized value is not UTF-8 or when distinct names normalize to the same
+  config key. Diagnostics identify the variable names without exposing their
+  values, and collision handling no longer depends on environment iteration
+  order.
+
 - The supervisor's replay now survives a crash loop: the bytes
   replayed into a replacement were cleared from the unacked
   history, so a second silent death dropped them (reported by

--- a/src/config.rs
+++ b/src/config.rs
@@ -1749,11 +1749,27 @@ fn boolish(value: &str) -> Option<bool> {
 }
 
 fn new_env_layer() -> (VMap, Vec<String>, Vec<String>) {
+    new_env_layer_from(std::env::vars_os())
+}
+
+struct ModernEnvValue {
+    name: String,
+    value: std::ffi::OsString,
+    kind: FieldKind,
+}
+
+/// Parse one immutable environment snapshot. Keeping collection outside the
+/// parser makes collision behavior testable without relying on the platform's
+/// environment iteration order.
+fn new_env_layer_from(
+    snapshot: impl IntoIterator<Item = (std::ffi::OsString, std::ffi::OsString)>,
+) -> (VMap, Vec<String>, Vec<String>) {
     let mut map = VMap::new();
     let mut warnings = Vec::new();
     let mut errors = Vec::new();
+    let mut recognized = std::collections::BTreeMap::<String, Vec<ModernEnvValue>>::new();
 
-    for (name, value) in std::env::vars_os() {
+    for (name, value) in snapshot {
         let Some(name) = name.to_str() else {
             continue;
         };
@@ -1783,13 +1799,42 @@ fn new_env_layer() -> (VMap, Vec<String>, Vec<String>) {
             ));
             continue;
         };
+        let canonical = format!("{section}.{key}");
+        recognized
+            .entry(canonical)
+            .or_default()
+            .push(ModernEnvValue {
+                name: name.to_string(),
+                value,
+                kind,
+            });
+    }
+
+    for (canonical, mut entries) in recognized {
+        entries.sort_by(|a, b| a.name.cmp(&b.name));
+        if entries.len() > 1 {
+            let mut names = entries
+                .iter()
+                .map(|entry| entry.name.as_str())
+                .collect::<Vec<_>>();
+            names.dedup();
+            errors.push(format!(
+                "{} map to the same key {canonical}; set only one",
+                names.join(", ")
+            ));
+            continue;
+        }
+
+        let ModernEnvValue { name, value, kind } = entries.pop().expect("recognized env entry");
         let Some(value) = value.to_str() else {
-            if (section, key) == ("transport", "token") {
+            if canonical == "transport.token" {
                 errors.push(format!("{name}: {MODERN_HTTP_TOKEN_REQUIREMENT}"));
+            } else {
+                errors.push(format!("{name} contains a non-UTF-8 value"));
             }
             continue;
         };
-        if (section, key) == ("transport", "token")
+        if canonical == "transport.token"
             && let Err(message) = validate_modern_http_token(value)
         {
             errors.push(format!("{name}: {message}"));
@@ -1801,7 +1846,7 @@ fn new_env_layer() -> (VMap, Vec<String>, Vec<String>) {
                 Some(b) => b.into(),
                 None => {
                     errors.push(format!(
-                        "{name}={value:?} is not a boolean (1/true/on/yes/0/false/off/no)"
+                        "{name} is not a boolean (1/true/on/yes/0/false/off/no)"
                     ));
                     continue;
                 }
@@ -1809,7 +1854,7 @@ fn new_env_layer() -> (VMap, Vec<String>, Vec<String>) {
             FieldKind::Int => match value.trim().parse::<i64>() {
                 Ok(n) => n.into(),
                 Err(_) => {
-                    errors.push(format!("{name}={value:?} is not an integer"));
+                    errors.push(format!("{name} is not an integer"));
                     continue;
                 }
             },
@@ -1820,9 +1865,11 @@ fn new_env_layer() -> (VMap, Vec<String>, Vec<String>) {
                 .collect::<Vec<_>>()
                 .into(),
         };
-        put(&mut map, &format!("{section}.{key}"), vkind, name);
+        put(&mut map, &canonical, vkind, &name);
     }
 
+    warnings.sort();
+    errors.sort();
     (map, warnings, errors)
 }
 
@@ -2710,6 +2757,81 @@ mod tests {
         }
         assert_eq!(boolish("maybe"), None);
         assert_eq!(boolish(""), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn recognized_modern_env_rejects_non_utf8_without_echoing_the_value() {
+        use std::os::unix::ffi::OsStringExt;
+
+        let secret = b"secret-\xff-sentinel".to_vec();
+        let (map, warnings, errors) = new_env_layer_from([(
+            std::ffi::OsString::from("DONSETCH_FETCH__H3"),
+            std::ffi::OsString::from_vec(secret),
+        )]);
+
+        assert!(map.is_empty());
+        assert!(warnings.is_empty());
+        assert_eq!(errors.len(), 1);
+        assert!(errors[0].contains("DONSETCH_FETCH__H3"));
+        assert!(errors[0].contains("non-UTF-8"));
+        assert!(!errors[0].contains("secret"), "value leaked: {}", errors[0]);
+    }
+
+    #[test]
+    fn modern_env_collisions_fail_independently_of_snapshot_order() {
+        let first = (
+            std::ffi::OsString::from("DONSETCH_FETCH__H3"),
+            std::ffi::OsString::from("first-value-sentinel"),
+        );
+        let second = (
+            std::ffi::OsString::from("DONSETCH_fetch__h3"),
+            std::ffi::OsString::from("second-value-sentinel"),
+        );
+
+        let (forward_map, forward_warnings, forward_errors) =
+            new_env_layer_from([first.clone(), second.clone()]);
+        let (reverse_map, reverse_warnings, reverse_errors) = new_env_layer_from([second, first]);
+
+        assert!(forward_map.is_empty());
+        assert!(reverse_map.is_empty());
+        assert_eq!(forward_warnings, reverse_warnings);
+        assert_eq!(forward_errors, reverse_errors);
+        assert_eq!(forward_errors.len(), 1);
+        let error = &forward_errors[0];
+        assert!(error.contains("DONSETCH_FETCH__H3"), "{error}");
+        assert!(error.contains("DONSETCH_fetch__h3"), "{error}");
+        assert!(error.contains("fetch.h3"), "{error}");
+        assert!(
+            !error.contains("first-value-sentinel"),
+            "value leaked: {error}"
+        );
+        assert!(
+            !error.contains("second-value-sentinel"),
+            "value leaked: {error}"
+        );
+    }
+
+    #[test]
+    fn modern_env_type_errors_name_variables_without_echoing_values() {
+        let (_, warnings, errors) = new_env_layer_from([
+            (
+                std::ffi::OsString::from("DONSETCH_FETCH__H3"),
+                std::ffi::OsString::from("boolean-value-sentinel"),
+            ),
+            (
+                std::ffi::OsString::from("DONSETCH_TRANSPORT__PORT"),
+                std::ffi::OsString::from("integer-value-sentinel"),
+            ),
+        ]);
+
+        assert!(warnings.is_empty());
+        assert_eq!(errors.len(), 2);
+        let diagnostic = errors.join("\n");
+        assert!(diagnostic.contains("DONSETCH_FETCH__H3"));
+        assert!(diagnostic.contains("DONSETCH_TRANSPORT__PORT"));
+        assert!(!diagnostic.contains("boolean-value-sentinel"));
+        assert!(!diagnostic.contains("integer-value-sentinel"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reject non-UTF-8 values for recognized modern environment variables
- reject distinct environment names that normalize to the same config key
- parse an immutable environment snapshot so collision handling is independent of OS iteration order
- keep diagnostics value-free and preserve legacy semantics
- compose with the HTTP token validation from #207
- document the behavior under Unreleased

## Type

- [ ] `feat` — new feature
- [x] `fix` — bug fix
- [ ] `docs` — documentation only
- [ ] `chore` — deps, CI, tooling
- [ ] `refactor` — no behavior change
- [ ] `test` — tests only

## Checks

- [x] 24 config tests
- [x] full suite (1,165 passed, 1 skipped)
- [x] full-feature all-target Clippy with `-Dwarnings`
- [x] `cargo fmt --all -- --check`
- [x] CI is green on Linux, macOS, and Windows

## Breaking changes

None for valid configuration. Previously ambiguous modern environment input now fails loudly instead of depending on iteration order or being silently ignored.

## Test plan

- cover recognized non-UTF-8 modern values without echoing bytes
- cover normalized-name collisions independently of snapshot order
- cover value-free type errors
- verify legacy environment semantics remain unchanged
