### PR TITLE
fix(crawl): reject a traversal resume token before it indexes the store

### DIFF
--- a/src/crawl/mod.rs
+++ b/src/crawl/mod.rs
@@ -271,6 +271,18 @@ fn token_path(dir: &std::path::Path, tok: &str) -> std::path::PathBuf {
     dir.join(format!("{tok}.json"))
 }
 
+/// A resume token is only ever ISSUED as `c<hex><hex>`, but the value
+/// consumed on resume is agent-supplied, and it is joined into a
+/// filesystem path (`<cache>/crawl-resumes/<tok>.json`). Reject
+/// anything that is not plain ASCII alphanumeric so a crafted token
+/// (`../../etc/x`, an absolute path, a NUL) cannot escape the store
+/// directory to read-then-delete a `.json` file outside it. Matches
+/// the traversal rejection paths::resolve_screenshot_path already
+/// applies to the screenshot output path.
+fn is_valid_resume_token(tok: &str) -> bool {
+    !tok.is_empty() && tok.bytes().all(|b| b.is_ascii_alphanumeric())
+}
+
 /// One-time migration: the v3 store kept every token in one JSON
 /// map; split it into per-token files so tokens already issued
 /// survive the upgrade.
@@ -369,6 +381,12 @@ fn resume_store_sweep(dir: &std::path::Path) {
 /// its crawl actually resumes). Unknown, corrupt, or unreadable =
 /// the same honest error.
 fn resume_store_take(tok: &str) -> Result<ResumeState, String> {
+    // The token is agent-supplied and about to index the filesystem:
+    // refuse anything that is not a well-formed token before it can
+    // traverse out of the store directory (no FS touch on a bad one).
+    if !is_valid_resume_token(tok) {
+        return Err(format!("resume token expired or unknown: {tok}"));
+    }
     let dir = resumes_dir();
     migrate_legacy_store();
     resume_store_sweep(&dir);

--- a/src/crawl/tests.rs
+++ b/src/crawl/tests.rs
@@ -1331,3 +1331,48 @@ fn legacy_store_migrates_and_the_token_survives() {
     );
     let _ = std::fs::remove_dir_all(&iso);
 }
+
+// The resume token is agent-supplied and joined into a filesystem
+// path (<cache>/crawl-resumes/<tok>.json). A traversal token
+// (`../../…`) must be refused before it can read-then-delete a
+// `.json` file outside the store. resume_store_take rejects any
+// non-alphanumeric token, and the planted victim file survives.
+#[test]
+fn resume_token_traversal_is_refused() {
+    // Format validity itself (no FS, deterministic).
+    assert!(super::is_valid_resume_token("c16a9a0f"));
+    for bad in [
+        "",
+        "../secret",
+        "..\\secret",
+        "a/b",
+        "a.b",
+        "tok\0",
+        "c16 a9",
+    ] {
+        assert!(!super::is_valid_resume_token(bad), "must reject {bad:?}");
+    }
+
+    // End to end: a planted valid-ResumeState `.json` OUTSIDE the
+    // store must not be consumed by a traversal token.
+    let iso = std::env::temp_dir().join(format!("ds-resume-trav-{}", std::process::id()));
+    let store = iso.join("crawl-resumes");
+    let _ = std::fs::create_dir_all(&store);
+    unsafe { std::env::set_var("DONSETCH_CACHE_DIR", &iso) };
+    let victim = iso.join("victim.json");
+    std::fs::write(
+        &victim,
+        serde_json::json!({"seed":"https://evil.example/","queue":[],"seen":[]}).to_string(),
+    )
+    .unwrap();
+    // <store>/../victim.json resolves to the planted file.
+    match super::resume_store_take("../victim") {
+        Err(e) => assert!(e.contains("expired or unknown"), "{e}"),
+        Ok(_) => panic!("a traversal token must be refused, not consumed"),
+    }
+    assert!(
+        victim.exists(),
+        "a traversal token must not delete an outside file"
+    );
+    let _ = std::fs::remove_dir_all(&iso);
+}


### PR DESCRIPTION
Found during a security review of the local attack surface. LOW severity, but a real missing input-validation on an agent-controlled value that indexes the filesystem.

## The issue

A crawl resume token is agent-supplied (the `resume` argument) and joined into a filesystem path: `token_path` builds `<cache>/crawl-resumes/<tok>.json`, and `resume_store_take` reads it and then `remove_file`s it on a successful parse. Tokens donsetch **issues** are `c<hex-micros><hex-seq>` and filename-safe (the `token_path` comment even asserts "no traversal surface") — but the value **consumed** on resume was trusted verbatim.

So `resume="../../../victim"` resolves to `<cache>/crawl-resumes/../../../victim.json`. If that file exists and deserializes as a `ResumeState`, `resume_store_take` reads it and **deletes it**, and its `seed` becomes a crawl target.

It's constrained — the target must end in `.json` and parse as `ResumeState {seed, queue, seen}`, and the recovered `seed` still passes the crawl SSRF guard — so it's a read-then-delete-outside-the-store primitive over resume-state-shaped `.json` files, not a general read/delete oracle. Hence LOW. But it is a real missing check on an agent-controlled path index.

## The fix

`resume_store_take` now rejects any token that is not a well-formed token id (non-empty, all ASCII alphanumeric — the shape everything issued as `c<hex>` already satisfies) before touching the filesystem, returning the same honest "expired or unknown" error. This matches the traversal rejection `paths::resolve_screenshot_path` already applies to the screenshot output path (`..`/NUL/out-of-root) — the resume path just never got the same treatment.

## Verification

`resume_token_traversal_is_refused` pins the format rule (rejects `""`, `../secret`, `..\secret`, `a/b`, `a.b`, `tok\0`, `c16 a9`; accepts `c16a9a0f`) and, end-to-end, that a planted valid-`ResumeState` file **outside** the store is neither consumed nor deleted by a `../victim` token. RED without the guard: the outside file is read and removed ("a traversal token must be refused, not consumed" fires). Full `cargo nextest run` **1172/1172** (1 skipped); `clippy --all-targets` and `fmt --check` clean.

Third of three PRs from a security review; the others cover a BYOK error-echo key-leak (#218, medium) and an h3 SSRF dial-filter parity gap (#217).

https://claude.ai/code/session_01Vg2CMnuvDevTxCpmJGbnRU