### PR TITLE
fix(byok): cap and scrub upstream error bodies before they reach the agent (key-leak + context DoS)

### DIFF
--- a/src/search/byok/bravesearch.rs
+++ b/src/search/byok/bravesearch.rs
@@ -121,7 +121,10 @@ pub async fn search(
         if lower.contains("quota") || lower.contains("exceeded") || lower.contains("plan") {
             return Err(KeyError::CreditDepleted);
         }
-        return Err(KeyError::UnknownError(format!("HTTP {status}: {text}")));
+        return Err(KeyError::UnknownError(format!(
+            "HTTP {status}: {}",
+            super::err_body(&text)
+        )));
     }
 
     let json: Value = serde_json::from_str(&text)

--- a/src/search/byok/brightdata.rs
+++ b/src/search/byok/brightdata.rs
@@ -144,7 +144,10 @@ pub(crate) async fn search(
         {
             return Err(KeyError::InvalidKey);
         }
-        return Err(KeyError::UnknownError(format!("HTTP {status}: {text}")));
+        return Err(KeyError::UnknownError(format!(
+            "HTTP {status}: {}",
+            super::err_body(&text)
+        )));
     }
 
     // Bright Data returns parsed JSON when brd_json=1 is in the URL.

--- a/src/search/byok/exa.rs
+++ b/src/search/byok/exa.rs
@@ -80,7 +80,10 @@ pub async fn search(
         if lower.contains("invalid") && lower.contains("key") {
             return Err(KeyError::InvalidKey);
         }
-        return Err(KeyError::UnknownError(format!("HTTP {status}: {text}")));
+        return Err(KeyError::UnknownError(format!(
+            "HTTP {status}: {}",
+            super::err_body(&text)
+        )));
     }
 
     let json: Value = serde_json::from_str(&text)

--- a/src/search/byok/mod.rs
+++ b/src/search/byok/mod.rs
@@ -109,6 +109,24 @@ impl KeyError {
     }
 }
 
+/// Cap on how much of an upstream error body is echoed into a
+/// `KeyError`. A `KeyError` reaches the model (the search error the
+/// agent sees), stderr, and the DONSEEK_DEBUG log, so echoing a raw
+/// multi-MB provider error page is both a context-budget hit and,
+/// for a provider that carries the key in the request URL (serpapi),
+/// a reflection surface: an intermediary that bounces the request
+/// line into its 4xx page would otherwise leak `?api_key=...` into
+/// all three sinks. 600 chars is enough to diagnose.
+const ERR_BODY_CAP: usize = 600;
+
+/// Bound an upstream error body before it lands in a `KeyError`.
+/// Every provider adapter routes its `HTTP {status}: <body>` echo
+/// through this so no single adapter can drift back to an uncapped
+/// echo (two capped, seven did not — the drift this centralizes).
+pub(super) fn err_body(text: &str) -> String {
+    text.chars().take(ERR_BODY_CAP).collect()
+}
+
 impl std::fmt::Display for KeyError {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -427,6 +445,39 @@ mod tests {
             "key leaked into KeyError: {mapped}"
         );
         assert!(matches!(mapped, KeyError::UnknownError(_)));
+    }
+
+    // Every adapter echoes an upstream error body through err_body,
+    // which caps it at 600 chars. Without the cap a burned proxy's
+    // multi-MB HTML error page landed verbatim in the model context,
+    // stderr and the debug log (a context DoS), and for serpapi
+    // specifically it could carry the URL-borne api_key.
+    #[test]
+    fn err_body_caps_the_echoed_error() {
+        let huge = "x".repeat(10_000);
+        let capped = err_body(&huge);
+        assert_eq!(capped.chars().count(), ERR_BODY_CAP);
+        // Multibyte input is capped on CHARS, never mid-codepoint.
+        let cjk = "東".repeat(10_000);
+        let out = err_body(&cjk);
+        assert_eq!(out.chars().count(), ERR_BODY_CAP);
+        assert!(out.chars().all(|c| c == '東'));
+        // A short body is returned intact.
+        assert_eq!(err_body("HTTP 429 slow down"), "HTTP 429 slow down");
+    }
+
+    // serpapi puts the key in the request URL, so a reflecting
+    // intermediary can bounce it into the error body. The adapter
+    // scrubs the exact key substring before it is echoed; this pins
+    // the scrub-then-cap the adapter relies on.
+    #[test]
+    fn serpapi_style_key_scrub_removes_the_reflected_key() {
+        const KEY: &str = "sk-serpapi-SECRET-9f8e7d";
+        let reflected =
+            format!("<html>Bad request to /search?q=x&api_key={KEY} : forbidden</html>");
+        let echoed = err_body(&reflected).replace(KEY, "<redacted>");
+        assert!(!echoed.contains(KEY), "the key must not survive: {echoed}");
+        assert!(echoed.contains("<redacted>"));
     }
 
     #[test]

--- a/src/search/byok/parallel.rs
+++ b/src/search/byok/parallel.rs
@@ -78,7 +78,10 @@ pub async fn search(
         if lower.contains("invalid") && (lower.contains("key") || lower.contains("api")) {
             return Err(KeyError::InvalidKey);
         }
-        return Err(KeyError::UnknownError(format!("HTTP {status}: {text}")));
+        return Err(KeyError::UnknownError(format!(
+            "HTTP {status}: {}",
+            super::err_body(&text)
+        )));
     }
 
     let json: Value = serde_json::from_str(&text)

--- a/src/search/byok/serpapi.rs
+++ b/src/search/byok/serpapi.rs
@@ -133,7 +133,12 @@ pub async fn search(
         if lower.contains("run out") || lower.contains("quota") || lower.contains("plan") {
             return Err(KeyError::CreditDepleted);
         }
-        return Err(KeyError::UnknownError(format!("HTTP {status}: {text}")));
+        // serpapi carries the key in the request URL (?api_key=...),
+        // so an intermediary that reflects the request line into its
+        // error page would echo the key here. Cap the body AND scrub
+        // the key before it reaches the model / stderr / debug log.
+        let body = super::err_body(&text).replace(key, "<redacted>");
+        return Err(KeyError::UnknownError(format!("HTTP {status}: {body}")));
     }
 
     let json: Value = serde_json::from_str(&text)

--- a/src/search/byok/serpbase.rs
+++ b/src/search/byok/serpbase.rs
@@ -115,7 +115,10 @@ pub async fn search(
         if lower.contains("credit") || lower.contains("quota") || lower.contains("billing") {
             return Err(KeyError::CreditDepleted);
         }
-        return Err(KeyError::UnknownError(format!("HTTP {status}: {text}")));
+        return Err(KeyError::UnknownError(format!(
+            "HTTP {status}: {}",
+            super::err_body(&text)
+        )));
     }
 
     let json: Value = serde_json::from_str(&text)

--- a/src/search/byok/serper.rs
+++ b/src/search/byok/serper.rs
@@ -74,7 +74,10 @@ pub async fn search(
         if lower.contains("invalid") && lower.contains("key") {
             return Err(KeyError::InvalidKey);
         }
-        return Err(KeyError::UnknownError(format!("HTTP {status}: {text}")));
+        return Err(KeyError::UnknownError(format!(
+            "HTTP {status}: {}",
+            super::err_body(&text)
+        )));
     }
 
     let json: Value = serde_json::from_str(&text)

--- a/src/search/byok/tavily.rs
+++ b/src/search/byok/tavily.rs
@@ -78,8 +78,10 @@ pub async fn search(
         // The error body rides to the agent surface: an uncapped
         // HTML error page from a burned proxy lands in the model's
         // context. Same 600-char class as the plugin adapters.
-        let text: String = text.chars().take(600).collect();
-        return Err(KeyError::UnknownError(format!("HTTP {status}: {text}")));
+        return Err(KeyError::UnknownError(format!(
+            "HTTP {status}: {}",
+            super::err_body(&text)
+        )));
     }
 
     // Parse success response.

--- a/src/search/byok/tinyfish.rs
+++ b/src/search/byok/tinyfish.rs
@@ -75,8 +75,10 @@ pub async fn search(
         // The error body rides to the agent surface: an uncapped
         // HTML error page from a burned proxy lands in the model's
         // context. Same 600-char class as the plugin adapters.
-        let text: String = text.chars().take(600).collect();
-        return Err(KeyError::UnknownError(format!("HTTP {status}: {text}")));
+        return Err(KeyError::UnknownError(format!(
+            "HTTP {status}: {}",
+            super::err_body(&text)
+        )));
     }
 
     let json: Value = serde_json::from_str(&text)


### PR DESCRIPTION
Found during a security review of secret handling. The most significant finding of that review (MEDIUM): a BYOK provider's API key can leak into the agent's context.

## The problem

A BYOK `KeyError` reaches three sinks: the **model** (the search error the agent reads via `SearchFailure.cause` / "all providers exhausted: …"), **stderr**, and the **DONSEEK_DEBUG log**. Seven of the nine provider adapters echoed the upstream error body verbatim:

```rust
return Err(KeyError::UnknownError(format!("HTTP {status}: {text}")));  // uncapped
```

Only `tavily` and `tinyfish` capped it, each with its own inline `chars().take(600)` — so the cap was a per-adapter copy that seven adapters simply didn't have.

Two consequences:

1. **Key leakage (the reason this is MEDIUM).** `serpapi` carries the key in the request **URL** (`?api_key=<key>`), unlike the other adapters which send it in a header. An intermediary that reflects the request line into its error page — a corporate MITM proxy, a captive portal, a WAF 4xx page — bounces `?api_key=<key>` straight into all three sinks, where the agent can read (and exfiltrate) it. BYOK's direct lane commonly runs through exactly such middleboxes. This is the residual PR #134 explicitly flagged for the generic 4xx branches, now sharpened by serpapi's URL-borne key.
2. **Context-budget DoS.** A burned proxy/WAF can answer with a multi-MB HTML error page that then lands whole in the model's context (and stderr, and the log) — which is precisely why tavily/tinyfish already capped it.

## The fix

One shared `err_body` helper caps every adapter's echo at 600 chars, and **all nine** adapters route through it (including the two that already capped), so no adapter can silently drift back to an uncapped echo — the exact split that caused this. `serpapi` additionally **scrubs the key** from the body before echoing (`err_body(&text).replace(key, "<redacted>")`), defense-in-depth for the URL-key case.

## Verification

`err_body_caps_the_echoed_error` (caps on chars, multibyte-safe, short bodies intact) and `serpapi_style_key_scrub_removes_the_reflected_key` (a reflected `?api_key=<key>` is removed). Full `cargo nextest run` **1173/1173** (1 skipped); `clippy --all-targets` and `fmt --check` clean.

The transport-error path was already safe (`KeyError::from_transport` strips the URL via `without_url()`); this closes the response-body path it did not cover.

One related NIT the review noted, not changed here to keep this focused: `src/search/byok/store.rs` writes the key file with `.mode(0o600)` on open, which only applies on creation — a pre-existing loose tmp is reused at its mode until the post-rename `set_permissions`. Switching that inline write to `config::write_private` (which `fchmod`s the fd, as the keys-export path already does) would close the tiny window. Happy to fold it in or send separately.

Part of a broader security review; sibling PRs cover an h3 SSRF dial-filter parity gap and a crawl resume-token path traversal.

https://claude.ai/code/session_01Vg2CMnuvDevTxCpmJGbnRU